### PR TITLE
build: relax engine requirements and also use Dashboard instead of Console terminology

### DIFF
--- a/api/api.yaml
+++ b/api/api.yaml
@@ -45,7 +45,7 @@ paths:
                   type: string
                   description:
                     ID of the provider app (e.g. Salesforce connected app), returned from a CreateProviderApp call.
-                    If omitted, the default provider app that was set up on the Ampersand Console is assumed.
+                    If omitted, the default provider app that was set up on the Ampersand Dashboard is assumed.
                 provider:
                   type: string
                   description: The provider that this app connects to.
@@ -2835,7 +2835,7 @@ components:
         providerAppId:
           description:
             ID of the provider app (e.g. Salesforce connected app), returned from a CreateProviderApp call.
-            If omitted, the default provider app that was set up on the Ampersand Console is assumed.
+            If omitted, the default provider app that was set up on the Ampersand Dashboard is assumed.
           type: string
         groupRef:
           description:

--- a/api/generated/api.json
+++ b/api/generated/api.json
@@ -57,7 +57,7 @@
                   },
                   "providerAppId": {
                     "type": "string",
-                    "description": "ID of the provider app (e.g. Salesforce connected app), returned from a CreateProviderApp call. If omitted, the default provider app that was set up on the Ampersand Console is assumed."
+                    "description": "ID of the provider app (e.g. Salesforce connected app), returned from a CreateProviderApp call. If omitted, the default provider app that was set up on the Ampersand Dashboard is assumed."
                   },
                   "provider": {
                     "type": "string",
@@ -13025,7 +13025,7 @@
                     "type": "object",
                     "properties": {
                       "providerAppId": {
-                        "description": "ID of the provider app (e.g. Salesforce connected app), returned from a CreateProviderApp call. If omitted, the default provider app that was set up on the Ampersand Console is assumed.",
+                        "description": "ID of the provider app (e.g. Salesforce connected app), returned from a CreateProviderApp call. If omitted, the default provider app that was set up on the Ampersand Dashboard is assumed.",
                         "type": "string"
                       },
                       "groupRef": {
@@ -22113,6 +22113,23 @@
                         "example": true,
                         "description": "If true, we require additional information after auth to start making requests.",
                         "x-go-type-skip-optional-pointer": true
+                      },
+                      "media": {
+                        "type": "object",
+                        "properties": {
+                          "iconURL": {
+                            "type": "string",
+                            "example": "https://example.com/icon.png",
+                            "description": "URL to the icon for the provider.",
+                            "x-go-type-skip-optional-pointer": true
+                          },
+                          "logoURL": {
+                            "type": "string",
+                            "example": "https://example.com/logo.png",
+                            "description": "URL to the logo for the provider.",
+                            "x-go-type-skip-optional-pointer": true
+                          }
+                        }
                       }
                     }
                   }
@@ -22540,6 +22557,23 @@
                       "example": true,
                       "description": "If true, we require additional information after auth to start making requests.",
                       "x-go-type-skip-optional-pointer": true
+                    },
+                    "media": {
+                      "type": "object",
+                      "properties": {
+                        "iconURL": {
+                          "type": "string",
+                          "example": "https://example.com/icon.png",
+                          "description": "URL to the icon for the provider.",
+                          "x-go-type-skip-optional-pointer": true
+                        },
+                        "logoURL": {
+                          "type": "string",
+                          "example": "https://example.com/logo.png",
+                          "description": "URL to the logo for the provider.",
+                          "x-go-type-skip-optional-pointer": true
+                        }
+                      }
                     }
                   }
                 }
@@ -38080,7 +38114,7 @@
         "type": "object",
         "properties": {
           "providerAppId": {
-            "description": "ID of the provider app (e.g. Salesforce connected app), returned from a CreateProviderApp call. If omitted, the default provider app that was set up on the Ampersand Console is assumed.",
+            "description": "ID of the provider app (e.g. Salesforce connected app), returned from a CreateProviderApp call. If omitted, the default provider app that was set up on the Ampersand Dashboard is assumed.",
             "type": "string"
           },
           "groupRef": {

--- a/package.json
+++ b/package.json
@@ -13,9 +13,7 @@
     "prepare": "husky"
   },
   "engines": {
-      "node": "20.15.1",
-      "pnpm": "9.6.0"
+      "pnpm": "^9.6.0"
   },
-  "packageManager": "pnpm@9.6.0"
-  
+  "packageManager": "pnpm@9.6.0+"
 }


### PR DESCRIPTION
- call Ampersand Console the Ampersand Dashboard instead
- make the engine requirement not as strict, no need to require the exact version of pnpm, there's also no need to require a specific node version since even pnpm itself does not specify a node verion: https://github.com/pnpm/pnpm/blob/96821291a816464ef8f77745a4a77249cdec6b94/package.json#L64