### PR TITLE
chore: add action field to webhook & other fixes

### DIFF
--- a/webhook/webhook.yaml
+++ b/webhook/webhook.yaml
@@ -14,6 +14,7 @@ components:
     WebhookMessage:
       type: object
       required:
+        - action
         - projectId
         - provider
         - groupRef
@@ -21,7 +22,6 @@ components:
         - installationId
         - objectName
         - resultInfo
-        - result
       properties:
         projectId:
           description: The Ampersand Project ID.
@@ -47,6 +47,9 @@ components:
         mappedObjectName:
           description: If there is a mapping for this object, the mapped name of the object.
           type: string
+        action:
+          description: The Ampersand action that triggered the webhook.
+          type: string
         resultInfo:
           $ref: '#/components/schemas/ResultInfo'
         result:
@@ -59,25 +62,25 @@ components:
       description: Each ResultEntry corresponds with a record in the SaaS provider (e.g. a Salesforce Account).
       properties:
         fields:
-          description: A key-value map of field names to values.
-            If you have mapped fields, this will contain the original (pre-mapped) field names and their values,
-            in addition to the unmapped fields and their values.
           $ref: '#/components/schemas/FieldsMap'
         mappedFields:
-          description: A key-value map of mapped field names to values.
-          $ref: '#/components/schemas/FieldsMap'
+          $ref: '#/components/schemas/MappedFieldsMap'
         raw:
-          description: The raw data of the record, exactly as it is returned by the SaaS API.
           $ref: '#/components/schemas/RawData'
 
     FieldsMap:
       type: object
-      description: Map of field names to values.
-      additionalProperties:
-        type: string
+      description: A key-value map of field names to values.
+                  If you have mapped fields, this will contain the original (pre-mapped) field names and their values,
+                  in addition to the unmapped fields and their values.
+
+    MappedFieldsMap:
+      type: object
+      description: A key-value map of mapped field names to values.
 
     RawData:
       type: object
+      description: The raw data of the record, exactly as it is returned by the SaaS API.
       additionalProperties: true
 
     ResultInfo:


### PR DESCRIPTION
## Changes
1) The `action` field seems to be missing from the webhook definition.
2) Any properties at the same level at `$ref` are ignored. Moved `description` properties to the components being referred to.
3) Currently, the `ResultEntry` schema has defined field and raw maps as `map[string]string`, but we can receive maps from APIs that have fields like - 
```
{
  "user": {
    "id": "1",
    "workspace": "foo"
  }
}
```
To support builders requesting the `user` field, we should use `map[string]any`. 
4) The `result` field is no longer always required. In the case that we send a URL to the results, it will be absent. Instead, since we will always send `ResultInfo`, we make that required