### PR TITLE
Add a makefile with the lint command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,12 @@
+.PHONY: all
+all:
+	echo "No default target."
+
+.PHONY: lint
+lint:
+	cd api && rdme openapi:validate write.yaml && cd ..
+	cd api && rdme openapi:validate api.yaml && cd ..
+	cd config && rdme openapi:validate config.yaml && cd ..
+	cd catalog && rdme openapi:validate catalog.yaml && cd ..
+	cd manifest && rdme openapi:validate manifest.yaml && cd ..
+	cd problem && rdme openapi:validate problem.yaml


### PR DESCRIPTION
The README refers to a make command which doesn't exist. This PR adds that.