### PR TITLE
feat: Set the enum var names explicitly

### DIFF
--- a/api/generated/api.json
+++ b/api/generated/api.json
@@ -21975,8 +21975,8 @@
                         }
                       },
                       "oauth2Opts": {
-                        "description": "Configuration for OAuth2.0. Must be provided if authType is oauth2.",
                         "type": "object",
+                        "description": "Configuration for OAuth2.0. Must be provided if authType is oauth2.",
                         "required": [
                           "grantType",
                           "tokenURL",
@@ -22070,8 +22070,8 @@
                         }
                       },
                       "apiKeyOpts": {
-                        "description": "Configuration for API key. Must be provided if authType is api_key.",
                         "type": "object",
+                        "description": "Configuration for API key. Must be provided if authType is apiKey.",
                         "required": [
                           "attachmentType"
                         ],
@@ -22132,8 +22132,8 @@
                         }
                       },
                       "basicOpts": {
-                        "description": "Configuration for Basic Auth. Optional.",
                         "type": "object",
+                        "description": "Configuration for Basic Auth. Optional.",
                         "properties": {
                           "apiKeyAsBasic": {
                             "type": "boolean",
@@ -22153,7 +22153,11 @@
                                 ],
                                 "example": "username",
                                 "description": "whether the API key should be used as the username or password.",
-                                "x-go-type-skip-optional-pointer": true
+                                "x-go-type-skip-optional-pointer": true,
+                                "x-enum-varnames": [
+                                  "UsernameField",
+                                  "PasswordField"
+                                ]
                               },
                               "keyFormat": {
                                 "type": "string",
@@ -22172,8 +22176,8 @@
                         }
                       },
                       "support": {
-                        "description": "The supported features for the provider.",
                         "type": "object",
+                        "description": "The supported features for the provider.",
                         "x-oapi-codegen-extra-tags": {
                           "validate": "required"
                         },
@@ -22482,8 +22486,8 @@
                       }
                     },
                     "oauth2Opts": {
-                      "description": "Configuration for OAuth2.0. Must be provided if authType is oauth2.",
                       "type": "object",
+                      "description": "Configuration for OAuth2.0. Must be provided if authType is oauth2.",
                       "required": [
                         "grantType",
                         "tokenURL",
@@ -22577,8 +22581,8 @@
                       }
                     },
                     "apiKeyOpts": {
-                      "description": "Configuration for API key. Must be provided if authType is api_key.",
                       "type": "object",
+                      "description": "Configuration for API key. Must be provided if authType is apiKey.",
                       "required": [
                         "attachmentType"
                       ],
@@ -22639,8 +22643,8 @@
                       }
                     },
                     "basicOpts": {
-                      "description": "Configuration for Basic Auth. Optional.",
                       "type": "object",
+                      "description": "Configuration for Basic Auth. Optional.",
                       "properties": {
                         "apiKeyAsBasic": {
                           "type": "boolean",
@@ -22660,7 +22664,11 @@
                               ],
                               "example": "username",
                               "description": "whether the API key should be used as the username or password.",
-                              "x-go-type-skip-optional-pointer": true
+                              "x-go-type-skip-optional-pointer": true,
+                              "x-enum-varnames": [
+                                "UsernameField",
+                                "PasswordField"
+                              ]
                             },
                             "keyFormat": {
                               "type": "string",
@@ -22679,8 +22687,8 @@
                       }
                     },
                     "support": {
-                      "description": "The supported features for the provider.",
                       "type": "object",
+                      "description": "The supported features for the provider.",
                       "x-oapi-codegen-extra-tags": {
                         "validate": "required"
                       },

--- a/catalog/catalog.yaml
+++ b/catalog/catalog.yaml
@@ -18,6 +18,7 @@ paths: {}
 components:
   schemas:
     AuthType:
+      description: The type of authentication required by the provider.
       type: string
       enum: [oauth2, apiKey, basic, none]
       x-oapi-codegen-extra-tags:
@@ -25,6 +26,7 @@ components:
 
     Support:
       type: object
+      description: The supported features for the provider.
       x-oapi-codegen-extra-tags:
         validate: required
       required:
@@ -232,6 +234,9 @@ components:
           example: username
           description: whether the API key should be used as the username or password.
           x-go-type-skip-optional-pointer: true
+          x-enum-varnames:
+            - UsernameField
+            - PasswordField
         keyFormat:
           type: string
           example: "api:%s"
@@ -256,9 +261,10 @@ components:
           x-go-type-skip-optional-pointer: true
 
     ProviderOpts:
-        type: object
-        additionalProperties:
-          type: string
+      description: Additional provider-specific metadata.
+      type: object
+      additionalProperties:
+        type: string
 
     Provider:
       type: string
@@ -278,7 +284,6 @@ components:
           # so you don't need to worry about it. Add it for completeness if you want.
           type: string
         authType:
-          description: The type of authentication required by the provider.
           $ref: '#/components/schemas/AuthType'
         baseURL:
           description: The base URL for making API requests.
@@ -286,19 +291,14 @@ components:
           x-oapi-codegen-extra-tags:
             validate: required
         oauth2Opts:
-          description: Configuration for OAuth2.0. Must be provided if authType is oauth2.
           $ref: '#/components/schemas/Oauth2Opts'
         apiKeyOpts:
-          description: Configuration for API key. Must be provided if authType is api_key.
           $ref: '#/components/schemas/ApiKeyOpts'
         basicOpts:
-          description: Configuration for Basic Auth. Optional.
           $ref: '#/components/schemas/BasicAuthOpts'
         support:
-          description: The supported features for the provider.
           $ref: '#/components/schemas/Support'
         providerOpts:
-          description: Additional provider-specific metadata.
           $ref: '#/components/schemas/ProviderOpts'
         displayName:
           type: string


### PR DESCRIPTION
There's a conflict with enum names (username and password) with another type.

This isn't a problem, but oapi-codegen sees the clash and disambiguates the two by renaming both with long prefixes.

This breaks the existing code. It's easier to just de-conflict the var names explicitly, which avoids this breakage.

This also moves the description field in a few places to their actual valid places. Putting them next to $ref will just be ignored.