### PR TITLE
feat: Add `CatalogDescriptor`, a catalog wrapper type

### DIFF
--- a/api/generated/api.json
+++ b/api/generated/api.json
@@ -22001,6 +22001,7 @@
                           },
                           "tokenMetadataFields": {
                             "type": "object",
+                            "description": "Fields to be used to extract token metadata from the token response.",
                             "properties": {
                               "workspaceRefField": {
                                 "type": "string",
@@ -22058,6 +22059,7 @@
                           },
                           "query": {
                             "type": "object",
+                            "description": "Configuration for API key in query parameter. Must be provided if type is in-query.",
                             "required": [
                               "name"
                             ],
@@ -22072,6 +22074,7 @@
                           },
                           "header": {
                             "type": "object",
+                            "description": "Configuration for API key in header. Must be provided if type is in-header.",
                             "required": [
                               "name"
                             ],
@@ -22477,6 +22480,7 @@
                         },
                         "tokenMetadataFields": {
                           "type": "object",
+                          "description": "Fields to be used to extract token metadata from the token response.",
                           "properties": {
                             "workspaceRefField": {
                               "type": "string",
@@ -22534,6 +22538,7 @@
                         },
                         "query": {
                           "type": "object",
+                          "description": "Configuration for API key in query parameter. Must be provided if type is in-query.",
                           "required": [
                             "name"
                           ],
@@ -22548,6 +22553,7 @@
                         },
                         "header": {
                           "type": "object",
+                          "description": "Configuration for API key in header. Must be provided if type is in-header.",
                           "required": [
                             "name"
                           ],

--- a/api/generated/api.json
+++ b/api/generated/api.json
@@ -22000,7 +22000,6 @@
                             "x-go-type-skip-optional-pointer": true
                           },
                           "tokenMetadataFields": {
-                            "description": "Fields to be used to extract token metadata from the token response.",
                             "type": "object",
                             "properties": {
                               "workspaceRefField": {
@@ -22058,7 +22057,6 @@
                             }
                           },
                           "query": {
-                            "description": "Configuration for API key in query parameter. Must be provided if type is in-query.",
                             "type": "object",
                             "required": [
                               "name"
@@ -22073,7 +22071,6 @@
                             }
                           },
                           "header": {
-                            "description": "Configuration for API key in header. Must be provided if type is in-header.",
                             "type": "object",
                             "required": [
                               "name"
@@ -22479,7 +22476,6 @@
                           "x-go-type-skip-optional-pointer": true
                         },
                         "tokenMetadataFields": {
-                          "description": "Fields to be used to extract token metadata from the token response.",
                           "type": "object",
                           "properties": {
                             "workspaceRefField": {
@@ -22537,7 +22533,6 @@
                           }
                         },
                         "query": {
-                          "description": "Configuration for API key in query parameter. Must be provided if type is in-query.",
                           "type": "object",
                           "required": [
                             "name"
@@ -22552,7 +22547,6 @@
                           }
                         },
                         "header": {
-                          "description": "Configuration for API key in header. Must be provided if type is in-header.",
                           "type": "object",
                           "required": [
                             "name"

--- a/catalog/catalog.yaml
+++ b/catalog/catalog.yaml
@@ -155,7 +155,6 @@ components:
           description: A list of URLs that represent the audience for the token, which is needed for some client credential grant flows.
           x-go-type-skip-optional-pointer: true
         tokenMetadataFields:
-          description: Fields to be used to extract token metadata from the token response.
           $ref: '#/components/schemas/TokenMetadataFields'
         docsURL:
           type: string
@@ -184,10 +183,8 @@ components:
           x-oapi-codegen-extra-tags:
             validate: required
         query:
-          description: Configuration for API key in query parameter. Must be provided if type is in-query.
           $ref: '#/components/schemas/ApiKeyOptsQuery'
         header:
-          description: Configuration for API key in header. Must be provided if type is in-header.
           $ref: '#/components/schemas/ApiKeyOptsHeader'
         docsURL:
           type: string
@@ -289,6 +286,21 @@ components:
           x-go-type-skip-optional-pointer: true
         media:
           $ref: '#/components/schemas/Media'
+
+    CatalogDescriptor:
+      type: object
+      required:
+        - timestamp
+        - catalog
+      properties:
+        timestamp:
+          type: string
+          example: 2024-07-30T15:14:51-07:00
+          description: An RFC3339 formatted timestamp of when the catalog was generated.
+          x-oapi-codegen-extra-tags:
+            validate: required
+        catalog:
+          $ref: '#/components/schemas/CatalogType'
 
     CatalogType:
       type: object

--- a/catalog/catalog.yaml
+++ b/catalog/catalog.yaml
@@ -64,6 +64,7 @@ components:
           type: boolean
     TokenMetadataFields:
       type: object
+      description: Fields to be used to extract token metadata from the token response.
       properties:
         workspaceRefField:
           type: string
@@ -194,6 +195,7 @@ components:
 
     ApiKeyOptsQuery:
       type: object
+      description: Configuration for API key in query parameter. Must be provided if type is in-query.
       required:
         - name
       properties:
@@ -205,6 +207,7 @@ components:
 
     ApiKeyOptsHeader:
       type: object
+      description: Configuration for API key in header. Must be provided if type is in-header.
       required:
         - name
       properties:
@@ -287,7 +290,7 @@ components:
         media:
           $ref: '#/components/schemas/Media'
 
-    CatalogDescriptor:
+    CatalogWrapper:
       type: object
       required:
         - timestamp


### PR DESCRIPTION
At some point it would be good to know when a catalog was generated. The top-level `CatalogType` entity doesn't allow for this additional metadata. This adds a new structure which will hold (a) the timestamp, and (b) the catalog.

The intention is to have `CatalogDescriptor` be the top-level type, but everything else can continue to just operate on `CatalogType` 
