### PR TITLE
feat: Add a `scopes` field to `oauth2ClientCredentials` and `oauth2Password`

### DIFF
--- a/api/api.yaml
+++ b/api/api.yaml
@@ -1724,6 +1724,11 @@ paths:
                     clientSecret:
                       type: string
                       description: The client secret to use for the connection.
+                    scopes:
+                      type: array
+                      items:
+                        type: string
+                      description: The scopes to use for the connection (optional).
                 oauth2Password:
                   type: object
                   required:
@@ -1744,6 +1749,11 @@ paths:
                     clientSecret:
                       type: string
                       description: The client secret to use for the connection.
+                    scopes:
+                      type: array
+                      items:
+                        type: string
+                      description: The scopes to use for the connection (optional).
       responses:
         201:
           description: Created

--- a/api/generated/api.json
+++ b/api/generated/api.json
@@ -22287,6 +22287,12 @@
                             }
                           }
                         }
+                      },
+                      "labels": {
+                        "type": "object",
+                        "additionalProperties": {
+                          "type": "string"
+                        }
                       }
                     }
                   }
@@ -22797,6 +22803,12 @@
                             }
                           }
                         }
+                      }
+                    },
+                    "labels": {
+                      "type": "object",
+                      "additionalProperties": {
+                        "type": "string"
                       }
                     }
                   }
@@ -26821,6 +26833,13 @@
                       "clientSecret": {
                         "type": "string",
                         "description": "The client secret to use for the connection."
+                      },
+                      "scopes": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        },
+                        "description": "The scopes to use for the connection (optional)."
                       }
                     }
                   },
@@ -26848,6 +26867,13 @@
                       "clientSecret": {
                         "type": "string",
                         "description": "The client secret to use for the connection."
+                      },
+                      "scopes": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        },
+                        "description": "The scopes to use for the connection (optional)."
                       }
                     }
                   }


### PR DESCRIPTION
See title. Fairly straightforward change.