### PR TITLE
[ENG-1268] Allow passing extra headers in OAuth2 AuthURL

### DIFF
--- a/catalog/catalog.yaml
+++ b/catalog/catalog.yaml
@@ -125,6 +125,14 @@ components:
           description: URL with more information about where to retrieve Client ID and Client Secret, etc.
           example: https://docs.example.com/client-credentials
           x-go-type-skip-optional-pointer: true
+        authURLParams:
+          type: object
+          additionalProperties:
+            type: string
+          x-go-type-skip-optional-pointer: true
+          example:
+            access_type: offline
+            duration: permanent
 
     ApiKeyOpts:
       type: object


### PR DESCRIPTION
- Allows setting certain headers in the catalog that can be passed in with an OAuth2 auth request