### PR TITLE
fix: Remove projectId from generateConnection request body

### DIFF
--- a/api/api.yaml
+++ b/api/api.yaml
@@ -1675,14 +1675,10 @@ paths:
             schema:
               type: object
               required:
-                - projectId
                 - groupRef
                 - consumerRef
                 - provider
               properties:
-                projectId:
-                  type: string
-                  description: The ID of the project that this connection belongs to.
                 providerWorkspaceRef:
                   type: string
                   description: The ID of the provider workspace that this connection belongs to.

--- a/api/generated/api.json
+++ b/api/generated/api.json
@@ -26693,16 +26693,11 @@
               "schema": {
                 "type": "object",
                 "required": [
-                  "projectId",
                   "groupRef",
                   "consumerRef",
                   "provider"
                 ],
                 "properties": {
-                  "projectId": {
-                    "type": "string",
-                    "description": "The ID of the project that this connection belongs to."
-                  },
                   "providerWorkspaceRef": {
                     "type": "string",
                     "description": "The ID of the provider workspace that this connection belongs to."


### PR DESCRIPTION
Since project ID is already in the request path, we should not have it in the request body also. Corresponding server change in https://github.com/amp-labs/server/pull/1416