### PR TITLE
[ENG-1637] Move eventType fields into ResultEntry from top level message

### DIFF
--- a/webhook/webhook.yaml
+++ b/webhook/webhook.yaml
@@ -59,14 +59,6 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/ResultEntry'
-        subscribeEventType:
-          description: The type of event that triggered the message.
-          type: string
-          enum: [create, update, delete, other]
-        providerEventType:
-          description: The type of event that triggered the message, as defined by the SaaS provider.
-          type: string
-
     ResultEntry:
       type: object
       description: Each ResultEntry corresponds with a record in the SaaS provider (e.g. a Salesforce Account).
@@ -90,6 +82,13 @@ components:
             this is the raw webhook payload
           additionalProperties: true
           x-go-type-skip-optional-pointer: true
+        subscribeEventType:
+          description: The type of event that triggered the message.
+          type: string
+          enum: [create, update, delete, other]
+        providerEventType:
+          description: The type of event that triggered the message, as defined by the SaaS provider.
+          type: string
 
     ResultInfo:
       type: object


### PR DESCRIPTION
The linter didn't run so I ran local linter

```
jaehyunlim@Jaehyuns-MacBook-Pro openapi % make lint
cd api && rdme openapi:validate write.yaml && cd ..
write.yaml is a valid OpenAPI API definition!
cd api && rdme openapi:validate read.yaml && cd ..
read.yaml is a valid OpenAPI API definition!
cd api && rdme openapi:validate api.yaml && cd ..
api.yaml is a valid OpenAPI API definition!
cd config && rdme openapi:validate config.yaml && cd ..
config.yaml is a valid OpenAPI API definition!
cd catalog && rdme openapi:validate catalog.yaml && cd ..
catalog.yaml is a valid OpenAPI API definition!
cd manifest && rdme openapi:validate manifest.yaml && cd ..
manifest.yaml is a valid OpenAPI API definition!
cd problem && rdme openapi:validate problem.yaml && cd ..
problem.yaml is a valid OpenAPI API definition!
cd webhook && rdme openapi:validate webhook.yaml
webhook.yaml is a valid OpenAPI API definition!
```