### PR TITLE
Fix catalog link from api.yaml

### DIFF
--- a/api/api.yaml
+++ b/api/api.yaml
@@ -1410,7 +1410,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "https://raw.githubusercontent.com/amp-labs/connectors/main/providers/types.yaml#/components/schemas/CatalogType"
+                $ref: "../catalog/catalog.yaml#/components/schemas/CatalogType"
         default:
           description: Error
           content:
@@ -1434,7 +1434,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "https://raw.githubusercontent.com/amp-labs/connectors/main/providers/types.yaml#/components/schemas/ProviderInfo"
+                $ref: "../catalog/catalog.yaml#/components/schemas/ProviderInfo"
         default:
           description: Error
           content:


### PR DESCRIPTION
Test below

```
make lint
cd api && rdme openapi:validate write.yaml && cd ..
write.yaml is a valid OpenAPI API definition!
cd api && rdme openapi:validate api.yaml && cd ..
api.yaml is a valid OpenAPI API definition!
cd config && rdme openapi:validate config.yaml && cd ..
config.yaml is a valid OpenAPI API definition!
cd catalog && rdme openapi:validate catalog.yaml && cd ..
catalog.yaml is a valid OpenAPI API definition!
cd manifest && rdme openapi:validate manifest.yaml && cd ..
manifest.yaml is a valid OpenAPI API definition!
cd problem && rdme openapi:validate problem.yaml
problem.yaml is a valid OpenAPI API definition!
```