### PR TITLE
feat: Add builder-defined object name mapping to HydratedIntegrationObject

### DIFF
--- a/api/generated/api.json
+++ b/api/generated/api.json
@@ -10051,6 +10051,18 @@
                                   "displayName": {
                                     "type": "string"
                                   },
+                                  "mapToName": {
+                                    "type": "string",
+                                    "description": "An object name to map to in the destination.",
+                                    "example": "people",
+                                    "x-go-type-skip-optional-pointer": true
+                                  },
+                                  "mapToDisplayName": {
+                                    "type": "string",
+                                    "description": "A display name to map to in the destination.",
+                                    "example": "People",
+                                    "x-go-type-skip-optional-pointer": true
+                                  },
                                   "destination": {
                                     "type": "string"
                                   },
@@ -36151,6 +36163,18 @@
                         },
                         "displayName": {
                           "type": "string"
+                        },
+                        "mapToName": {
+                          "type": "string",
+                          "description": "An object name to map to in the destination.",
+                          "example": "people",
+                          "x-go-type-skip-optional-pointer": true
+                        },
+                        "mapToDisplayName": {
+                          "type": "string",
+                          "description": "A display name to map to in the destination.",
+                          "example": "People",
+                          "x-go-type-skip-optional-pointer": true
                         },
                         "destination": {
                           "type": "string"

--- a/api/generated/api.json
+++ b/api/generated/api.json
@@ -10083,6 +10083,12 @@
                                             "fieldName": {
                                               "type": "string"
                                             },
+                                            "mapToName": {
+                                              "type": "string",
+                                              "description": "The field name to map to in the destination.",
+                                              "example": "account_id",
+                                              "x-go-type-skip-optional-pointer": true
+                                            },
                                             "displayName": {
                                               "type": "string"
                                             }
@@ -10124,6 +10130,12 @@
                                           "properties": {
                                             "fieldName": {
                                               "type": "string"
+                                            },
+                                            "mapToName": {
+                                              "type": "string",
+                                              "description": "The field name to map to in the destination.",
+                                              "example": "account_id",
+                                              "x-go-type-skip-optional-pointer": true
                                             },
                                             "displayName": {
                                               "type": "string"
@@ -10173,6 +10185,12 @@
                                           "properties": {
                                             "fieldName": {
                                               "type": "string"
+                                            },
+                                            "mapToName": {
+                                              "type": "string",
+                                              "description": "The field name to map to in the destination.",
+                                              "example": "account_id",
+                                              "x-go-type-skip-optional-pointer": true
                                             },
                                             "displayName": {
                                               "type": "string"
@@ -36196,6 +36214,12 @@
                                   "fieldName": {
                                     "type": "string"
                                   },
+                                  "mapToName": {
+                                    "type": "string",
+                                    "description": "The field name to map to in the destination.",
+                                    "example": "account_id",
+                                    "x-go-type-skip-optional-pointer": true
+                                  },
                                   "displayName": {
                                     "type": "string"
                                   }
@@ -36237,6 +36261,12 @@
                                 "properties": {
                                   "fieldName": {
                                     "type": "string"
+                                  },
+                                  "mapToName": {
+                                    "type": "string",
+                                    "description": "The field name to map to in the destination.",
+                                    "example": "account_id",
+                                    "x-go-type-skip-optional-pointer": true
                                   },
                                   "displayName": {
                                     "type": "string"
@@ -36286,6 +36316,12 @@
                                 "properties": {
                                   "fieldName": {
                                     "type": "string"
+                                  },
+                                  "mapToName": {
+                                    "type": "string",
+                                    "description": "The field name to map to in the destination.",
+                                    "example": "account_id",
+                                    "x-go-type-skip-optional-pointer": true
                                   },
                                   "displayName": {
                                     "type": "string"

--- a/manifest/manifest.yaml
+++ b/manifest/manifest.yaml
@@ -272,6 +272,11 @@ components:
       properties:
         fieldName:
           type: string
+        mapToName:
+          type: string
+          description: The field name to map to in the destination.
+          example: account_id
+          x-go-type-skip-optional-pointer: true
         displayName:
           type: string
 

--- a/manifest/manifest.yaml
+++ b/manifest/manifest.yaml
@@ -178,6 +178,16 @@ components:
           type: string
         displayName:
           type: string
+        mapToName:
+          type: string
+          description: An object name to map to in the destination.
+          example: people
+          x-go-type-skip-optional-pointer: true
+        mapToDisplayName:
+          type: string
+          description: A display name to map to in the destination.
+          example: People
+          x-go-type-skip-optional-pointer: true
         destination:
           type: string
         schedule:


### PR DESCRIPTION
This PR adds builder-defined object name mapping fields to the hydrated revision object