### PR TITLE
fix: correct the request body for CreateIntegration

### DIFF
--- a/api/api.yaml
+++ b/api/api.yaml
@@ -531,6 +531,7 @@ paths:
               required:
                 - name
                 - provider
+                - latestRevision
               type: object
               properties:
                 name:

--- a/api/api.yaml
+++ b/api/api.yaml
@@ -542,20 +542,16 @@ paths:
                   description: The provider name (e.g. "salesforce", "hubspot")
                 latestRevision:
                   type: object
+                  required:
+                    - content
+                    - specVersion
                   properties:
-                    sourceZipUrl:
+                    specVersion:
                       type: string
-                      description:
-                        URL of where a zip of the source files can be downloaded
-                        (e.g. Google Cloud Storage URL).
-                    sourceYaml:
-                      type: string
-                      description:
-                        A YAML string that defines the integration.
-                  description:
-                    If included, creating this integration will also create
-                    a new revision of the integration. For LatestRevision, one of sourceZipUrl or
-                    sourceYaml is required.
+                      description: The spec version string.
+                      example: 1.0.0
+                    content:
+                      $ref: "../manifest/manifest.yaml#/components/schemas/Integration"
         required: true
       responses:
         201:
@@ -2546,8 +2542,8 @@ components:
           example: revision-id-1
         specVersion:
           type: string
-          description: The spec version string (e.g. "0.1.0").
-          example: 0.1.0
+          description: The spec version string.
+          example: 1.0.0
         createTime:
           type: string
           description: The time the revision was created.
@@ -2568,8 +2564,8 @@ components:
           example: revision-id-1
         specVersion:
           type: string
-          description: The spec version string (e.g. "0.1.0").
-          example: 0.1.0
+          description: The spec version string.
+          example: 1.0.0
         createTime:
           type: string
           description: The time the revision was created.

--- a/api/generated/api.json
+++ b/api/generated/api.json
@@ -5760,8 +5760,8 @@
                           },
                           "specVersion": {
                             "type": "string",
-                            "description": "The spec version string (e.g. \"0.1.0\").",
-                            "example": "0.1.0"
+                            "description": "The spec version string.",
+                            "example": "1.0.0"
                           },
                           "createTime": {
                             "type": "string",
@@ -6470,17 +6470,221 @@
                   },
                   "latestRevision": {
                     "type": "object",
+                    "required": [
+                      "content",
+                      "specVersion"
+                    ],
                     "properties": {
-                      "sourceZipUrl": {
+                      "specVersion": {
                         "type": "string",
-                        "description": "URL of where a zip of the source files can be downloaded (e.g. Google Cloud Storage URL)."
+                        "description": "The spec version string.",
+                        "example": "1.0.0"
                       },
-                      "sourceYaml": {
-                        "type": "string",
-                        "description": "A YAML string that defines the integration."
+                      "content": {
+                        "type": "object",
+                        "required": [
+                          "name",
+                          "provider"
+                        ],
+                        "properties": {
+                          "name": {
+                            "type": "string"
+                          },
+                          "displayName": {
+                            "type": "string"
+                          },
+                          "provider": {
+                            "type": "string"
+                          },
+                          "read": {
+                            "type": "object",
+                            "properties": {
+                              "objects": {
+                                "type": "array",
+                                "items": {
+                                  "type": "object",
+                                  "required": [
+                                    "objectName",
+                                    "destination",
+                                    "schedule"
+                                  ],
+                                  "properties": {
+                                    "objectName": {
+                                      "type": "string"
+                                    },
+                                    "destination": {
+                                      "type": "string"
+                                    },
+                                    "schedule": {
+                                      "type": "string"
+                                    },
+                                    "requiredFields": {
+                                      "type": "array",
+                                      "items": {
+                                        "oneOf": [
+                                          {
+                                            "type": "object",
+                                            "required": [
+                                              "fieldName"
+                                            ],
+                                            "properties": {
+                                              "fieldName": {
+                                                "type": "string"
+                                              }
+                                            }
+                                          },
+                                          {
+                                            "type": "object",
+                                            "required": [
+                                              "mapToName"
+                                            ],
+                                            "properties": {
+                                              "mapToName": {
+                                                "type": "string"
+                                              },
+                                              "mapToDisplayName": {
+                                                "type": "string"
+                                              },
+                                              "default": {
+                                                "type": "string"
+                                              },
+                                              "prompt": {
+                                                "type": "string"
+                                              }
+                                            }
+                                          }
+                                        ]
+                                      }
+                                    },
+                                    "optionalFields": {
+                                      "type": "array",
+                                      "items": {
+                                        "oneOf": [
+                                          {
+                                            "type": "object",
+                                            "required": [
+                                              "fieldName"
+                                            ],
+                                            "properties": {
+                                              "fieldName": {
+                                                "type": "string"
+                                              }
+                                            }
+                                          },
+                                          {
+                                            "type": "object",
+                                            "required": [
+                                              "mapToName"
+                                            ],
+                                            "properties": {
+                                              "mapToName": {
+                                                "type": "string"
+                                              },
+                                              "mapToDisplayName": {
+                                                "type": "string"
+                                              },
+                                              "default": {
+                                                "type": "string"
+                                              },
+                                              "prompt": {
+                                                "type": "string"
+                                              }
+                                            }
+                                          }
+                                        ]
+                                      }
+                                    },
+                                    "optionalFieldsAuto": {
+                                      "type": "string",
+                                      "enum": [
+                                        "all"
+                                      ]
+                                    },
+                                    "backfill": {
+                                      "type": "object",
+                                      "required": [
+                                        "defaultPeriod"
+                                      ],
+                                      "properties": {
+                                        "defaultPeriod": {
+                                          "type": "object",
+                                          "properties": {
+                                            "days": {
+                                              "type": "integer",
+                                              "description": "Number of days in past to backfill from. 0 is no backfill. e.g) if 10, then backfill last 10 days of data. Required if fullHistory is not set.",
+                                              "minimum": 0,
+                                              "example": 30,
+                                              "x-oapi-codegen-extra-tags": {
+                                                "validate": "required_without=FullHistory,omitempty,min=0"
+                                              }
+                                            },
+                                            "fullHistory": {
+                                              "type": "boolean",
+                                              "description": "If true, backfill all history. Required if days is not set.",
+                                              "example": false,
+                                              "x-oapi-codegen-extra-tags": {
+                                                "validate": "required_without=Days"
+                                              }
+                                            }
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "delivery": {
+                                      "type": "object",
+                                      "properties": {
+                                        "mode": {
+                                          "type": "string",
+                                          "default": "auto",
+                                          "enum": [
+                                            "onRequest",
+                                            "auto"
+                                          ],
+                                          "description": "The data delivery mode for this object. If not specified, defaults to automatic."
+                                        },
+                                        "pageSize": {
+                                          "type": "integer",
+                                          "description": "The number of records to receive per data delivery.",
+                                          "minimum": 50,
+                                          "maximum": 500
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          "write": {
+                            "type": "object",
+                            "properties": {
+                              "objects": {
+                                "type": "array",
+                                "items": {
+                                  "type": "object",
+                                  "required": [
+                                    "objectName"
+                                  ],
+                                  "properties": {
+                                    "objectName": {
+                                      "type": "string"
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          "proxy": {
+                            "type": "object",
+                            "properties": {
+                              "enabled": {
+                                "type": "boolean"
+                              }
+                            }
+                          }
+                        }
                       }
-                    },
-                    "description": "If included, creating this integration will also create a new revision of the integration. For LatestRevision, one of sourceZipUrl or sourceYaml is required."
+                    }
                   }
                 }
               }
@@ -8168,8 +8372,8 @@
                           },
                           "specVersion": {
                             "type": "string",
-                            "description": "The spec version string (e.g. \"0.1.0\").",
-                            "example": "0.1.0"
+                            "description": "The spec version string.",
+                            "example": "1.0.0"
                           },
                           "createTime": {
                             "type": "string",
@@ -9728,8 +9932,8 @@
                     },
                     "specVersion": {
                       "type": "string",
-                      "description": "The spec version string (e.g. \"0.1.0\").",
-                      "example": "0.1.0"
+                      "description": "The spec version string.",
+                      "example": "1.0.0"
                     },
                     "createTime": {
                       "type": "string",
@@ -34519,8 +34723,8 @@
               },
               "specVersion": {
                 "type": "string",
-                "description": "The spec version string (e.g. \"0.1.0\").",
-                "example": "0.1.0"
+                "description": "The spec version string.",
+                "example": "1.0.0"
               },
               "createTime": {
                 "type": "string",
@@ -34751,8 +34955,8 @@
           },
           "specVersion": {
             "type": "string",
-            "description": "The spec version string (e.g. \"0.1.0\").",
-            "example": "0.1.0"
+            "description": "The spec version string.",
+            "example": "1.0.0"
           },
           "createTime": {
             "type": "string",
@@ -34981,8 +35185,8 @@
           },
           "specVersion": {
             "type": "string",
-            "description": "The spec version string (e.g. \"0.1.0\").",
-            "example": "0.1.0"
+            "description": "The spec version string.",
+            "example": "1.0.0"
           },
           "createTime": {
             "type": "string",

--- a/api/generated/api.json
+++ b/api/generated/api.json
@@ -6455,7 +6455,8 @@
               "schema": {
                 "required": [
                   "name",
-                  "provider"
+                  "provider",
+                  "latestRevision"
                 ],
                 "type": "object",
                 "properties": {


### PR DESCRIPTION
Our existing API reference is totally wrong, since the server implementation expects a fully formed LatestRevision object, and does not do any parsing of URLs or yaml strings. https://github.com/amp-labs/server/blob/ce750cc6844dcb57e785a33e5aad5f528514b048/api/routes/integration.go#L49

(Only batchUpsertIntegrations will parse yaml)