### PR TITLE
fix: Path params need to be unique

### DIFF
--- a/api/api.yaml
+++ b/api/api.yaml
@@ -1933,7 +1933,7 @@ paths:
           required: true
           schema:
             type: string
-          description: The destination Id
+          description: The destination ID
       requestBody:
         required: true
         content:
@@ -2016,7 +2016,7 @@ paths:
           required: true
           schema:
             type: string
-          description: The destination Id
+          description: The destination ID
       responses:
         204:
           description: Deleted

--- a/api/api.yaml
+++ b/api/api.yaml
@@ -1882,22 +1882,23 @@ paths:
             application/problem+json:
               schema:
                 $ref: "../problem/problem.yaml#/components/schemas/ApiProblem"
-  /projects/{projectIdOrName}/destinations/{destinationName}:
+  /projects/{projectIdOrName}/destinations/{destination}:
     get:
       summary: Get a destination
       operationId: getDestination
-      tags: ["Destination"]
+      tags: [ "Destination" ]
       parameters:
         - name: projectIdOrName
           in: path
           required: true
           schema:
             type: string
-        - name: destinationName
+        - name: destination
           in: path
           required: true
           schema:
             type: string
+          description: The destination name
       responses:
         404:
           description: Destination not found
@@ -1917,7 +1918,6 @@ paths:
             application/problem+json:
               schema:
                 $ref: "../problem/problem.yaml#/components/schemas/ApiProblem"
-  /projects/{projectIdOrName}/destinations/{destinationId}:
     patch:
       summary: Update a destination
       operationId: updateDestination
@@ -1928,11 +1928,12 @@ paths:
           required: true
           schema:
             type: string
-        - name: destinationId
+        - name: destination
           in: path
           required: true
           schema:
             type: string
+          description: The destination Id
       requestBody:
         required: true
         content:
@@ -2010,11 +2011,12 @@ paths:
           required: true
           schema:
             type: string
-        - name: destinationId
+        - name: destination
           in: path
           required: true
           schema:
             type: string
+          description: The destination Id
       responses:
         204:
           description: Deleted

--- a/api/generated/api.json
+++ b/api/generated/api.json
@@ -29360,7 +29360,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "The destination Id"
+            "description": "The destination ID"
           }
         ],
         "requestBody": {
@@ -30601,7 +30601,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "The destination Id"
+            "description": "The destination ID"
           }
         ],
         "responses": {

--- a/api/generated/api.json
+++ b/api/generated/api.json
@@ -28793,7 +28793,7 @@
         }
       }
     },
-    "/projects/{projectIdOrName}/destinations/{destinationName}": {
+    "/projects/{projectIdOrName}/destinations/{destination}": {
       "get": {
         "summary": "Get a destination",
         "operationId": "getDestination",
@@ -28810,12 +28810,13 @@
             }
           },
           {
-            "name": "destinationName",
+            "name": "destination",
             "in": "path",
             "required": true,
             "schema": {
               "type": "string"
-            }
+            },
+            "description": "The destination name"
           }
         ],
         "responses": {
@@ -29336,9 +29337,7 @@
             }
           }
         }
-      }
-    },
-    "/projects/{projectIdOrName}/destinations/{destinationId}": {
+      },
       "patch": {
         "summary": "Update a destination",
         "operationId": "updateDestination",
@@ -29355,12 +29354,13 @@
             }
           },
           {
-            "name": "destinationId",
+            "name": "destination",
             "in": "path",
             "required": true,
             "schema": {
               "type": "string"
-            }
+            },
+            "description": "The destination Id"
           }
         ],
         "requestBody": {
@@ -30595,12 +30595,13 @@
             }
           },
           {
-            "name": "destinationId",
+            "name": "destination",
             "in": "path",
             "required": true,
             "schema": {
               "type": "string"
-            }
+            },
+            "description": "The destination Id"
           }
         ],
         "responses": {


### PR DESCRIPTION
- All declared paths need to be unique 
- The `GET /destination` path is the same as `POST /destination` / `PATCH /destination` / `DELETE /destination` paths, but has been defined separately because the query params have different data types
- This PR merges both, and renames the query param as `destination`, and adds a description about what we expect 