### PR TITLE
fix: add missing required tags to request bodies

### DIFF
--- a/api/api.yaml
+++ b/api/api.yaml
@@ -627,6 +627,7 @@ paths:
           schema:
             type: string
       requestBody:
+        required: true
         content:
           application/json:
             schema:
@@ -693,6 +694,7 @@ paths:
                   type: string
                   description: The source YAML file that defines the revision.
               description: The source of the revision to create. One of sourceZipUrl or sourceYaml is required.
+        required: true
       responses:
         201:
           description: Created
@@ -2499,6 +2501,7 @@ paths:
           schema:
             type: string
       requestBody:
+        required: true
         content:
           application/json:
             schema:

--- a/api/generated/api.json
+++ b/api/generated/api.json
@@ -8396,6 +8396,7 @@
           }
         ],
         "requestBody": {
+          "required": true,
           "content": {
             "application/json": {
               "schema": {
@@ -9248,7 +9249,8 @@
                 "description": "The source of the revision to create. One of sourceZipUrl or sourceYaml is required."
               }
             }
-          }
+          },
+          "required": true
         },
         "responses": {
           "201": {
@@ -36254,6 +36256,7 @@
           }
         ],
         "requestBody": {
+          "required": true,
           "content": {
             "application/json": {
               "schema": {

--- a/api/generated/read.json
+++ b/api/generated/read.json
@@ -535,6 +535,7 @@
           }
         ],
         "requestBody": {
+          "required": true,
           "description": "ResultDeliveryRequestBody",
           "content": {
             "application/json": {

--- a/api/generated/read.json
+++ b/api/generated/read.json
@@ -46,6 +46,7 @@
         ],
         "requestBody": {
           "description": "Read Request",
+          "required": true,
           "content": {
             "application/json": {
               "schema": {
@@ -535,8 +536,8 @@
           }
         ],
         "requestBody": {
-          "required": true,
           "description": "ResultDeliveryRequestBody",
+          "required": true,
           "content": {
             "application/json": {
               "schema": {

--- a/api/generated/write.json
+++ b/api/generated/write.json
@@ -45,6 +45,7 @@
         ],
         "requestBody": {
           "description": "Write request",
+          "required": true,
           "content": {
             "application/json": {
               "schema": {

--- a/api/read.yaml
+++ b/api/read.yaml
@@ -30,6 +30,7 @@ paths:
             type: string
       requestBody:
         description: Read Request
+        required: true
         content:
           application/json:
             schema:
@@ -85,8 +86,8 @@ paths:
           schema:
             type: string
       requestBody:
-        required: true
         description: ResultDeliveryRequestBody
+        required: true
         content:
           application/json:
             schema:

--- a/api/read.yaml
+++ b/api/read.yaml
@@ -85,6 +85,7 @@ paths:
           schema:
             type: string
       requestBody:
+        required: true
         description: ResultDeliveryRequestBody
         content:
           application/json:

--- a/api/write.yaml
+++ b/api/write.yaml
@@ -28,6 +28,7 @@ paths:
             type: string
       requestBody:
         description: Write request
+        required: true
         content:
           application/json:
             schema:


### PR DESCRIPTION
Some operations require a request body, but do not say that in the spec.