### PR TITLE
[ENG-1471] fix: ensure `x-api-key` is populated in oai spec & docs

### DIFF
--- a/api/api.yaml
+++ b/api/api.yaml
@@ -11,6 +11,7 @@ paths:
       summary: Get URL for OAuth flow
       description: Generate a URL for the browser to render to kick off OAuth flow.
       tags: ["OAuth"]
+      security: []  # This overrides the global security
       requestBody:
         content:
           application/json:
@@ -1390,6 +1391,7 @@ paths:
       summary: List providers
       operationId: listProviders
       tags: ["Provider"]
+      security: []  # This overrides the global security
       responses:
         200:
           description: List of providers & their information
@@ -1408,6 +1410,7 @@ paths:
       summary: Get provider
       operationId: getProvider
       tags: ["Provider"]
+      security: []  # This overrides the global security
       parameters:
         - name: provider
           in: path
@@ -2440,6 +2443,7 @@ paths:
       summary: Get information about the current user
       operationId: getMyInfo
       tags: ["User"]
+      security: []  # This overrides the global security
       responses:
         200:
           description: Information about the current user and their organizations and projects
@@ -2458,6 +2462,7 @@ paths:
       summary: Accept an invite
       operationId: acceptInvite
       tags: ["User"]
+      security: []  # This overrides the global security
       requestBody:
         content:
           application/json:

--- a/api/api.yaml
+++ b/api/api.yaml
@@ -3277,3 +3277,5 @@ components:
       type: apiKey
       name: Authorization
       in: header
+security:
+  - APIKeyHeader: []

--- a/api/api.yaml
+++ b/api/api.yaml
@@ -1391,7 +1391,6 @@ paths:
       summary: List providers
       operationId: listProviders
       tags: ["Provider"]
-      security: []  # This overrides the global security
       responses:
         200:
           description: List of providers & their information
@@ -1410,7 +1409,6 @@ paths:
       summary: Get provider
       operationId: getProvider
       tags: ["Provider"]
-      security: []  # This overrides the global security
       parameters:
         - name: provider
           in: path

--- a/api/generated/api.json
+++ b/api/generated/api.json
@@ -39133,5 +39133,10 @@
         "in": "header"
       }
     }
-  }
+  },
+  "security": [
+    {
+      "APIKeyHeader": []
+    }
+  ]
 }

--- a/api/generated/api.json
+++ b/api/generated/api.json
@@ -21935,7 +21935,6 @@
         "tags": [
           "Provider"
         ],
-        "security": [],
         "responses": {
           "200": {
             "description": "List of providers & their information",
@@ -22445,7 +22444,6 @@
         "tags": [
           "Provider"
         ],
-        "security": [],
         "parameters": [
           {
             "name": "provider",

--- a/api/generated/api.json
+++ b/api/generated/api.json
@@ -18,6 +18,7 @@
         "tags": [
           "OAuth"
         ],
+        "security": [],
         "requestBody": {
           "content": {
             "application/json": {
@@ -21934,6 +21935,7 @@
         "tags": [
           "Provider"
         ],
+        "security": [],
         "responses": {
           "200": {
             "description": "List of providers & their information",
@@ -22443,6 +22445,7 @@
         "tags": [
           "Provider"
         ],
+        "security": [],
         "parameters": [
           {
             "name": "provider",
@@ -36034,6 +36037,7 @@
         "tags": [
           "User"
         ],
+        "security": [],
         "responses": {
           "200": {
             "description": "Information about the current user and their organizations and projects",
@@ -36373,6 +36377,7 @@
         "tags": [
           "User"
         ],
+        "security": [],
         "requestBody": {
           "content": {
             "application/json": {

--- a/api/generated/read.json
+++ b/api/generated/read.json
@@ -541,6 +541,28 @@
           }
         }
       }
+    },
+    "securitySchemes": {
+      "APIKeyHeader": {
+        "type": "apiKey",
+        "name": "X-Api-Key",
+        "in": "header"
+      },
+      "APIKeyQueryParam": {
+        "type": "apiKey",
+        "name": "apiKey",
+        "in": "query"
+      },
+      "Bearer": {
+        "type": "apiKey",
+        "name": "Authorization",
+        "in": "header"
+      }
     }
-  }
+  },
+  "security": [
+    {
+      "APIKeyHeader": []
+    }
+  ]
 }

--- a/api/generated/write.json
+++ b/api/generated/write.json
@@ -796,5 +796,10 @@
         "in": "header"
       }
     }
-  }
+  },
+  "security": [
+    {
+      "APIKeyHeader": []
+    }
+  ]
 }

--- a/api/read.yaml
+++ b/api/read.yaml
@@ -89,4 +89,18 @@ components:
           type: string
           description: The operation ID
           example: 60deaf48-3856-4a2b-bfd4-3de85125eca8
-
+  securitySchemes:
+    APIKeyHeader:
+      type: apiKey
+      name: X-Api-Key
+      in: header
+    APIKeyQueryParam:
+      type: apiKey
+      name: apiKey
+      in: query
+    Bearer:
+      type: apiKey
+      name: Authorization
+      in: header
+security:
+  - APIKeyHeader: []

--- a/api/write.yaml
+++ b/api/write.yaml
@@ -239,3 +239,5 @@ components:
       type: apiKey
       name: Authorization
       in: header
+security:
+  - APIKeyHeader: []


### PR DESCRIPTION
Api reference pages in docs now show api headers correctly:


<img width="1294" alt="Screenshot 2024-08-21 at 3 05 36 PM" src="https://github.com/user-attachments/assets/717628dd-a37e-4b13-9ab9-855594aa707f">
