### PR TITLE
[ENG-1299] Read.yaml for read route

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,8 +5,10 @@ all:
 .PHONY: lint
 lint:
 	cd api && rdme openapi:validate write.yaml && cd ..
+	cd api && rdme openapi:validate read.yaml && cd ..
 	cd api && rdme openapi:validate api.yaml && cd ..
 	cd config && rdme openapi:validate config.yaml && cd ..
 	cd catalog && rdme openapi:validate catalog.yaml && cd ..
 	cd manifest && rdme openapi:validate manifest.yaml && cd ..
 	cd problem && rdme openapi:validate problem.yaml
+

--- a/api/read.yaml
+++ b/api/read.yaml
@@ -7,8 +7,8 @@ servers:
 paths:
   /projects/{projectIdOrName}/integrations/{integrationId}/objects/{objectName}:
     post:
-      summary: Create read operation for records
-      operationId: createRead
+      summary: Read records
+      operationId: readRecords
       tags: ["Read"]
       parameters:
         - name: projectIdOrName
@@ -26,18 +26,12 @@ paths:
           required: true
           schema:
             type: string
-        - name: X-Amp-Request-Type
-          in: header
-          required: true
-          schema:
-            type: string
-            enum: [read]
       requestBody:
         description: Read Request
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/CreateReadAsync"
+              $ref: "#/components/schemas/ReadRequest"
       responses:
         201:
           description: The success response
@@ -66,7 +60,7 @@ paths:
 
 components:
   schemas:
-    CreateReadAsync:
+    ReadRequest:
       required:
         - groupRef
         - mode
@@ -85,6 +79,7 @@ components:
         since:
           type: string
           description: The timestamp from which to read data. If omitted, we will read all data.
+          example: "2024-07-01T18:22:30.323771761Z"
     ReadResultAsync:
       type: object
       required:

--- a/api/read.yaml
+++ b/api/read.yaml
@@ -7,7 +7,7 @@ servers:
 paths:
   /projects/{projectIdOrName}/integrations/{integrationId}/objects/{objectName}:
     post:
-      summary: Create, update, upsert or delete records
+      summary: Create read operation for records
       operationId: createRead
       tags: ["Read"]
       parameters:
@@ -63,7 +63,6 @@ paths:
             application/problem+json:
               schema:
                 $ref: "../problem/problem.yaml#/components/schemas/ApiProblem"
-
 
 components:
   schemas:

--- a/api/read.yaml
+++ b/api/read.yaml
@@ -1,0 +1,98 @@
+openapi: 3.0.1
+info:
+  title: Ampersand public read API
+  version: 1.0.0
+servers:
+  - url: https://read.withampersand.com/v1
+paths:
+  /projects/{projectIdOrName}/integrations/{integrationId}/objects/{objectName}:
+    post:
+      summary: Create, update, upsert or delete records
+      operationId: createRead
+      tags: ["Read"]
+      parameters:
+        - name: projectIdOrName
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: integrationId
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: objectName
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: X-Amp-Request-Type
+          in: header
+          required: true
+          schema:
+            type: string
+            enum: [read]
+      requestBody:
+        description: Read Request
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateReadAsync"
+      responses:
+        201:
+          description: The success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ReadResultAsync"
+        400:
+          description: The failure response for bad request.
+          content:
+            application/json:
+              schema:
+                $ref: "../problem/problem.yaml#/components/schemas/ApiProblem"
+        500:
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: "../problem/problem.yaml#/components/schemas/ApiProblem"
+        default:
+          description: Error
+          content:
+            application/problem+json:
+              schema:
+                $ref: "../problem/problem.yaml#/components/schemas/ApiProblem"
+
+
+components:
+  schemas:
+    CreateReadAsync:
+      required:
+        - groupRef
+        - mode
+      type: object
+      properties:
+        groupRef:
+          type: string
+          description:
+            The ID of the user group whose SaaS instance you'd like to read data from. This is the ID that was provided
+            during installation creation.
+        mode:
+          type: string
+          description: The mode of read operation. Currently only asynchronus operation is supported.
+          enum: [async]
+          example: async
+        since:
+          type: string
+          description: The timestamp from which to read data. If omitted, we will read all data.
+    ReadResultAsync:
+      type: object
+      required:
+        - operationId
+      properties:
+        operationId:
+          type: string
+          description: The operation ID
+          example: 60deaf48-3856-4a2b-bfd4-3de85125eca8
+  

--- a/api/read.yaml
+++ b/api/read.yaml
@@ -95,4 +95,4 @@ components:
           type: string
           description: The operation ID
           example: 60deaf48-3856-4a2b-bfd4-3de85125eca8
-  
+


### PR DESCRIPTION
Test

```
jaehyunlim@Jaehyuns-MBP openapi % make lint
cd api && rdme openapi:validate write.yaml && cd ..
write.yaml is a valid OpenAPI API definition!
cd api && rdme openapi:validate read.yaml && cd ..
read.yaml is a valid OpenAPI API definition!
cd api && rdme openapi:validate api.yaml && cd ..
api.yaml is a valid OpenAPI API definition!
cd config && rdme openapi:validate config.yaml && cd ..
config.yaml is a valid OpenAPI API definition!
cd catalog && rdme openapi:validate catalog.yaml && cd ..
catalog.yaml is a valid OpenAPI API definition!
cd manifest && rdme openapi:validate manifest.yaml && cd ..
manifest.yaml is a valid OpenAPI API definition!
cd problem && rdme openapi:validate problem.yaml
problem.yaml is a valid OpenAPI API definition!
```