### PR TITLE
[bug] fix: Batchupsert to take backfill definition

### DIFF
--- a/api/generated/api.json
+++ b/api/generated/api.json
@@ -5886,6 +5886,36 @@
                                           "enum": [
                                             "all"
                                           ]
+                                        },
+                                        "backfill": {
+                                          "type": "object",
+                                          "required": [
+                                            "defaultPeriod"
+                                          ],
+                                          "properties": {
+                                            "defaultPeriod": {
+                                              "type": "object",
+                                              "properties": {
+                                                "days": {
+                                                  "type": "integer",
+                                                  "description": "Number of days in past to backfill from. 0 is no backfill. e.g) if 10, then backfill last 10 days of data. Required if fullHistory is not set.",
+                                                  "minimum": 0,
+                                                  "example": 30,
+                                                  "x-oapi-codegen-extra-tags": {
+                                                    "validate": "required_without=FullHistory,omitempty,min=0"
+                                                  }
+                                                },
+                                                "fullHistory": {
+                                                  "type": "boolean",
+                                                  "description": "If true, backfill all history. Required if days is not set.",
+                                                  "example": false,
+                                                  "x-oapi-codegen-extra-tags": {
+                                                    "validate": "required_without=Days"
+                                                  }
+                                                }
+                                              }
+                                            }
+                                          }
                                         }
                                       }
                                     }
@@ -8240,6 +8270,36 @@
                                           "enum": [
                                             "all"
                                           ]
+                                        },
+                                        "backfill": {
+                                          "type": "object",
+                                          "required": [
+                                            "defaultPeriod"
+                                          ],
+                                          "properties": {
+                                            "defaultPeriod": {
+                                              "type": "object",
+                                              "properties": {
+                                                "days": {
+                                                  "type": "integer",
+                                                  "description": "Number of days in past to backfill from. 0 is no backfill. e.g) if 10, then backfill last 10 days of data. Required if fullHistory is not set.",
+                                                  "minimum": 0,
+                                                  "example": 30,
+                                                  "x-oapi-codegen-extra-tags": {
+                                                    "validate": "required_without=FullHistory,omitempty,min=0"
+                                                  }
+                                                },
+                                                "fullHistory": {
+                                                  "type": "boolean",
+                                                  "description": "If true, backfill all history. Required if days is not set.",
+                                                  "example": false,
+                                                  "x-oapi-codegen-extra-tags": {
+                                                    "validate": "required_without=Days"
+                                                  }
+                                                }
+                                              }
+                                            }
+                                          }
                                         }
                                       }
                                     }
@@ -36928,6 +36988,36 @@
                               "enum": [
                                 "all"
                               ]
+                            },
+                            "backfill": {
+                              "type": "object",
+                              "required": [
+                                "defaultPeriod"
+                              ],
+                              "properties": {
+                                "defaultPeriod": {
+                                  "type": "object",
+                                  "properties": {
+                                    "days": {
+                                      "type": "integer",
+                                      "description": "Number of days in past to backfill from. 0 is no backfill. e.g) if 10, then backfill last 10 days of data. Required if fullHistory is not set.",
+                                      "minimum": 0,
+                                      "example": 30,
+                                      "x-oapi-codegen-extra-tags": {
+                                        "validate": "required_without=FullHistory,omitempty,min=0"
+                                      }
+                                    },
+                                    "fullHistory": {
+                                      "type": "boolean",
+                                      "description": "If true, backfill all history. Required if days is not set.",
+                                      "example": false,
+                                      "x-oapi-codegen-extra-tags": {
+                                        "validate": "required_without=Days"
+                                      }
+                                    }
+                                  }
+                                }
+                              }
                             }
                           }
                         }
@@ -37110,6 +37200,36 @@
                           "enum": [
                             "all"
                           ]
+                        },
+                        "backfill": {
+                          "type": "object",
+                          "required": [
+                            "defaultPeriod"
+                          ],
+                          "properties": {
+                            "defaultPeriod": {
+                              "type": "object",
+                              "properties": {
+                                "days": {
+                                  "type": "integer",
+                                  "description": "Number of days in past to backfill from. 0 is no backfill. e.g) if 10, then backfill last 10 days of data. Required if fullHistory is not set.",
+                                  "minimum": 0,
+                                  "example": 30,
+                                  "x-oapi-codegen-extra-tags": {
+                                    "validate": "required_without=FullHistory,omitempty,min=0"
+                                  }
+                                },
+                                "fullHistory": {
+                                  "type": "boolean",
+                                  "description": "If true, backfill all history. Required if days is not set.",
+                                  "example": false,
+                                  "x-oapi-codegen-extra-tags": {
+                                    "validate": "required_without=Days"
+                                  }
+                                }
+                              }
+                            }
+                          }
                         }
                       }
                     }

--- a/manifest/manifest.yaml
+++ b/manifest/manifest.yaml
@@ -94,6 +94,8 @@ components:
             $ref: '#/components/schemas/IntegrationField'
         optionalFieldsAuto:
           $ref: '#/components/schemas/OptionalFieldsAutoOption'
+        backfill:
+          $ref: '../config/config.yaml#/components/schemas/Backfill'
 
     # We might end up using the same IntegrationObject type for both read and write,
     # but for now we're introducing a new type to keep them separate, and not renaming the


### PR DESCRIPTION
As stated,  openapi definition for createInstallation endpoint had backfill definition, but integrationObject did not because they were differently typed. Updating the object definition. 


## Tests

- build and lint succeeded. 