### PR TITLE
Bug: update manifest with duplicate backfill definition

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,3 +12,6 @@ lint:
 	cd manifest && rdme openapi:validate manifest.yaml && cd ..
 	cd problem && rdme openapi:validate problem.yaml
 
+.PHONY: gen
+gen:
+	pnpm run gen:json

--- a/manifest/manifest.yaml
+++ b/manifest/manifest.yaml
@@ -95,7 +95,7 @@ components:
         optionalFieldsAuto:
           $ref: '#/components/schemas/OptionalFieldsAutoOption'
         backfill:
-          $ref: '../config/config.yaml#/components/schemas/Backfill'
+          $ref: '#/components/schemas/Backfill'
 
     # We might end up using the same IntegrationObject type for both read and write,
     # but for now we're introducing a new type to keep them separate, and not renaming the
@@ -244,3 +244,29 @@ components:
           type: string
         displayName:
           type: string
+
+
+    Backfill:
+      type: object
+      required:
+        - defaultPeriod
+      properties:
+        defaultPeriod:
+          $ref: '#/components/schemas/DefaultPeriod'
+
+    DefaultPeriod:
+      type: object
+      properties:
+        days:
+          type: integer
+          description: Number of days in past to backfill from. 0 is no backfill. e.g) if 10, then backfill last 10 days of data. Required if fullHistory is not set.
+          minimum: 0
+          example: 30
+          x-oapi-codegen-extra-tags:
+            validate: required_without=FullHistory,omitempty,min=0
+        fullHistory:
+          type: boolean
+          description: If true, backfill all history. Required if days is not set.
+          example: false
+          x-oapi-codegen-extra-tags:
+            validate: required_without=Days

--- a/manifest/manifest.yaml
+++ b/manifest/manifest.yaml
@@ -245,7 +245,6 @@ components:
         displayName:
           type: string
 
-
     Backfill:
       type: object
       required:


### PR DESCRIPTION
As stated. using duplicate backfill definition

## Tests

make lint, make gen