### PR TITLE
[ENG-1424] feat: Add `apiKeyLike` and `apiKeyFormat` to `BasicAuthOpts`

### DIFF
--- a/api/generated/api.json
+++ b/api/generated/api.json
@@ -22135,7 +22135,7 @@
                         "description": "Configuration for Basic Auth. Optional.",
                         "type": "object",
                         "properties": {
-                          "apiKeyLike": {
+                          "apiKeyAsBasic": {
                             "type": "boolean",
                             "example": true,
                             "description": "If true, the provider uses an API key which then gets encoded as a basic auth user:pass string.",
@@ -22642,7 +22642,7 @@
                       "description": "Configuration for Basic Auth. Optional.",
                       "type": "object",
                       "properties": {
-                        "apiKeyLike": {
+                        "apiKeyAsBasic": {
                           "type": "boolean",
                           "example": true,
                           "description": "If true, the provider uses an API key which then gets encoded as a basic auth user:pass string.",

--- a/api/generated/api.json
+++ b/api/generated/api.json
@@ -22135,6 +22135,18 @@
                         "description": "Configuration for Basic Auth. Optional.",
                         "type": "object",
                         "properties": {
+                          "apiKeyLike": {
+                            "type": "boolean",
+                            "example": true,
+                            "description": "If true, the provider uses an API key which then gets encoded as a basic auth user:pass string.",
+                            "x-go-type-skip-optional-pointer": true
+                          },
+                          "apiKeyFormat": {
+                            "type": "string",
+                            "example": "api:%s",
+                            "description": "How to transform the API key in to a basic auth user:pass string. The %s is replaced with the API key value.",
+                            "x-go-type-skip-optional-pointer": true
+                          },
                           "docsURL": {
                             "type": "string",
                             "description": "URL with more information about how to get or use an API key.",
@@ -22614,6 +22626,18 @@
                       "description": "Configuration for Basic Auth. Optional.",
                       "type": "object",
                       "properties": {
+                        "apiKeyLike": {
+                          "type": "boolean",
+                          "example": true,
+                          "description": "If true, the provider uses an API key which then gets encoded as a basic auth user:pass string.",
+                          "x-go-type-skip-optional-pointer": true
+                        },
+                        "apiKeyFormat": {
+                          "type": "string",
+                          "example": "api:%s",
+                          "description": "How to transform the API key in to a basic auth user:pass string. The %s is replaced with the API key value.",
+                          "x-go-type-skip-optional-pointer": true
+                        },
                         "docsURL": {
                           "type": "string",
                           "description": "URL with more information about how to get or use an API key.",

--- a/api/generated/api.json
+++ b/api/generated/api.json
@@ -22148,7 +22148,7 @@
                             "x-go-type-skip-optional-pointer": true
                           },
                           "apiKeyField": {
-                            "type": "enum",
+                            "type": "string",
                             "enum": [
                               "username",
                               "password"
@@ -22649,7 +22649,7 @@
                           "x-go-type-skip-optional-pointer": true
                         },
                         "apiKeyField": {
-                          "type": "enum",
+                          "type": "string",
                           "enum": [
                             "username",
                             "password"

--- a/api/generated/api.json
+++ b/api/generated/api.json
@@ -22147,6 +22147,16 @@
                             "description": "How to transform the API key in to a basic auth user:pass string. The %s is replaced with the API key value.",
                             "x-go-type-skip-optional-pointer": true
                           },
+                          "apiKeyField": {
+                            "type": "enum",
+                            "enum": [
+                              "username",
+                              "password"
+                            ],
+                            "example": "username",
+                            "description": "When apiKeyLike is true, this field specifies whether the API key should be used as the username or password.",
+                            "x-go-type-skip-optional-pointer": true
+                          },
                           "docsURL": {
                             "type": "string",
                             "description": "URL with more information about how to get or use an API key.",
@@ -22636,6 +22646,16 @@
                           "type": "string",
                           "example": "api:%s",
                           "description": "How to transform the API key in to a basic auth user:pass string. The %s is replaced with the API key value.",
+                          "x-go-type-skip-optional-pointer": true
+                        },
+                        "apiKeyField": {
+                          "type": "enum",
+                          "enum": [
+                            "username",
+                            "password"
+                          ],
+                          "example": "username",
+                          "description": "When apiKeyLike is true, this field specifies whether the API key should be used as the username or password.",
                           "x-go-type-skip-optional-pointer": true
                         },
                         "docsURL": {

--- a/api/generated/api.json
+++ b/api/generated/api.json
@@ -22141,21 +22141,27 @@
                             "description": "If true, the provider uses an API key which then gets encoded as a basic auth user:pass string.",
                             "x-go-type-skip-optional-pointer": true
                           },
-                          "apiKeyFormat": {
-                            "type": "string",
-                            "example": "api:%s",
-                            "description": "How to transform the API key in to a basic auth user:pass string. The %s is replaced with the API key value.",
-                            "x-go-type-skip-optional-pointer": true
-                          },
-                          "apiKeyField": {
-                            "type": "string",
-                            "enum": [
-                              "username",
-                              "password"
-                            ],
-                            "example": "username",
-                            "description": "When apiKeyLike is true, this field specifies whether the API key should be used as the username or password.",
-                            "x-go-type-skip-optional-pointer": true
+                          "apiKeyAsBasicOpts": {
+                            "type": "object",
+                            "description": "when this object is present, it means that this provider uses Basic Auth to actually collect an API key",
+                            "properties": {
+                              "fieldUsed": {
+                                "type": "string",
+                                "enum": [
+                                  "username",
+                                  "password"
+                                ],
+                                "example": "username",
+                                "description": "whether the API key should be used as the username or password.",
+                                "x-go-type-skip-optional-pointer": true
+                              },
+                              "keyFormat": {
+                                "type": "string",
+                                "example": "api:%s",
+                                "description": "How to transform the API key in to a basic auth user:pass string. The %s is replaced with the API key value.",
+                                "x-go-type-skip-optional-pointer": true
+                              }
+                            }
                           },
                           "docsURL": {
                             "type": "string",
@@ -22642,21 +22648,27 @@
                           "description": "If true, the provider uses an API key which then gets encoded as a basic auth user:pass string.",
                           "x-go-type-skip-optional-pointer": true
                         },
-                        "apiKeyFormat": {
-                          "type": "string",
-                          "example": "api:%s",
-                          "description": "How to transform the API key in to a basic auth user:pass string. The %s is replaced with the API key value.",
-                          "x-go-type-skip-optional-pointer": true
-                        },
-                        "apiKeyField": {
-                          "type": "string",
-                          "enum": [
-                            "username",
-                            "password"
-                          ],
-                          "example": "username",
-                          "description": "When apiKeyLike is true, this field specifies whether the API key should be used as the username or password.",
-                          "x-go-type-skip-optional-pointer": true
+                        "apiKeyAsBasicOpts": {
+                          "type": "object",
+                          "description": "when this object is present, it means that this provider uses Basic Auth to actually collect an API key",
+                          "properties": {
+                            "fieldUsed": {
+                              "type": "string",
+                              "enum": [
+                                "username",
+                                "password"
+                              ],
+                              "example": "username",
+                              "description": "whether the API key should be used as the username or password.",
+                              "x-go-type-skip-optional-pointer": true
+                            },
+                            "keyFormat": {
+                              "type": "string",
+                              "example": "api:%s",
+                              "description": "How to transform the API key in to a basic auth user:pass string. The %s is replaced with the API key value.",
+                              "x-go-type-skip-optional-pointer": true
+                            }
+                          }
                         },
                         "docsURL": {
                           "type": "string",

--- a/catalog/catalog.yaml
+++ b/catalog/catalog.yaml
@@ -237,7 +237,7 @@ components:
           description: How to transform the API key in to a basic auth user:pass string. The %s is replaced with the API key value.
           x-go-type-skip-optional-pointer: true
         apiKeyField:
-          type: enum
+          type: string
           enum: [username, password]
           example: username
           description: When apiKeyLike is true, this field specifies whether the API key should be used as the username or password.

--- a/catalog/catalog.yaml
+++ b/catalog/catalog.yaml
@@ -226,6 +226,16 @@ components:
       type: object
       description: Configuration for Basic Auth. Optional.
       properties:
+        apiKeyLike:
+          type: boolean
+          example: true
+          description: If true, the provider uses an API key which then gets encoded as a basic auth user:pass string.
+          x-go-type-skip-optional-pointer: true
+        apiKeyFormat:
+          type: string
+          example: "api:%s"
+          description: How to transform the API key in to a basic auth user:pass string. The %s is replaced with the API key value.
+          x-go-type-skip-optional-pointer: true
         docsURL:
           type: string
           description: URL with more information about how to get or use an API key.

--- a/catalog/catalog.yaml
+++ b/catalog/catalog.yaml
@@ -222,6 +222,22 @@ components:
           description: The prefix to be added to the API key value when it is sent in the header.
           x-go-type-skip-optional-pointer: true
 
+    ApiKeyAsBasicOpts:
+      type: object
+      description: when this object is present, it means that this provider uses Basic Auth to actually collect an API key
+      properties:
+        fieldUsed:
+          type: string
+          enum: [username, password]
+          example: username
+          description: whether the API key should be used as the username or password.
+          x-go-type-skip-optional-pointer: true
+        keyFormat:
+          type: string
+          example: "api:%s"
+          description: How to transform the API key in to a basic auth user:pass string. The %s is replaced with the API key value.
+          x-go-type-skip-optional-pointer: true
+
     BasicAuthOpts:
       type: object
       description: Configuration for Basic Auth. Optional.
@@ -231,17 +247,8 @@ components:
           example: true
           description: If true, the provider uses an API key which then gets encoded as a basic auth user:pass string.
           x-go-type-skip-optional-pointer: true
-        apiKeyFormat:
-          type: string
-          example: "api:%s"
-          description: How to transform the API key in to a basic auth user:pass string. The %s is replaced with the API key value.
-          x-go-type-skip-optional-pointer: true
-        apiKeyField:
-          type: string
-          enum: [username, password]
-          example: username
-          description: When apiKeyLike is true, this field specifies whether the API key should be used as the username or password.
-          x-go-type-skip-optional-pointer: true
+        apiKeyAsBasicOpts:
+          $ref: '#/components/schemas/ApiKeyAsBasicOpts'
         docsURL:
           type: string
           description: URL with more information about how to get or use an API key.

--- a/catalog/catalog.yaml
+++ b/catalog/catalog.yaml
@@ -242,7 +242,7 @@ components:
       type: object
       description: Configuration for Basic Auth. Optional.
       properties:
-        apiKeyLike:
+        apiKeyAsBasic:
           type: boolean
           example: true
           description: If true, the provider uses an API key which then gets encoded as a basic auth user:pass string.

--- a/catalog/catalog.yaml
+++ b/catalog/catalog.yaml
@@ -236,6 +236,12 @@ components:
           example: "api:%s"
           description: How to transform the API key in to a basic auth user:pass string. The %s is replaced with the API key value.
           x-go-type-skip-optional-pointer: true
+        apiKeyField:
+          type: enum
+          enum: [username, password]
+          example: username
+          description: When apiKeyLike is true, this field specifies whether the API key should be used as the username or password.
+          x-go-type-skip-optional-pointer: true
         docsURL:
           type: string
           description: URL with more information about how to get or use an API key.


### PR DESCRIPTION
There are several providers now which ostensibly have API keys, but for whatever reason choose to encode their API keys as basic authentication.

This makes the UI confusing, and it makes validation difficult (some actually use, for example, username=$apiKey,password=\<blank\> -- which the UI struggles with).

This modifies the schema for basic auth so that we can eventually support "basic auth masquerading as API key" style authentication. The backend will 100% consider these basic auth, but the frontend will now be able to present a more intuitive layout, and hide the complexity from the end user.
