### PR TITLE
Add light/dark theme options for media

### DIFF
--- a/api/generated/api.json
+++ b/api/generated/api.json
@@ -22115,19 +22115,42 @@
                         "x-go-type-skip-optional-pointer": true
                       },
                       "media": {
-                        "type": "object",
                         "properties": {
-                          "iconURL": {
-                            "type": "string",
-                            "example": "https://example.com/icon.png",
-                            "description": "URL to the icon for the provider.",
-                            "x-go-type-skip-optional-pointer": true
+                          "regular": {
+                            "type": "object",
+                            "description": "Media for light/regular mode.",
+                            "properties": {
+                              "iconURL": {
+                                "type": "string",
+                                "example": "https://example.com/icon.png",
+                                "description": "URL to the icon for the provider.",
+                                "x-go-type-skip-optional-pointer": true
+                              },
+                              "logoURL": {
+                                "type": "string",
+                                "example": "https://example.com/logo.png",
+                                "description": "URL to the logo for the provider.",
+                                "x-go-type-skip-optional-pointer": true
+                              }
+                            }
                           },
-                          "logoURL": {
-                            "type": "string",
-                            "example": "https://example.com/logo.png",
-                            "description": "URL to the logo for the provider.",
-                            "x-go-type-skip-optional-pointer": true
+                          "darkMode": {
+                            "type": "object",
+                            "description": "Media to be used in dark mode.",
+                            "properties": {
+                              "iconURL": {
+                                "type": "string",
+                                "example": "https://example.com/icon.png",
+                                "description": "URL to the icon for the provider that is to be used in dark mode.",
+                                "x-go-type-skip-optional-pointer": true
+                              },
+                              "logoURL": {
+                                "type": "string",
+                                "example": "https://example.com/logo.png",
+                                "description": "URL to the logo for the provider that is to be used in dark mode.",
+                                "x-go-type-skip-optional-pointer": true
+                              }
+                            }
                           }
                         }
                       }
@@ -22559,19 +22582,42 @@
                       "x-go-type-skip-optional-pointer": true
                     },
                     "media": {
-                      "type": "object",
                       "properties": {
-                        "iconURL": {
-                          "type": "string",
-                          "example": "https://example.com/icon.png",
-                          "description": "URL to the icon for the provider.",
-                          "x-go-type-skip-optional-pointer": true
+                        "regular": {
+                          "type": "object",
+                          "description": "Media for light/regular mode.",
+                          "properties": {
+                            "iconURL": {
+                              "type": "string",
+                              "example": "https://example.com/icon.png",
+                              "description": "URL to the icon for the provider.",
+                              "x-go-type-skip-optional-pointer": true
+                            },
+                            "logoURL": {
+                              "type": "string",
+                              "example": "https://example.com/logo.png",
+                              "description": "URL to the logo for the provider.",
+                              "x-go-type-skip-optional-pointer": true
+                            }
+                          }
                         },
-                        "logoURL": {
-                          "type": "string",
-                          "example": "https://example.com/logo.png",
-                          "description": "URL to the logo for the provider.",
-                          "x-go-type-skip-optional-pointer": true
+                        "darkMode": {
+                          "type": "object",
+                          "description": "Media to be used in dark mode.",
+                          "properties": {
+                            "iconURL": {
+                              "type": "string",
+                              "example": "https://example.com/icon.png",
+                              "description": "URL to the icon for the provider that is to be used in dark mode.",
+                              "x-go-type-skip-optional-pointer": true
+                            },
+                            "logoURL": {
+                              "type": "string",
+                              "example": "https://example.com/logo.png",
+                              "description": "URL to the logo for the provider that is to be used in dark mode.",
+                              "x-go-type-skip-optional-pointer": true
+                            }
+                          }
                         }
                       }
                     }

--- a/catalog/catalog.yaml
+++ b/catalog/catalog.yaml
@@ -79,7 +79,30 @@ components:
           x-go-type-skip-optional-pointer: true
 
     Media:
+      properties:
+        regular:
+          $ref: '#/components/schemas/MediaTypeRegular'
+        darkMode:
+          $ref: '#/components/schemas/MediaTypeDarkMode'
+
+    MediaTypeDarkMode:
       type: object
+      description: Media to be used in dark mode.
+      properties:
+        iconURL:
+          type: string
+          example: https://example.com/icon.png
+          description: URL to the icon for the provider that is to be used in dark mode.
+          x-go-type-skip-optional-pointer: true
+        logoURL:
+          type: string
+          example: https://example.com/logo.png
+          description: URL to the logo for the provider that is to be used in dark mode.
+          x-go-type-skip-optional-pointer: true
+
+    MediaTypeRegular:
+      type: object
+      description: Media for light/regular mode.
       properties:
         iconURL:
           type: string


### PR DESCRIPTION
A lot of brands have light/dark themed icons and logos, so we should accomodate for that.