### PR TITLE
feat: Provider flag WorkspaceRequired

### DIFF
--- a/catalog/catalog.yaml
+++ b/catalog/catalog.yaml
@@ -85,7 +85,6 @@ components:
           - grantType
           - tokenURL
           - explicitScopesRequired
-          - explicitWorkspaceRequired
           - tokenMetadataFields
       properties:
         grantType:
@@ -105,10 +104,6 @@ components:
         explicitScopesRequired:
           type: boolean
           description: Whether scopes are required to be known ahead of the OAuth flow.
-          example: true
-        explicitWorkspaceRequired:
-          type: boolean
-          description: Whether the workspace is required to be known ahead of the OAuth flow.
           example: true
         audience:
           type: array
@@ -190,6 +185,16 @@ components:
         additionalProperties:
           type: string
 
+    ProviderFlags:
+      type: object
+      required:
+        - explicitWorkspaceRequired
+      properties:
+        explicitWorkspaceRequired:
+          type: boolean
+          description: Whether the workspace is required to be known ahead of the OAuth flow.
+          example: true
+
     Provider:
       type: string
       example: salesforce
@@ -202,6 +207,7 @@ components:
         - authType
         - support
         - providerOpts
+        - providerFlags
       properties:
         name:
           # If you're maintaining catalog.go, the name field will be auto-set for you,
@@ -227,6 +233,8 @@ components:
         providerOpts:
           description: Additional provider-specific metadata.
           $ref: '#/components/schemas/ProviderOpts'
+        providerFlags:
+          $ref: '#/components/schemas/ProviderFlags'
         displayName:
           type: string
           example: Zendesk Chat


### PR DESCRIPTION
Flag `ExplicitWorkspaceRequired` lives under Oauth2 options.

Workspace requirement is independant of the type of authentication and hence must live in a different place.