### PR TITLE
[ENG-1713] feat: Add installationLastUpdated field

### DIFF
--- a/webhook/webhook.yaml
+++ b/webhook/webhook.yaml
@@ -20,6 +20,7 @@ components:
         - groupRef
         - groupName
         - installationId
+        - installationLastUpdated
         - objectName
         - resultInfo
       properties:
@@ -41,6 +42,10 @@ components:
         installationId:
           description: The ID of the Ampersand installation.
           type: string
+        installationLastUpdated:
+          description: The timestamp of the last update to the installation.
+          type: string
+          format: date-time
         objectName:
           description:
             The name of the object. If there is a mapping for this object, this is the mapped name.


### PR DESCRIPTION
This PR adds a field to contain the installation's "last updated" timestamp, since some receivers need to know this in order to trigger certain processes on their side to update the schemas.