### PR TITLE
chore: add titles for better sdk class names

### DIFF
--- a/api/api.yaml
+++ b/api/api.yaml
@@ -2542,6 +2542,7 @@ paths:
 components:
   schemas:
     Org:
+      title: Organisation
       required:
         - id
         - label
@@ -2569,6 +2570,7 @@ components:
           description: The time the organization was updated.
           format: date-time
     Destination:
+      title: Destination
       required:
         - id
         - name
@@ -2606,6 +2608,7 @@ components:
           description: The time the destination was updated.
           format: date-time
     Project:
+      title: Project
       required:
         - appName
         - createTime
@@ -2638,6 +2641,7 @@ components:
           description: The time the project was updated.
           format: date-time
     ProviderApp:
+      title: Provider App
       required:
         - clientId
         - createTime
@@ -2684,6 +2688,7 @@ components:
           description: The time the provider app was updated.
           format: date-time
     Integration:
+      title: Integration
       required:
         - createTime
         - id
@@ -2720,6 +2725,7 @@ components:
         latestRevision:
           $ref: "#/components/schemas/Revision"
     Revision:
+      title: Revision
       required:
         - content
         - createTime
@@ -2742,6 +2748,7 @@ components:
         content:
           $ref: "../manifest/manifest.yaml#/components/schemas/Integration"
     HydratedRevision:
+      title: Hydrated Revision
       required:
         - content
         - createTime
@@ -2764,6 +2771,7 @@ components:
         content:
           $ref: "../manifest/manifest.yaml#/components/schemas/HydratedIntegration"
     Installation:
+      title: Installation
       required:
         - config
         - connection
@@ -2810,6 +2818,7 @@ components:
         config:
           $ref: "#/components/schemas/Config"
     Config:
+      title: Config
       required:
         - content
         - createTime
@@ -2839,6 +2848,7 @@ components:
         content:
           $ref: "../config/config.yaml#/components/schemas/ConfigContent"
     Connection:
+      title: Connection
       required:
         - id
         - createTime
@@ -2914,6 +2924,7 @@ components:
           description: The API key used while making the connection.
           example: api-key-123
     Oauth2AuthorizationCodeTokensOnly:
+      title: OAuth2 AuthorizationCode Token
       type: object
       properties:
         accessToken:
@@ -2938,6 +2949,7 @@ components:
             type: string
           description: The scopes for the tokens.
     Oauth2AuthorizationCode:
+      title: OAuth2 Authorization Code
       type: object
       properties:
         accessToken:
@@ -2974,6 +2986,7 @@ components:
             type: string
           description: The scopes for the tokens.
     ImportConnectionRequest:
+      title: Import Connection Request
       required:
         - groupRef
         - groupName
@@ -3023,6 +3036,7 @@ components:
           items:
             type: string
     Group:
+      title: Group
       required:
         - createTime
         - groupName
@@ -3053,6 +3067,7 @@ components:
           format: date-time
           example: 2023-07-13T21:34:44.816354Z
     Consumer:
+      title: Consumer
       required:
         - consumerName
         - consumerRef
@@ -3083,6 +3098,7 @@ components:
           format: date-time
           example: 2023-07-13T21:34:44.816354Z
     Operation:
+      title: Operation
       required:
         - projectId
         - integrationId
@@ -3135,6 +3151,7 @@ components:
           format: date-time
           example: 2023-07-13T21:34:44.816354Z
     Log:
+      title: Log
       type: object
       required:
         - timestamp
@@ -3166,6 +3183,7 @@ components:
           description: The severity of the log.
           example: DEBUG
     SignedUrl:
+      title: Signed URL
       type: object
       required:
         - url
@@ -3182,6 +3200,7 @@ components:
           type: string
           description: The path (will match the path part of the url).
     ApiKeyScopes:
+      title: API Key Scopes
       type: array
       description: The scopes for the API key.
       items:
@@ -3190,6 +3209,7 @@ components:
           - full
           - frontend
     ApiKeyRequest:
+      title: API Key Request
       type: object
       required:
         - label
@@ -3201,6 +3221,7 @@ components:
         scopes:
           $ref: "#/components/schemas/ApiKeyScopes"
     ApiKey:
+      title: API Key
       type: object
       required:
         - key
@@ -3227,6 +3248,7 @@ components:
           description: Whether the API key is active.
           example: true
     PatchApiKeyRequest:
+      title: Patch API Key Request
       type: object
       required:
         - updateMask
@@ -3256,6 +3278,7 @@ components:
             scopes:
               $ref: "#/components/schemas/ApiKeyScopes"
     WebhookHeaders:
+      title: Webhook Headers
       type: object
       nullable: true
       description: Additional headers to add when Ampersand sends a webhook message
@@ -3265,6 +3288,7 @@ components:
       example:
         Authorization: "Bearer 1234"
     Invite:
+      title: Invite
       type: object
       required:
         - id
@@ -3300,6 +3324,7 @@ components:
           description: The time the invite was updated.
           format: date-time
     Builder:
+      title: Builder
       type: object
       required:
         - id
@@ -3331,6 +3356,7 @@ components:
         primaryEmail:
           type: string
     BillingAccount:
+      title: Billing Account
       type: object
       required:
         - id
@@ -3363,6 +3389,7 @@ components:
           description: The time the billing account was last updated.
           format: date-time
     BuilderInfo:
+      title: Builder Info
       type: object
       required:
         - builder
@@ -3423,6 +3450,7 @@ components:
               $ref: "#/components/schemas/Org"
             # This schema actually isn't used in the manifest but it is used by the GetObjectMetadata endpoint
     ObjectMetadata:
+      title: Object Metadata
       type: object
       required:
         - name
@@ -3445,6 +3473,7 @@ components:
           additionalProperties:
             $ref: "../manifest/manifest.yaml#/components/schemas/FieldMetadata"
     PaginationInfo:
+      title: Pagination Information
       type: object
       required:
         - done

--- a/api/generated/api.json
+++ b/api/generated/api.json
@@ -91,12 +91,15 @@
             "content": {
               "application/problem+json": {
                 "schema": {
+                  "title": "Input Validation Problem",
                   "type": "object",
                   "allOf": [
                     {
+                      "title": "API Problem",
                       "type": "object",
                       "allOf": [
                         {
+                          "title": "Problem",
                           "description": "A Problem Details object (RFC 9457).\n\nAdditional properties specific to the problem type may be present.\n",
                           "type": "object",
                           "properties": {
@@ -224,13 +227,16 @@
                     "issues": {
                       "type": "array",
                       "items": {
+                        "title": "Input Validation Issue",
                         "type": "object",
                         "description": "An issue detected during input validation.\n",
                         "allOf": [
                           {
+                            "title": "API Problem",
                             "type": "object",
                             "allOf": [
                               {
+                                "title": "Problem",
                                 "description": "A Problem Details object (RFC 9457).\n\nAdditional properties specific to the problem type may be present.\n",
                                 "type": "object",
                                 "properties": {
@@ -409,9 +415,11 @@
             "content": {
               "application/problem+json": {
                 "schema": {
+                  "title": "API Problem",
                   "type": "object",
                   "allOf": [
                     {
+                      "title": "Problem",
                       "description": "A Problem Details object (RFC 9457).\n\nAdditional properties specific to the problem type may be present.\n",
                       "type": "object",
                       "properties": {
@@ -556,6 +564,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
+                    "title": "Project",
                     "required": [
                       "appName",
                       "createTime",
@@ -604,9 +613,11 @@
             "content": {
               "application/problem+json": {
                 "schema": {
+                  "title": "API Problem",
                   "type": "object",
                   "allOf": [
                     {
+                      "title": "Problem",
                       "description": "A Problem Details object (RFC 9457).\n\nAdditional properties specific to the problem type may be present.\n",
                       "type": "object",
                       "properties": {
@@ -777,6 +788,7 @@
             "content": {
               "application/json": {
                 "schema": {
+                  "title": "Project",
                   "required": [
                     "appName",
                     "createTime",
@@ -824,12 +836,15 @@
             "content": {
               "application/problem+json": {
                 "schema": {
+                  "title": "Input Validation Problem",
                   "type": "object",
                   "allOf": [
                     {
+                      "title": "API Problem",
                       "type": "object",
                       "allOf": [
                         {
+                          "title": "Problem",
                           "description": "A Problem Details object (RFC 9457).\n\nAdditional properties specific to the problem type may be present.\n",
                           "type": "object",
                           "properties": {
@@ -957,13 +972,16 @@
                     "issues": {
                       "type": "array",
                       "items": {
+                        "title": "Input Validation Issue",
                         "type": "object",
                         "description": "An issue detected during input validation.\n",
                         "allOf": [
                           {
+                            "title": "API Problem",
                             "type": "object",
                             "allOf": [
                               {
+                                "title": "Problem",
                                 "description": "A Problem Details object (RFC 9457).\n\nAdditional properties specific to the problem type may be present.\n",
                                 "type": "object",
                                 "properties": {
@@ -1142,9 +1160,11 @@
             "content": {
               "application/problem+json": {
                 "schema": {
+                  "title": "API Problem",
                   "type": "object",
                   "allOf": [
                     {
+                      "title": "Problem",
                       "description": "A Problem Details object (RFC 9457).\n\nAdditional properties specific to the problem type may be present.\n",
                       "type": "object",
                       "properties": {
@@ -1297,6 +1317,7 @@
             "content": {
               "application/json": {
                 "schema": {
+                  "title": "Project",
                   "required": [
                     "appName",
                     "createTime",
@@ -1344,12 +1365,15 @@
             "content": {
               "application/problem+json": {
                 "schema": {
+                  "title": "Input Validation Problem",
                   "type": "object",
                   "allOf": [
                     {
+                      "title": "API Problem",
                       "type": "object",
                       "allOf": [
                         {
+                          "title": "Problem",
                           "description": "A Problem Details object (RFC 9457).\n\nAdditional properties specific to the problem type may be present.\n",
                           "type": "object",
                           "properties": {
@@ -1477,13 +1501,16 @@
                     "issues": {
                       "type": "array",
                       "items": {
+                        "title": "Input Validation Issue",
                         "type": "object",
                         "description": "An issue detected during input validation.\n",
                         "allOf": [
                           {
+                            "title": "API Problem",
                             "type": "object",
                             "allOf": [
                               {
+                                "title": "Problem",
                                 "description": "A Problem Details object (RFC 9457).\n\nAdditional properties specific to the problem type may be present.\n",
                                 "type": "object",
                                 "properties": {
@@ -1662,9 +1689,11 @@
             "content": {
               "application/problem+json": {
                 "schema": {
+                  "title": "API Problem",
                   "type": "object",
                   "allOf": [
                     {
+                      "title": "Problem",
                       "description": "A Problem Details object (RFC 9457).\n\nAdditional properties specific to the problem type may be present.\n",
                       "type": "object",
                       "properties": {
@@ -1817,12 +1846,15 @@
             "content": {
               "application/problem+json": {
                 "schema": {
+                  "title": "Input Validation Problem",
                   "type": "object",
                   "allOf": [
                     {
+                      "title": "API Problem",
                       "type": "object",
                       "allOf": [
                         {
+                          "title": "Problem",
                           "description": "A Problem Details object (RFC 9457).\n\nAdditional properties specific to the problem type may be present.\n",
                           "type": "object",
                           "properties": {
@@ -1950,13 +1982,16 @@
                     "issues": {
                       "type": "array",
                       "items": {
+                        "title": "Input Validation Issue",
                         "type": "object",
                         "description": "An issue detected during input validation.\n",
                         "allOf": [
                           {
+                            "title": "API Problem",
                             "type": "object",
                             "allOf": [
                               {
+                                "title": "Problem",
                                 "description": "A Problem Details object (RFC 9457).\n\nAdditional properties specific to the problem type may be present.\n",
                                 "type": "object",
                                 "properties": {
@@ -2135,9 +2170,11 @@
             "content": {
               "application/problem+json": {
                 "schema": {
+                  "title": "API Problem",
                   "type": "object",
                   "allOf": [
                     {
+                      "title": "Problem",
                       "description": "A Problem Details object (RFC 9457).\n\nAdditional properties specific to the problem type may be present.\n",
                       "type": "object",
                       "properties": {
@@ -2329,6 +2366,7 @@
             "content": {
               "application/json": {
                 "schema": {
+                  "title": "Project",
                   "required": [
                     "appName",
                     "createTime",
@@ -2376,12 +2414,15 @@
             "content": {
               "application/problem+json": {
                 "schema": {
+                  "title": "Input Validation Problem",
                   "type": "object",
                   "allOf": [
                     {
+                      "title": "API Problem",
                       "type": "object",
                       "allOf": [
                         {
+                          "title": "Problem",
                           "description": "A Problem Details object (RFC 9457).\n\nAdditional properties specific to the problem type may be present.\n",
                           "type": "object",
                           "properties": {
@@ -2509,13 +2550,16 @@
                     "issues": {
                       "type": "array",
                       "items": {
+                        "title": "Input Validation Issue",
                         "type": "object",
                         "description": "An issue detected during input validation.\n",
                         "allOf": [
                           {
+                            "title": "API Problem",
                             "type": "object",
                             "allOf": [
                               {
+                                "title": "Problem",
                                 "description": "A Problem Details object (RFC 9457).\n\nAdditional properties specific to the problem type may be present.\n",
                                 "type": "object",
                                 "properties": {
@@ -2694,12 +2738,15 @@
             "content": {
               "application/problem+json": {
                 "schema": {
+                  "title": "Input Validation Problem",
                   "type": "object",
                   "allOf": [
                     {
+                      "title": "API Problem",
                       "type": "object",
                       "allOf": [
                         {
+                          "title": "Problem",
                           "description": "A Problem Details object (RFC 9457).\n\nAdditional properties specific to the problem type may be present.\n",
                           "type": "object",
                           "properties": {
@@ -2827,13 +2874,16 @@
                     "issues": {
                       "type": "array",
                       "items": {
+                        "title": "Input Validation Issue",
                         "type": "object",
                         "description": "An issue detected during input validation.\n",
                         "allOf": [
                           {
+                            "title": "API Problem",
                             "type": "object",
                             "allOf": [
                               {
+                                "title": "Problem",
                                 "description": "A Problem Details object (RFC 9457).\n\nAdditional properties specific to the problem type may be present.\n",
                                 "type": "object",
                                 "properties": {
@@ -3012,9 +3062,11 @@
             "content": {
               "application/problem+json": {
                 "schema": {
+                  "title": "API Problem",
                   "type": "object",
                   "allOf": [
                     {
+                      "title": "Problem",
                       "description": "A Problem Details object (RFC 9457).\n\nAdditional properties specific to the problem type may be present.\n",
                       "type": "object",
                       "properties": {
@@ -3169,6 +3221,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
+                    "title": "Provider App",
                     "required": [
                       "clientId",
                       "createTime",
@@ -3236,12 +3289,15 @@
             "content": {
               "application/problem+json": {
                 "schema": {
+                  "title": "Input Validation Problem",
                   "type": "object",
                   "allOf": [
                     {
+                      "title": "API Problem",
                       "type": "object",
                       "allOf": [
                         {
+                          "title": "Problem",
                           "description": "A Problem Details object (RFC 9457).\n\nAdditional properties specific to the problem type may be present.\n",
                           "type": "object",
                           "properties": {
@@ -3369,13 +3425,16 @@
                     "issues": {
                       "type": "array",
                       "items": {
+                        "title": "Input Validation Issue",
                         "type": "object",
                         "description": "An issue detected during input validation.\n",
                         "allOf": [
                           {
+                            "title": "API Problem",
                             "type": "object",
                             "allOf": [
                               {
+                                "title": "Problem",
                                 "description": "A Problem Details object (RFC 9457).\n\nAdditional properties specific to the problem type may be present.\n",
                                 "type": "object",
                                 "properties": {
@@ -3554,9 +3613,11 @@
             "content": {
               "application/problem+json": {
                 "schema": {
+                  "title": "API Problem",
                   "type": "object",
                   "allOf": [
                     {
+                      "title": "Problem",
                       "description": "A Problem Details object (RFC 9457).\n\nAdditional properties specific to the problem type may be present.\n",
                       "type": "object",
                       "properties": {
@@ -3754,6 +3815,7 @@
             "content": {
               "application/json": {
                 "schema": {
+                  "title": "Provider App",
                   "required": [
                     "clientId",
                     "createTime",
@@ -3820,12 +3882,15 @@
             "content": {
               "application/problem+json": {
                 "schema": {
+                  "title": "Input Validation Problem",
                   "type": "object",
                   "allOf": [
                     {
+                      "title": "API Problem",
                       "type": "object",
                       "allOf": [
                         {
+                          "title": "Problem",
                           "description": "A Problem Details object (RFC 9457).\n\nAdditional properties specific to the problem type may be present.\n",
                           "type": "object",
                           "properties": {
@@ -3953,13 +4018,16 @@
                     "issues": {
                       "type": "array",
                       "items": {
+                        "title": "Input Validation Issue",
                         "type": "object",
                         "description": "An issue detected during input validation.\n",
                         "allOf": [
                           {
+                            "title": "API Problem",
                             "type": "object",
                             "allOf": [
                               {
+                                "title": "Problem",
                                 "description": "A Problem Details object (RFC 9457).\n\nAdditional properties specific to the problem type may be present.\n",
                                 "type": "object",
                                 "properties": {
@@ -4138,12 +4206,15 @@
             "content": {
               "application/problem+json": {
                 "schema": {
+                  "title": "Input Validation Problem",
                   "type": "object",
                   "allOf": [
                     {
+                      "title": "API Problem",
                       "type": "object",
                       "allOf": [
                         {
+                          "title": "Problem",
                           "description": "A Problem Details object (RFC 9457).\n\nAdditional properties specific to the problem type may be present.\n",
                           "type": "object",
                           "properties": {
@@ -4271,13 +4342,16 @@
                     "issues": {
                       "type": "array",
                       "items": {
+                        "title": "Input Validation Issue",
                         "type": "object",
                         "description": "An issue detected during input validation.\n",
                         "allOf": [
                           {
+                            "title": "API Problem",
                             "type": "object",
                             "allOf": [
                               {
+                                "title": "Problem",
                                 "description": "A Problem Details object (RFC 9457).\n\nAdditional properties specific to the problem type may be present.\n",
                                 "type": "object",
                                 "properties": {
@@ -4456,9 +4530,11 @@
             "content": {
               "application/problem+json": {
                 "schema": {
+                  "title": "API Problem",
                   "type": "object",
                   "allOf": [
                     {
+                      "title": "Problem",
                       "description": "A Problem Details object (RFC 9457).\n\nAdditional properties specific to the problem type may be present.\n",
                       "type": "object",
                       "properties": {
@@ -4622,12 +4698,15 @@
             "content": {
               "application/problem+json": {
                 "schema": {
+                  "title": "Input Validation Problem",
                   "type": "object",
                   "allOf": [
                     {
+                      "title": "API Problem",
                       "type": "object",
                       "allOf": [
                         {
+                          "title": "Problem",
                           "description": "A Problem Details object (RFC 9457).\n\nAdditional properties specific to the problem type may be present.\n",
                           "type": "object",
                           "properties": {
@@ -4755,13 +4834,16 @@
                     "issues": {
                       "type": "array",
                       "items": {
+                        "title": "Input Validation Issue",
                         "type": "object",
                         "description": "An issue detected during input validation.\n",
                         "allOf": [
                           {
+                            "title": "API Problem",
                             "type": "object",
                             "allOf": [
                               {
+                                "title": "Problem",
                                 "description": "A Problem Details object (RFC 9457).\n\nAdditional properties specific to the problem type may be present.\n",
                                 "type": "object",
                                 "properties": {
@@ -4940,9 +5022,11 @@
             "content": {
               "application/problem+json": {
                 "schema": {
+                  "title": "API Problem",
                   "type": "object",
                   "allOf": [
                     {
+                      "title": "Problem",
                       "description": "A Problem Details object (RFC 9457).\n\nAdditional properties specific to the problem type may be present.\n",
                       "type": "object",
                       "properties": {
@@ -5166,6 +5250,7 @@
             "content": {
               "application/json": {
                 "schema": {
+                  "title": "Provider App",
                   "required": [
                     "clientId",
                     "createTime",
@@ -5232,12 +5317,15 @@
             "content": {
               "application/problem+json": {
                 "schema": {
+                  "title": "Input Validation Problem",
                   "type": "object",
                   "allOf": [
                     {
+                      "title": "API Problem",
                       "type": "object",
                       "allOf": [
                         {
+                          "title": "Problem",
                           "description": "A Problem Details object (RFC 9457).\n\nAdditional properties specific to the problem type may be present.\n",
                           "type": "object",
                           "properties": {
@@ -5365,13 +5453,16 @@
                     "issues": {
                       "type": "array",
                       "items": {
+                        "title": "Input Validation Issue",
                         "type": "object",
                         "description": "An issue detected during input validation.\n",
                         "allOf": [
                           {
+                            "title": "API Problem",
                             "type": "object",
                             "allOf": [
                               {
+                                "title": "Problem",
                                 "description": "A Problem Details object (RFC 9457).\n\nAdditional properties specific to the problem type may be present.\n",
                                 "type": "object",
                                 "properties": {
@@ -5550,9 +5641,11 @@
             "content": {
               "application/problem+json": {
                 "schema": {
+                  "title": "API Problem",
                   "type": "object",
                   "allOf": [
                     {
+                      "title": "Problem",
                       "description": "A Problem Details object (RFC 9457).\n\nAdditional properties specific to the problem type may be present.\n",
                       "type": "object",
                       "properties": {
@@ -5707,6 +5800,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
+                    "title": "Integration",
                     "required": [
                       "createTime",
                       "id",
@@ -5748,6 +5842,7 @@
                         "format": "date-time"
                       },
                       "latestRevision": {
+                        "title": "Revision",
                         "required": [
                           "content",
                           "createTime",
@@ -5772,6 +5867,7 @@
                             "format": "date-time"
                           },
                           "content": {
+                            "title": "Integration",
                             "type": "object",
                             "required": [
                               "name",
@@ -5788,11 +5884,13 @@
                                 "type": "string"
                               },
                               "read": {
+                                "title": "Read Integration",
                                 "type": "object",
                                 "properties": {
                                   "objects": {
                                     "type": "array",
                                     "items": {
+                                      "title": "Integration Object",
                                       "type": "object",
                                       "required": [
                                         "objectName",
@@ -5824,8 +5922,10 @@
                                         "requiredFields": {
                                           "type": "array",
                                           "items": {
+                                            "title": "Integration Field",
                                             "oneOf": [
                                               {
+                                                "title": "Integration Field Existent",
                                                 "type": "object",
                                                 "required": [
                                                   "fieldName"
@@ -5849,6 +5949,7 @@
                                                 }
                                               },
                                               {
+                                                "title": "Integration Field Mapping",
                                                 "type": "object",
                                                 "required": [
                                                   "mapToName"
@@ -5874,8 +5975,10 @@
                                         "optionalFields": {
                                           "type": "array",
                                           "items": {
+                                            "title": "Integration Field",
                                             "oneOf": [
                                               {
+                                                "title": "Integration Field Existent",
                                                 "type": "object",
                                                 "required": [
                                                   "fieldName"
@@ -5899,6 +6002,7 @@
                                                 }
                                               },
                                               {
+                                                "title": "Integration Field Mapping",
                                                 "type": "object",
                                                 "required": [
                                                   "mapToName"
@@ -5922,18 +6026,21 @@
                                           }
                                         },
                                         "optionalFieldsAuto": {
+                                          "title": "Optional Fields Auto Option",
                                           "type": "string",
                                           "enum": [
                                             "all"
                                           ]
                                         },
                                         "backfill": {
+                                          "title": "Backfill",
                                           "type": "object",
                                           "required": [
                                             "defaultPeriod"
                                           ],
                                           "properties": {
                                             "defaultPeriod": {
+                                              "title": "Default Period",
                                               "type": "object",
                                               "properties": {
                                                 "days": {
@@ -5958,6 +6065,7 @@
                                           }
                                         },
                                         "delivery": {
+                                          "title": "Delivery",
                                           "type": "object",
                                           "properties": {
                                             "mode": {
@@ -5983,11 +6091,13 @@
                                 }
                               },
                               "write": {
+                                "title": "Write Integration",
                                 "type": "object",
                                 "properties": {
                                   "objects": {
                                     "type": "array",
                                     "items": {
+                                      "title": "Integration Write Object",
                                       "type": "object",
                                       "required": [
                                         "objectName"
@@ -6002,6 +6112,7 @@
                                           "example": true
                                         },
                                         "valueDefaults": {
+                                          "title": "Value Defaults",
                                           "type": "object",
                                           "description": "Configuration to set default write values for object fields.",
                                           "properties": {
@@ -6018,6 +6129,7 @@
                                 }
                               },
                               "proxy": {
+                                "title": "Proxy Integration",
                                 "type": "object",
                                 "properties": {
                                   "enabled": {
@@ -6040,12 +6152,15 @@
             "content": {
               "application/problem+json": {
                 "schema": {
+                  "title": "Input Validation Problem",
                   "type": "object",
                   "allOf": [
                     {
+                      "title": "API Problem",
                       "type": "object",
                       "allOf": [
                         {
+                          "title": "Problem",
                           "description": "A Problem Details object (RFC 9457).\n\nAdditional properties specific to the problem type may be present.\n",
                           "type": "object",
                           "properties": {
@@ -6173,13 +6288,16 @@
                     "issues": {
                       "type": "array",
                       "items": {
+                        "title": "Input Validation Issue",
                         "type": "object",
                         "description": "An issue detected during input validation.\n",
                         "allOf": [
                           {
+                            "title": "API Problem",
                             "type": "object",
                             "allOf": [
                               {
+                                "title": "Problem",
                                 "description": "A Problem Details object (RFC 9457).\n\nAdditional properties specific to the problem type may be present.\n",
                                 "type": "object",
                                 "properties": {
@@ -6358,9 +6476,11 @@
             "content": {
               "application/problem+json": {
                 "schema": {
+                  "title": "API Problem",
                   "type": "object",
                   "allOf": [
                     {
+                      "title": "Problem",
                       "description": "A Problem Details object (RFC 9457).\n\nAdditional properties specific to the problem type may be present.\n",
                       "type": "object",
                       "properties": {
@@ -6536,6 +6656,7 @@
                         "example": "1.0.0"
                       },
                       "content": {
+                        "title": "Integration",
                         "type": "object",
                         "required": [
                           "name",
@@ -6552,11 +6673,13 @@
                             "type": "string"
                           },
                           "read": {
+                            "title": "Read Integration",
                             "type": "object",
                             "properties": {
                               "objects": {
                                 "type": "array",
                                 "items": {
+                                  "title": "Integration Object",
                                   "type": "object",
                                   "required": [
                                     "objectName",
@@ -6588,8 +6711,10 @@
                                     "requiredFields": {
                                       "type": "array",
                                       "items": {
+                                        "title": "Integration Field",
                                         "oneOf": [
                                           {
+                                            "title": "Integration Field Existent",
                                             "type": "object",
                                             "required": [
                                               "fieldName"
@@ -6613,6 +6738,7 @@
                                             }
                                           },
                                           {
+                                            "title": "Integration Field Mapping",
                                             "type": "object",
                                             "required": [
                                               "mapToName"
@@ -6638,8 +6764,10 @@
                                     "optionalFields": {
                                       "type": "array",
                                       "items": {
+                                        "title": "Integration Field",
                                         "oneOf": [
                                           {
+                                            "title": "Integration Field Existent",
                                             "type": "object",
                                             "required": [
                                               "fieldName"
@@ -6663,6 +6791,7 @@
                                             }
                                           },
                                           {
+                                            "title": "Integration Field Mapping",
                                             "type": "object",
                                             "required": [
                                               "mapToName"
@@ -6686,18 +6815,21 @@
                                       }
                                     },
                                     "optionalFieldsAuto": {
+                                      "title": "Optional Fields Auto Option",
                                       "type": "string",
                                       "enum": [
                                         "all"
                                       ]
                                     },
                                     "backfill": {
+                                      "title": "Backfill",
                                       "type": "object",
                                       "required": [
                                         "defaultPeriod"
                                       ],
                                       "properties": {
                                         "defaultPeriod": {
+                                          "title": "Default Period",
                                           "type": "object",
                                           "properties": {
                                             "days": {
@@ -6722,6 +6854,7 @@
                                       }
                                     },
                                     "delivery": {
+                                      "title": "Delivery",
                                       "type": "object",
                                       "properties": {
                                         "mode": {
@@ -6747,11 +6880,13 @@
                             }
                           },
                           "write": {
+                            "title": "Write Integration",
                             "type": "object",
                             "properties": {
                               "objects": {
                                 "type": "array",
                                 "items": {
+                                  "title": "Integration Write Object",
                                   "type": "object",
                                   "required": [
                                     "objectName"
@@ -6766,6 +6901,7 @@
                                       "example": true
                                     },
                                     "valueDefaults": {
+                                      "title": "Value Defaults",
                                       "type": "object",
                                       "description": "Configuration to set default write values for object fields.",
                                       "properties": {
@@ -6782,6 +6918,7 @@
                             }
                           },
                           "proxy": {
+                            "title": "Proxy Integration",
                             "type": "object",
                             "properties": {
                               "enabled": {
@@ -6809,12 +6946,15 @@
             "content": {
               "application/problem+json": {
                 "schema": {
+                  "title": "Input Validation Problem",
                   "type": "object",
                   "allOf": [
                     {
+                      "title": "API Problem",
                       "type": "object",
                       "allOf": [
                         {
+                          "title": "Problem",
                           "description": "A Problem Details object (RFC 9457).\n\nAdditional properties specific to the problem type may be present.\n",
                           "type": "object",
                           "properties": {
@@ -6942,13 +7082,16 @@
                     "issues": {
                       "type": "array",
                       "items": {
+                        "title": "Input Validation Issue",
                         "type": "object",
                         "description": "An issue detected during input validation.\n",
                         "allOf": [
                           {
+                            "title": "API Problem",
                             "type": "object",
                             "allOf": [
                               {
+                                "title": "Problem",
                                 "description": "A Problem Details object (RFC 9457).\n\nAdditional properties specific to the problem type may be present.\n",
                                 "type": "object",
                                 "properties": {
@@ -7127,12 +7270,15 @@
             "content": {
               "application/problem+json": {
                 "schema": {
+                  "title": "Input Validation Problem",
                   "type": "object",
                   "allOf": [
                     {
+                      "title": "API Problem",
                       "type": "object",
                       "allOf": [
                         {
+                          "title": "Problem",
                           "description": "A Problem Details object (RFC 9457).\n\nAdditional properties specific to the problem type may be present.\n",
                           "type": "object",
                           "properties": {
@@ -7260,13 +7406,16 @@
                     "issues": {
                       "type": "array",
                       "items": {
+                        "title": "Input Validation Issue",
                         "type": "object",
                         "description": "An issue detected during input validation.\n",
                         "allOf": [
                           {
+                            "title": "API Problem",
                             "type": "object",
                             "allOf": [
                               {
+                                "title": "Problem",
                                 "description": "A Problem Details object (RFC 9457).\n\nAdditional properties specific to the problem type may be present.\n",
                                 "type": "object",
                                 "properties": {
@@ -7445,9 +7594,11 @@
             "content": {
               "application/problem+json": {
                 "schema": {
+                  "title": "API Problem",
                   "type": "object",
                   "allOf": [
                     {
+                      "title": "Problem",
                       "description": "A Problem Details object (RFC 9457).\n\nAdditional properties specific to the problem type may be present.\n",
                       "type": "object",
                       "properties": {
@@ -7611,12 +7762,15 @@
             "content": {
               "application/problem+json": {
                 "schema": {
+                  "title": "Input Validation Problem",
                   "type": "object",
                   "allOf": [
                     {
+                      "title": "API Problem",
                       "type": "object",
                       "allOf": [
                         {
+                          "title": "Problem",
                           "description": "A Problem Details object (RFC 9457).\n\nAdditional properties specific to the problem type may be present.\n",
                           "type": "object",
                           "properties": {
@@ -7744,13 +7898,16 @@
                     "issues": {
                       "type": "array",
                       "items": {
+                        "title": "Input Validation Issue",
                         "type": "object",
                         "description": "An issue detected during input validation.\n",
                         "allOf": [
                           {
+                            "title": "API Problem",
                             "type": "object",
                             "allOf": [
                               {
+                                "title": "Problem",
                                 "description": "A Problem Details object (RFC 9457).\n\nAdditional properties specific to the problem type may be present.\n",
                                 "type": "object",
                                 "properties": {
@@ -7929,12 +8086,15 @@
             "content": {
               "application/problem+json": {
                 "schema": {
+                  "title": "Input Validation Problem",
                   "type": "object",
                   "allOf": [
                     {
+                      "title": "API Problem",
                       "type": "object",
                       "allOf": [
                         {
+                          "title": "Problem",
                           "description": "A Problem Details object (RFC 9457).\n\nAdditional properties specific to the problem type may be present.\n",
                           "type": "object",
                           "properties": {
@@ -8062,13 +8222,16 @@
                     "issues": {
                       "type": "array",
                       "items": {
+                        "title": "Input Validation Issue",
                         "type": "object",
                         "description": "An issue detected during input validation.\n",
                         "allOf": [
                           {
+                            "title": "API Problem",
                             "type": "object",
                             "allOf": [
                               {
+                                "title": "Problem",
                                 "description": "A Problem Details object (RFC 9457).\n\nAdditional properties specific to the problem type may be present.\n",
                                 "type": "object",
                                 "properties": {
@@ -8247,9 +8410,11 @@
             "content": {
               "application/problem+json": {
                 "schema": {
+                  "title": "API Problem",
                   "type": "object",
                   "allOf": [
                     {
+                      "title": "Problem",
                       "description": "A Problem Details object (RFC 9457).\n\nAdditional properties specific to the problem type may be present.\n",
                       "type": "object",
                       "properties": {
@@ -8424,6 +8589,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
+                    "title": "Integration",
                     "required": [
                       "createTime",
                       "id",
@@ -8465,6 +8631,7 @@
                         "format": "date-time"
                       },
                       "latestRevision": {
+                        "title": "Revision",
                         "required": [
                           "content",
                           "createTime",
@@ -8489,6 +8656,7 @@
                             "format": "date-time"
                           },
                           "content": {
+                            "title": "Integration",
                             "type": "object",
                             "required": [
                               "name",
@@ -8505,11 +8673,13 @@
                                 "type": "string"
                               },
                               "read": {
+                                "title": "Read Integration",
                                 "type": "object",
                                 "properties": {
                                   "objects": {
                                     "type": "array",
                                     "items": {
+                                      "title": "Integration Object",
                                       "type": "object",
                                       "required": [
                                         "objectName",
@@ -8541,8 +8711,10 @@
                                         "requiredFields": {
                                           "type": "array",
                                           "items": {
+                                            "title": "Integration Field",
                                             "oneOf": [
                                               {
+                                                "title": "Integration Field Existent",
                                                 "type": "object",
                                                 "required": [
                                                   "fieldName"
@@ -8566,6 +8738,7 @@
                                                 }
                                               },
                                               {
+                                                "title": "Integration Field Mapping",
                                                 "type": "object",
                                                 "required": [
                                                   "mapToName"
@@ -8591,8 +8764,10 @@
                                         "optionalFields": {
                                           "type": "array",
                                           "items": {
+                                            "title": "Integration Field",
                                             "oneOf": [
                                               {
+                                                "title": "Integration Field Existent",
                                                 "type": "object",
                                                 "required": [
                                                   "fieldName"
@@ -8616,6 +8791,7 @@
                                                 }
                                               },
                                               {
+                                                "title": "Integration Field Mapping",
                                                 "type": "object",
                                                 "required": [
                                                   "mapToName"
@@ -8639,18 +8815,21 @@
                                           }
                                         },
                                         "optionalFieldsAuto": {
+                                          "title": "Optional Fields Auto Option",
                                           "type": "string",
                                           "enum": [
                                             "all"
                                           ]
                                         },
                                         "backfill": {
+                                          "title": "Backfill",
                                           "type": "object",
                                           "required": [
                                             "defaultPeriod"
                                           ],
                                           "properties": {
                                             "defaultPeriod": {
+                                              "title": "Default Period",
                                               "type": "object",
                                               "properties": {
                                                 "days": {
@@ -8675,6 +8854,7 @@
                                           }
                                         },
                                         "delivery": {
+                                          "title": "Delivery",
                                           "type": "object",
                                           "properties": {
                                             "mode": {
@@ -8700,11 +8880,13 @@
                                 }
                               },
                               "write": {
+                                "title": "Write Integration",
                                 "type": "object",
                                 "properties": {
                                   "objects": {
                                     "type": "array",
                                     "items": {
+                                      "title": "Integration Write Object",
                                       "type": "object",
                                       "required": [
                                         "objectName"
@@ -8719,6 +8901,7 @@
                                           "example": true
                                         },
                                         "valueDefaults": {
+                                          "title": "Value Defaults",
                                           "type": "object",
                                           "description": "Configuration to set default write values for object fields.",
                                           "properties": {
@@ -8735,6 +8918,7 @@
                                 }
                               },
                               "proxy": {
+                                "title": "Proxy Integration",
                                 "type": "object",
                                 "properties": {
                                   "enabled": {
@@ -8757,12 +8941,15 @@
             "content": {
               "application/problem+json": {
                 "schema": {
+                  "title": "Input Validation Problem",
                   "type": "object",
                   "allOf": [
                     {
+                      "title": "API Problem",
                       "type": "object",
                       "allOf": [
                         {
+                          "title": "Problem",
                           "description": "A Problem Details object (RFC 9457).\n\nAdditional properties specific to the problem type may be present.\n",
                           "type": "object",
                           "properties": {
@@ -8890,13 +9077,16 @@
                     "issues": {
                       "type": "array",
                       "items": {
+                        "title": "Input Validation Issue",
                         "type": "object",
                         "description": "An issue detected during input validation.\n",
                         "allOf": [
                           {
+                            "title": "API Problem",
                             "type": "object",
                             "allOf": [
                               {
+                                "title": "Problem",
                                 "description": "A Problem Details object (RFC 9457).\n\nAdditional properties specific to the problem type may be present.\n",
                                 "type": "object",
                                 "properties": {
@@ -9075,9 +9265,11 @@
             "content": {
               "application/problem+json": {
                 "schema": {
+                  "title": "API Problem",
                   "type": "object",
                   "allOf": [
                     {
+                      "title": "Problem",
                       "description": "A Problem Details object (RFC 9457).\n\nAdditional properties specific to the problem type may be present.\n",
                       "type": "object",
                       "properties": {
@@ -9262,12 +9454,15 @@
             "content": {
               "application/problem+json": {
                 "schema": {
+                  "title": "Input Validation Problem",
                   "type": "object",
                   "allOf": [
                     {
+                      "title": "API Problem",
                       "type": "object",
                       "allOf": [
                         {
+                          "title": "Problem",
                           "description": "A Problem Details object (RFC 9457).\n\nAdditional properties specific to the problem type may be present.\n",
                           "type": "object",
                           "properties": {
@@ -9395,13 +9590,16 @@
                     "issues": {
                       "type": "array",
                       "items": {
+                        "title": "Input Validation Issue",
                         "type": "object",
                         "description": "An issue detected during input validation.\n",
                         "allOf": [
                           {
+                            "title": "API Problem",
                             "type": "object",
                             "allOf": [
                               {
+                                "title": "Problem",
                                 "description": "A Problem Details object (RFC 9457).\n\nAdditional properties specific to the problem type may be present.\n",
                                 "type": "object",
                                 "properties": {
@@ -9580,12 +9778,15 @@
             "content": {
               "application/problem+json": {
                 "schema": {
+                  "title": "Input Validation Problem",
                   "type": "object",
                   "allOf": [
                     {
+                      "title": "API Problem",
                       "type": "object",
                       "allOf": [
                         {
+                          "title": "Problem",
                           "description": "A Problem Details object (RFC 9457).\n\nAdditional properties specific to the problem type may be present.\n",
                           "type": "object",
                           "properties": {
@@ -9713,13 +9914,16 @@
                     "issues": {
                       "type": "array",
                       "items": {
+                        "title": "Input Validation Issue",
                         "type": "object",
                         "description": "An issue detected during input validation.\n",
                         "allOf": [
                           {
+                            "title": "API Problem",
                             "type": "object",
                             "allOf": [
                               {
+                                "title": "Problem",
                                 "description": "A Problem Details object (RFC 9457).\n\nAdditional properties specific to the problem type may be present.\n",
                                 "type": "object",
                                 "properties": {
@@ -9898,9 +10102,11 @@
             "content": {
               "application/problem+json": {
                 "schema": {
+                  "title": "API Problem",
                   "type": "object",
                   "allOf": [
                     {
+                      "title": "Problem",
                       "description": "A Problem Details object (RFC 9457).\n\nAdditional properties specific to the problem type may be present.\n",
                       "type": "object",
                       "properties": {
@@ -10078,6 +10284,7 @@
             "content": {
               "application/json": {
                 "schema": {
+                  "title": "Hydrated Revision",
                   "required": [
                     "content",
                     "createTime",
@@ -10102,6 +10309,7 @@
                       "format": "date-time"
                     },
                     "content": {
+                      "title": "Hydrated Integration",
                       "type": "object",
                       "required": [
                         "name",
@@ -10118,11 +10326,13 @@
                           "type": "string"
                         },
                         "read": {
+                          "title": "Hydrated Read Integration",
                           "type": "object",
                           "properties": {
                             "objects": {
                               "type": "array",
                               "items": {
+                                "title": "Hydrated Integration Object",
                                 "type": "object",
                                 "required": [
                                   "objectName",
@@ -10158,6 +10368,7 @@
                                   "requiredFields": {
                                     "type": "array",
                                     "items": {
+                                      "title": "Hydrated Integration Field",
                                       "oneOf": [
                                         {
                                           "type": "object",
@@ -10187,6 +10398,7 @@
                                           }
                                         },
                                         {
+                                          "title": "Integration Field Mapping",
                                           "type": "object",
                                           "required": [
                                             "mapToName"
@@ -10212,6 +10424,7 @@
                                   "optionalFields": {
                                     "type": "array",
                                     "items": {
+                                      "title": "Hydrated Integration Field",
                                       "oneOf": [
                                         {
                                           "type": "object",
@@ -10241,6 +10454,7 @@
                                           }
                                         },
                                         {
+                                          "title": "Integration Field Mapping",
                                           "type": "object",
                                           "required": [
                                             "mapToName"
@@ -10264,6 +10478,7 @@
                                     }
                                   },
                                   "optionalFieldsAuto": {
+                                    "title": "Optional Fields Auto Option",
                                     "type": "string",
                                     "enum": [
                                       "all"
@@ -10273,6 +10488,7 @@
                                     "description": "This is a list of all fields on the object for a particular SaaS instance, including their display names.",
                                     "type": "array",
                                     "items": {
+                                      "title": "Hydrated Integration Field",
                                       "oneOf": [
                                         {
                                           "type": "object",
@@ -10302,6 +10518,7 @@
                                           }
                                         },
                                         {
+                                          "title": "Integration Field Mapping",
                                           "type": "object",
                                           "required": [
                                             "mapToName"
@@ -10328,6 +10545,7 @@
                                     "description": "This is a map of all fields on the object including their metadata (such as display name and type), the keys of the map are the field names.",
                                     "type": "object",
                                     "additionalProperties": {
+                                      "title": "Field Metadata",
                                       "type": "object",
                                       "required": [
                                         "fieldName",
@@ -10377,6 +10595,7 @@
                                           "description": "If the valueType is singleSelect or multiSelect, this is a list of possible values",
                                           "x-go-type-skip-optional-pointer": true,
                                           "items": {
+                                            "title": "Field Value",
                                             "type": "object",
                                             "required": [
                                               "value",
@@ -10401,12 +10620,14 @@
                                     }
                                   },
                                   "backfill": {
+                                    "title": "Backfill",
                                     "type": "object",
                                     "required": [
                                       "defaultPeriod"
                                     ],
                                     "properties": {
                                       "defaultPeriod": {
+                                        "title": "Default Period",
                                         "type": "object",
                                         "properties": {
                                           "days": {
@@ -10454,6 +10675,7 @@
                                     "type": "string"
                                   },
                                   "valueDefaults": {
+                                    "title": "Value Defaults",
                                     "type": "object",
                                     "description": "Configuration to set default write values for object fields.",
                                     "properties": {
@@ -10470,6 +10692,7 @@
                           }
                         },
                         "proxy": {
+                          "title": "Hydrated Proxy Integration",
                           "type": "object",
                           "properties": {
                             "enabled": {
@@ -10489,12 +10712,15 @@
             "content": {
               "application/problem+json": {
                 "schema": {
+                  "title": "Input Validation Problem",
                   "type": "object",
                   "allOf": [
                     {
+                      "title": "API Problem",
                       "type": "object",
                       "allOf": [
                         {
+                          "title": "Problem",
                           "description": "A Problem Details object (RFC 9457).\n\nAdditional properties specific to the problem type may be present.\n",
                           "type": "object",
                           "properties": {
@@ -10622,13 +10848,16 @@
                     "issues": {
                       "type": "array",
                       "items": {
+                        "title": "Input Validation Issue",
                         "type": "object",
                         "description": "An issue detected during input validation.\n",
                         "allOf": [
                           {
+                            "title": "API Problem",
                             "type": "object",
                             "allOf": [
                               {
+                                "title": "Problem",
                                 "description": "A Problem Details object (RFC 9457).\n\nAdditional properties specific to the problem type may be present.\n",
                                 "type": "object",
                                 "properties": {
@@ -10807,12 +11036,15 @@
             "content": {
               "application/problem+json": {
                 "schema": {
+                  "title": "Input Validation Problem",
                   "type": "object",
                   "allOf": [
                     {
+                      "title": "API Problem",
                       "type": "object",
                       "allOf": [
                         {
+                          "title": "Problem",
                           "description": "A Problem Details object (RFC 9457).\n\nAdditional properties specific to the problem type may be present.\n",
                           "type": "object",
                           "properties": {
@@ -10940,13 +11172,16 @@
                     "issues": {
                       "type": "array",
                       "items": {
+                        "title": "Input Validation Issue",
                         "type": "object",
                         "description": "An issue detected during input validation.\n",
                         "allOf": [
                           {
+                            "title": "API Problem",
                             "type": "object",
                             "allOf": [
                               {
+                                "title": "Problem",
                                 "description": "A Problem Details object (RFC 9457).\n\nAdditional properties specific to the problem type may be present.\n",
                                 "type": "object",
                                 "properties": {
@@ -11125,9 +11360,11 @@
             "content": {
               "application/problem+json": {
                 "schema": {
+                  "title": "API Problem",
                   "type": "object",
                   "allOf": [
                     {
+                      "title": "Problem",
                       "description": "A Problem Details object (RFC 9457).\n\nAdditional properties specific to the problem type may be present.\n",
                       "type": "object",
                       "properties": {
@@ -11296,6 +11533,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
+                    "title": "Installation",
                     "required": [
                       "config",
                       "connection",
@@ -11324,6 +11562,7 @@
                         "example": "integration-123"
                       },
                       "group": {
+                        "title": "Group",
                         "required": [
                           "createTime",
                           "groupName",
@@ -11367,6 +11606,7 @@
                         "example": "healthy"
                       },
                       "connection": {
+                        "title": "Connection",
                         "required": [
                           "id",
                           "createTime",
@@ -11395,6 +11635,7 @@
                             "example": "salesforce"
                           },
                           "providerApp": {
+                            "title": "Provider App",
                             "required": [
                               "clientId",
                               "createTime",
@@ -11454,6 +11695,7 @@
                             }
                           },
                           "group": {
+                            "title": "Group",
                             "required": [
                               "createTime",
                               "groupName",
@@ -11492,6 +11734,7 @@
                             }
                           },
                           "consumer": {
+                            "title": "Consumer",
                             "required": [
                               "consumerName",
                               "consumerRef",
@@ -11576,6 +11819,7 @@
                             ]
                           },
                           "oauth2AuthorizationCode": {
+                            "title": "OAuth2 AuthorizationCode Token",
                             "type": "object",
                             "properties": {
                               "accessToken": {
@@ -11634,6 +11878,7 @@
                         "format": "date-time"
                       },
                       "config": {
+                        "title": "Config",
                         "required": [
                           "content",
                           "createTime",
@@ -11664,8 +11909,10 @@
                             "example": "builder:builder-123"
                           },
                           "content": {
+                            "title": "Config Content",
                             "allOf": [
                               {
+                                "title": "Base Config Content",
                                 "type": "object",
                                 "properties": {
                                   "provider": {
@@ -11674,12 +11921,14 @@
                                     "type": "string"
                                   },
                                   "read": {
+                                    "title": "Base Read Config",
                                     "type": "object",
                                     "properties": {
                                       "objects": {
                                         "type": "object",
                                         "description": "This is a map of object names to their configuration.",
                                         "additionalProperties": {
+                                          "title": "Base Read Config Object",
                                           "type": "object",
                                           "properties": {
                                             "objectName": {
@@ -11720,6 +11969,7 @@
                                               },
                                               "x-go-type-skip-optional-pointer": true,
                                               "additionalProperties": {
+                                                "title": "Selected Value Mappings",
                                                 "type": "object",
                                                 "description": "This is a map of values to their mappings. The key is the value delivered to the webhook, the value is the value coming from the provider API.",
                                                 "example": {
@@ -11742,6 +11992,7 @@
                                               }
                                             },
                                             "selectedFieldsAuto": {
+                                              "title": "Selected Fields Auto Config",
                                               "description": "If selectedFieldsAuto is set to all, all fields will be read.",
                                               "type": "string",
                                               "enum": [
@@ -11752,12 +12003,14 @@
                                               ]
                                             },
                                             "backfill": {
+                                              "title": "Backfill Config",
                                               "type": "object",
                                               "required": [
                                                 "defaultPeriod"
                                               ],
                                               "properties": {
                                                 "defaultPeriod": {
+                                                  "title": "Default Period Config",
                                                   "type": "object",
                                                   "properties": {
                                                     "days": {
@@ -11787,12 +12040,14 @@
                                     }
                                   },
                                   "write": {
+                                    "title": "Base Write Config",
                                     "type": "object",
                                     "properties": {
                                       "objects": {
                                         "type": "object",
                                         "description": "This is a map of object names to their configuration.",
                                         "additionalProperties": {
+                                          "title": "Base Write Config Object",
                                           "type": "object",
                                           "properties": {
                                             "objectName": {
@@ -11808,8 +12063,10 @@
                                               "description": "This is a map of field names to default values. These values will be used when writing to the object.",
                                               "x-go-type-skip-optional-pointer": true,
                                               "additionalProperties": {
+                                                "title": "Value Default",
                                                 "oneOf": [
                                                   {
+                                                    "title": "Value Default String",
                                                     "type": "object",
                                                     "required": [
                                                       "value"
@@ -11830,6 +12087,7 @@
                                                     }
                                                   },
                                                   {
+                                                    "title": "Value Default Integer",
                                                     "type": "object",
                                                     "required": [
                                                       "value"
@@ -11850,6 +12108,7 @@
                                                     }
                                                   },
                                                   {
+                                                    "title": "Value Default Boolean",
                                                     "type": "object",
                                                     "required": [
                                                       "value"
@@ -11878,6 +12137,7 @@
                                     }
                                   },
                                   "proxy": {
+                                    "title": "Base Proxy Config",
                                     "type": "object",
                                     "properties": {
                                       "enabled": {
@@ -11916,12 +12176,15 @@
             "content": {
               "application/problem+json": {
                 "schema": {
+                  "title": "Input Validation Problem",
                   "type": "object",
                   "allOf": [
                     {
+                      "title": "API Problem",
                       "type": "object",
                       "allOf": [
                         {
+                          "title": "Problem",
                           "description": "A Problem Details object (RFC 9457).\n\nAdditional properties specific to the problem type may be present.\n",
                           "type": "object",
                           "properties": {
@@ -12049,13 +12312,16 @@
                     "issues": {
                       "type": "array",
                       "items": {
+                        "title": "Input Validation Issue",
                         "type": "object",
                         "description": "An issue detected during input validation.\n",
                         "allOf": [
                           {
+                            "title": "API Problem",
                             "type": "object",
                             "allOf": [
                               {
+                                "title": "Problem",
                                 "description": "A Problem Details object (RFC 9457).\n\nAdditional properties specific to the problem type may be present.\n",
                                 "type": "object",
                                 "properties": {
@@ -12234,9 +12500,11 @@
             "content": {
               "application/problem+json": {
                 "schema": {
+                  "title": "API Problem",
                   "type": "object",
                   "allOf": [
                     {
+                      "title": "Problem",
                       "description": "A Problem Details object (RFC 9457).\n\nAdditional properties specific to the problem type may be present.\n",
                       "type": "object",
                       "properties": {
@@ -12422,8 +12690,10 @@
                         "default": "api:create-installation"
                       },
                       "content": {
+                        "title": "Config Content",
                         "allOf": [
                           {
+                            "title": "Base Config Content",
                             "type": "object",
                             "properties": {
                               "provider": {
@@ -12432,12 +12702,14 @@
                                 "type": "string"
                               },
                               "read": {
+                                "title": "Base Read Config",
                                 "type": "object",
                                 "properties": {
                                   "objects": {
                                     "type": "object",
                                     "description": "This is a map of object names to their configuration.",
                                     "additionalProperties": {
+                                      "title": "Base Read Config Object",
                                       "type": "object",
                                       "properties": {
                                         "objectName": {
@@ -12478,6 +12750,7 @@
                                           },
                                           "x-go-type-skip-optional-pointer": true,
                                           "additionalProperties": {
+                                            "title": "Selected Value Mappings",
                                             "type": "object",
                                             "description": "This is a map of values to their mappings. The key is the value delivered to the webhook, the value is the value coming from the provider API.",
                                             "example": {
@@ -12500,6 +12773,7 @@
                                           }
                                         },
                                         "selectedFieldsAuto": {
+                                          "title": "Selected Fields Auto Config",
                                           "description": "If selectedFieldsAuto is set to all, all fields will be read.",
                                           "type": "string",
                                           "enum": [
@@ -12510,12 +12784,14 @@
                                           ]
                                         },
                                         "backfill": {
+                                          "title": "Backfill Config",
                                           "type": "object",
                                           "required": [
                                             "defaultPeriod"
                                           ],
                                           "properties": {
                                             "defaultPeriod": {
+                                              "title": "Default Period Config",
                                               "type": "object",
                                               "properties": {
                                                 "days": {
@@ -12545,12 +12821,14 @@
                                 }
                               },
                               "write": {
+                                "title": "Base Write Config",
                                 "type": "object",
                                 "properties": {
                                   "objects": {
                                     "type": "object",
                                     "description": "This is a map of object names to their configuration.",
                                     "additionalProperties": {
+                                      "title": "Base Write Config Object",
                                       "type": "object",
                                       "properties": {
                                         "objectName": {
@@ -12566,8 +12844,10 @@
                                           "description": "This is a map of field names to default values. These values will be used when writing to the object.",
                                           "x-go-type-skip-optional-pointer": true,
                                           "additionalProperties": {
+                                            "title": "Value Default",
                                             "oneOf": [
                                               {
+                                                "title": "Value Default String",
                                                 "type": "object",
                                                 "required": [
                                                   "value"
@@ -12588,6 +12868,7 @@
                                                 }
                                               },
                                               {
+                                                "title": "Value Default Integer",
                                                 "type": "object",
                                                 "required": [
                                                   "value"
@@ -12608,6 +12889,7 @@
                                                 }
                                               },
                                               {
+                                                "title": "Value Default Boolean",
                                                 "type": "object",
                                                 "required": [
                                                   "value"
@@ -12636,6 +12918,7 @@
                                 }
                               },
                               "proxy": {
+                                "title": "Base Proxy Config",
                                 "type": "object",
                                 "properties": {
                                   "enabled": {
@@ -12676,6 +12959,7 @@
             "content": {
               "application/json": {
                 "schema": {
+                  "title": "Installation",
                   "required": [
                     "config",
                     "connection",
@@ -12704,6 +12988,7 @@
                       "example": "integration-123"
                     },
                     "group": {
+                      "title": "Group",
                       "required": [
                         "createTime",
                         "groupName",
@@ -12747,6 +13032,7 @@
                       "example": "healthy"
                     },
                     "connection": {
+                      "title": "Connection",
                       "required": [
                         "id",
                         "createTime",
@@ -12775,6 +13061,7 @@
                           "example": "salesforce"
                         },
                         "providerApp": {
+                          "title": "Provider App",
                           "required": [
                             "clientId",
                             "createTime",
@@ -12834,6 +13121,7 @@
                           }
                         },
                         "group": {
+                          "title": "Group",
                           "required": [
                             "createTime",
                             "groupName",
@@ -12872,6 +13160,7 @@
                           }
                         },
                         "consumer": {
+                          "title": "Consumer",
                           "required": [
                             "consumerName",
                             "consumerRef",
@@ -12956,6 +13245,7 @@
                           ]
                         },
                         "oauth2AuthorizationCode": {
+                          "title": "OAuth2 AuthorizationCode Token",
                           "type": "object",
                           "properties": {
                             "accessToken": {
@@ -13014,6 +13304,7 @@
                       "format": "date-time"
                     },
                     "config": {
+                      "title": "Config",
                       "required": [
                         "content",
                         "createTime",
@@ -13044,8 +13335,10 @@
                           "example": "builder:builder-123"
                         },
                         "content": {
+                          "title": "Config Content",
                           "allOf": [
                             {
+                              "title": "Base Config Content",
                               "type": "object",
                               "properties": {
                                 "provider": {
@@ -13054,12 +13347,14 @@
                                   "type": "string"
                                 },
                                 "read": {
+                                  "title": "Base Read Config",
                                   "type": "object",
                                   "properties": {
                                     "objects": {
                                       "type": "object",
                                       "description": "This is a map of object names to their configuration.",
                                       "additionalProperties": {
+                                        "title": "Base Read Config Object",
                                         "type": "object",
                                         "properties": {
                                           "objectName": {
@@ -13100,6 +13395,7 @@
                                             },
                                             "x-go-type-skip-optional-pointer": true,
                                             "additionalProperties": {
+                                              "title": "Selected Value Mappings",
                                               "type": "object",
                                               "description": "This is a map of values to their mappings. The key is the value delivered to the webhook, the value is the value coming from the provider API.",
                                               "example": {
@@ -13122,6 +13418,7 @@
                                             }
                                           },
                                           "selectedFieldsAuto": {
+                                            "title": "Selected Fields Auto Config",
                                             "description": "If selectedFieldsAuto is set to all, all fields will be read.",
                                             "type": "string",
                                             "enum": [
@@ -13132,12 +13429,14 @@
                                             ]
                                           },
                                           "backfill": {
+                                            "title": "Backfill Config",
                                             "type": "object",
                                             "required": [
                                               "defaultPeriod"
                                             ],
                                             "properties": {
                                               "defaultPeriod": {
+                                                "title": "Default Period Config",
                                                 "type": "object",
                                                 "properties": {
                                                   "days": {
@@ -13167,12 +13466,14 @@
                                   }
                                 },
                                 "write": {
+                                  "title": "Base Write Config",
                                   "type": "object",
                                   "properties": {
                                     "objects": {
                                       "type": "object",
                                       "description": "This is a map of object names to their configuration.",
                                       "additionalProperties": {
+                                        "title": "Base Write Config Object",
                                         "type": "object",
                                         "properties": {
                                           "objectName": {
@@ -13188,8 +13489,10 @@
                                             "description": "This is a map of field names to default values. These values will be used when writing to the object.",
                                             "x-go-type-skip-optional-pointer": true,
                                             "additionalProperties": {
+                                              "title": "Value Default",
                                               "oneOf": [
                                                 {
+                                                  "title": "Value Default String",
                                                   "type": "object",
                                                   "required": [
                                                     "value"
@@ -13210,6 +13513,7 @@
                                                   }
                                                 },
                                                 {
+                                                  "title": "Value Default Integer",
                                                   "type": "object",
                                                   "required": [
                                                     "value"
@@ -13230,6 +13534,7 @@
                                                   }
                                                 },
                                                 {
+                                                  "title": "Value Default Boolean",
                                                   "type": "object",
                                                   "required": [
                                                     "value"
@@ -13258,6 +13563,7 @@
                                   }
                                 },
                                 "proxy": {
+                                  "title": "Base Proxy Config",
                                   "type": "object",
                                   "properties": {
                                     "enabled": {
@@ -13295,12 +13601,15 @@
             "content": {
               "application/problem+json": {
                 "schema": {
+                  "title": "Input Validation Problem",
                   "type": "object",
                   "allOf": [
                     {
+                      "title": "API Problem",
                       "type": "object",
                       "allOf": [
                         {
+                          "title": "Problem",
                           "description": "A Problem Details object (RFC 9457).\n\nAdditional properties specific to the problem type may be present.\n",
                           "type": "object",
                           "properties": {
@@ -13428,13 +13737,16 @@
                     "issues": {
                       "type": "array",
                       "items": {
+                        "title": "Input Validation Issue",
                         "type": "object",
                         "description": "An issue detected during input validation.\n",
                         "allOf": [
                           {
+                            "title": "API Problem",
                             "type": "object",
                             "allOf": [
                               {
+                                "title": "Problem",
                                 "description": "A Problem Details object (RFC 9457).\n\nAdditional properties specific to the problem type may be present.\n",
                                 "type": "object",
                                 "properties": {
@@ -13613,12 +13925,15 @@
             "content": {
               "application/problem+json": {
                 "schema": {
+                  "title": "Input Validation Problem",
                   "type": "object",
                   "allOf": [
                     {
+                      "title": "API Problem",
                       "type": "object",
                       "allOf": [
                         {
+                          "title": "Problem",
                           "description": "A Problem Details object (RFC 9457).\n\nAdditional properties specific to the problem type may be present.\n",
                           "type": "object",
                           "properties": {
@@ -13746,13 +14061,16 @@
                     "issues": {
                       "type": "array",
                       "items": {
+                        "title": "Input Validation Issue",
                         "type": "object",
                         "description": "An issue detected during input validation.\n",
                         "allOf": [
                           {
+                            "title": "API Problem",
                             "type": "object",
                             "allOf": [
                               {
+                                "title": "Problem",
                                 "description": "A Problem Details object (RFC 9457).\n\nAdditional properties specific to the problem type may be present.\n",
                                 "type": "object",
                                 "properties": {
@@ -13931,9 +14249,11 @@
             "content": {
               "application/problem+json": {
                 "schema": {
+                  "title": "API Problem",
                   "type": "object",
                   "allOf": [
                     {
+                      "title": "Problem",
                       "description": "A Problem Details object (RFC 9457).\n\nAdditional properties specific to the problem type may be present.\n",
                       "type": "object",
                       "properties": {
@@ -14102,6 +14422,7 @@
             "content": {
               "application/json": {
                 "schema": {
+                  "title": "Installation",
                   "required": [
                     "config",
                     "connection",
@@ -14130,6 +14451,7 @@
                       "example": "integration-123"
                     },
                     "group": {
+                      "title": "Group",
                       "required": [
                         "createTime",
                         "groupName",
@@ -14173,6 +14495,7 @@
                       "example": "healthy"
                     },
                     "connection": {
+                      "title": "Connection",
                       "required": [
                         "id",
                         "createTime",
@@ -14201,6 +14524,7 @@
                           "example": "salesforce"
                         },
                         "providerApp": {
+                          "title": "Provider App",
                           "required": [
                             "clientId",
                             "createTime",
@@ -14260,6 +14584,7 @@
                           }
                         },
                         "group": {
+                          "title": "Group",
                           "required": [
                             "createTime",
                             "groupName",
@@ -14298,6 +14623,7 @@
                           }
                         },
                         "consumer": {
+                          "title": "Consumer",
                           "required": [
                             "consumerName",
                             "consumerRef",
@@ -14382,6 +14708,7 @@
                           ]
                         },
                         "oauth2AuthorizationCode": {
+                          "title": "OAuth2 AuthorizationCode Token",
                           "type": "object",
                           "properties": {
                             "accessToken": {
@@ -14440,6 +14767,7 @@
                       "format": "date-time"
                     },
                     "config": {
+                      "title": "Config",
                       "required": [
                         "content",
                         "createTime",
@@ -14470,8 +14798,10 @@
                           "example": "builder:builder-123"
                         },
                         "content": {
+                          "title": "Config Content",
                           "allOf": [
                             {
+                              "title": "Base Config Content",
                               "type": "object",
                               "properties": {
                                 "provider": {
@@ -14480,12 +14810,14 @@
                                   "type": "string"
                                 },
                                 "read": {
+                                  "title": "Base Read Config",
                                   "type": "object",
                                   "properties": {
                                     "objects": {
                                       "type": "object",
                                       "description": "This is a map of object names to their configuration.",
                                       "additionalProperties": {
+                                        "title": "Base Read Config Object",
                                         "type": "object",
                                         "properties": {
                                           "objectName": {
@@ -14526,6 +14858,7 @@
                                             },
                                             "x-go-type-skip-optional-pointer": true,
                                             "additionalProperties": {
+                                              "title": "Selected Value Mappings",
                                               "type": "object",
                                               "description": "This is a map of values to their mappings. The key is the value delivered to the webhook, the value is the value coming from the provider API.",
                                               "example": {
@@ -14548,6 +14881,7 @@
                                             }
                                           },
                                           "selectedFieldsAuto": {
+                                            "title": "Selected Fields Auto Config",
                                             "description": "If selectedFieldsAuto is set to all, all fields will be read.",
                                             "type": "string",
                                             "enum": [
@@ -14558,12 +14892,14 @@
                                             ]
                                           },
                                           "backfill": {
+                                            "title": "Backfill Config",
                                             "type": "object",
                                             "required": [
                                               "defaultPeriod"
                                             ],
                                             "properties": {
                                               "defaultPeriod": {
+                                                "title": "Default Period Config",
                                                 "type": "object",
                                                 "properties": {
                                                   "days": {
@@ -14593,12 +14929,14 @@
                                   }
                                 },
                                 "write": {
+                                  "title": "Base Write Config",
                                   "type": "object",
                                   "properties": {
                                     "objects": {
                                       "type": "object",
                                       "description": "This is a map of object names to their configuration.",
                                       "additionalProperties": {
+                                        "title": "Base Write Config Object",
                                         "type": "object",
                                         "properties": {
                                           "objectName": {
@@ -14614,8 +14952,10 @@
                                             "description": "This is a map of field names to default values. These values will be used when writing to the object.",
                                             "x-go-type-skip-optional-pointer": true,
                                             "additionalProperties": {
+                                              "title": "Value Default",
                                               "oneOf": [
                                                 {
+                                                  "title": "Value Default String",
                                                   "type": "object",
                                                   "required": [
                                                     "value"
@@ -14636,6 +14976,7 @@
                                                   }
                                                 },
                                                 {
+                                                  "title": "Value Default Integer",
                                                   "type": "object",
                                                   "required": [
                                                     "value"
@@ -14656,6 +14997,7 @@
                                                   }
                                                 },
                                                 {
+                                                  "title": "Value Default Boolean",
                                                   "type": "object",
                                                   "required": [
                                                     "value"
@@ -14684,6 +15026,7 @@
                                   }
                                 },
                                 "proxy": {
+                                  "title": "Base Proxy Config",
                                   "type": "object",
                                   "properties": {
                                     "enabled": {
@@ -14721,12 +15064,15 @@
             "content": {
               "application/problem+json": {
                 "schema": {
+                  "title": "Input Validation Problem",
                   "type": "object",
                   "allOf": [
                     {
+                      "title": "API Problem",
                       "type": "object",
                       "allOf": [
                         {
+                          "title": "Problem",
                           "description": "A Problem Details object (RFC 9457).\n\nAdditional properties specific to the problem type may be present.\n",
                           "type": "object",
                           "properties": {
@@ -14854,13 +15200,16 @@
                     "issues": {
                       "type": "array",
                       "items": {
+                        "title": "Input Validation Issue",
                         "type": "object",
                         "description": "An issue detected during input validation.\n",
                         "allOf": [
                           {
+                            "title": "API Problem",
                             "type": "object",
                             "allOf": [
                               {
+                                "title": "Problem",
                                 "description": "A Problem Details object (RFC 9457).\n\nAdditional properties specific to the problem type may be present.\n",
                                 "type": "object",
                                 "properties": {
@@ -15039,9 +15388,11 @@
             "content": {
               "application/problem+json": {
                 "schema": {
+                  "title": "API Problem",
                   "type": "object",
                   "allOf": [
                     {
+                      "title": "Problem",
                       "description": "A Problem Details object (RFC 9457).\n\nAdditional properties specific to the problem type may be present.\n",
                       "type": "object",
                       "properties": {
@@ -15210,9 +15561,11 @@
             "content": {
               "application/problem+json": {
                 "schema": {
+                  "title": "API Problem",
                   "type": "object",
                   "allOf": [
                     {
+                      "title": "Problem",
                       "description": "A Problem Details object (RFC 9457).\n\nAdditional properties specific to the problem type may be present.\n",
                       "type": "object",
                       "properties": {
@@ -15414,8 +15767,10 @@
                           },
                           "content": {
                             "description": "The content of the config.",
+                            "title": "Update Installation Config Content",
                             "allOf": [
                               {
+                                "title": "Base Config Content",
                                 "type": "object",
                                 "properties": {
                                   "provider": {
@@ -15424,12 +15779,14 @@
                                     "type": "string"
                                   },
                                   "read": {
+                                    "title": "Base Read Config",
                                     "type": "object",
                                     "properties": {
                                       "objects": {
                                         "type": "object",
                                         "description": "This is a map of object names to their configuration.",
                                         "additionalProperties": {
+                                          "title": "Base Read Config Object",
                                           "type": "object",
                                           "properties": {
                                             "objectName": {
@@ -15470,6 +15827,7 @@
                                               },
                                               "x-go-type-skip-optional-pointer": true,
                                               "additionalProperties": {
+                                                "title": "Selected Value Mappings",
                                                 "type": "object",
                                                 "description": "This is a map of values to their mappings. The key is the value delivered to the webhook, the value is the value coming from the provider API.",
                                                 "example": {
@@ -15492,6 +15850,7 @@
                                               }
                                             },
                                             "selectedFieldsAuto": {
+                                              "title": "Selected Fields Auto Config",
                                               "description": "If selectedFieldsAuto is set to all, all fields will be read.",
                                               "type": "string",
                                               "enum": [
@@ -15502,12 +15861,14 @@
                                               ]
                                             },
                                             "backfill": {
+                                              "title": "Backfill Config",
                                               "type": "object",
                                               "required": [
                                                 "defaultPeriod"
                                               ],
                                               "properties": {
                                                 "defaultPeriod": {
+                                                  "title": "Default Period Config",
                                                   "type": "object",
                                                   "properties": {
                                                     "days": {
@@ -15537,12 +15898,14 @@
                                     }
                                   },
                                   "write": {
+                                    "title": "Base Write Config",
                                     "type": "object",
                                     "properties": {
                                       "objects": {
                                         "type": "object",
                                         "description": "This is a map of object names to their configuration.",
                                         "additionalProperties": {
+                                          "title": "Base Write Config Object",
                                           "type": "object",
                                           "properties": {
                                             "objectName": {
@@ -15558,8 +15921,10 @@
                                               "description": "This is a map of field names to default values. These values will be used when writing to the object.",
                                               "x-go-type-skip-optional-pointer": true,
                                               "additionalProperties": {
+                                                "title": "Value Default",
                                                 "oneOf": [
                                                   {
+                                                    "title": "Value Default String",
                                                     "type": "object",
                                                     "required": [
                                                       "value"
@@ -15580,6 +15945,7 @@
                                                     }
                                                   },
                                                   {
+                                                    "title": "Value Default Integer",
                                                     "type": "object",
                                                     "required": [
                                                       "value"
@@ -15600,6 +15966,7 @@
                                                     }
                                                   },
                                                   {
+                                                    "title": "Value Default Boolean",
                                                     "type": "object",
                                                     "required": [
                                                       "value"
@@ -15628,6 +15995,7 @@
                                     }
                                   },
                                   "proxy": {
+                                    "title": "Base Proxy Config",
                                     "type": "object",
                                     "properties": {
                                       "enabled": {
@@ -15657,6 +16025,7 @@
             "content": {
               "application/json": {
                 "schema": {
+                  "title": "Installation",
                   "required": [
                     "config",
                     "connection",
@@ -15685,6 +16054,7 @@
                       "example": "integration-123"
                     },
                     "group": {
+                      "title": "Group",
                       "required": [
                         "createTime",
                         "groupName",
@@ -15728,6 +16098,7 @@
                       "example": "healthy"
                     },
                     "connection": {
+                      "title": "Connection",
                       "required": [
                         "id",
                         "createTime",
@@ -15756,6 +16127,7 @@
                           "example": "salesforce"
                         },
                         "providerApp": {
+                          "title": "Provider App",
                           "required": [
                             "clientId",
                             "createTime",
@@ -15815,6 +16187,7 @@
                           }
                         },
                         "group": {
+                          "title": "Group",
                           "required": [
                             "createTime",
                             "groupName",
@@ -15853,6 +16226,7 @@
                           }
                         },
                         "consumer": {
+                          "title": "Consumer",
                           "required": [
                             "consumerName",
                             "consumerRef",
@@ -15937,6 +16311,7 @@
                           ]
                         },
                         "oauth2AuthorizationCode": {
+                          "title": "OAuth2 AuthorizationCode Token",
                           "type": "object",
                           "properties": {
                             "accessToken": {
@@ -15995,6 +16370,7 @@
                       "format": "date-time"
                     },
                     "config": {
+                      "title": "Config",
                       "required": [
                         "content",
                         "createTime",
@@ -16025,8 +16401,10 @@
                           "example": "builder:builder-123"
                         },
                         "content": {
+                          "title": "Config Content",
                           "allOf": [
                             {
+                              "title": "Base Config Content",
                               "type": "object",
                               "properties": {
                                 "provider": {
@@ -16035,12 +16413,14 @@
                                   "type": "string"
                                 },
                                 "read": {
+                                  "title": "Base Read Config",
                                   "type": "object",
                                   "properties": {
                                     "objects": {
                                       "type": "object",
                                       "description": "This is a map of object names to their configuration.",
                                       "additionalProperties": {
+                                        "title": "Base Read Config Object",
                                         "type": "object",
                                         "properties": {
                                           "objectName": {
@@ -16081,6 +16461,7 @@
                                             },
                                             "x-go-type-skip-optional-pointer": true,
                                             "additionalProperties": {
+                                              "title": "Selected Value Mappings",
                                               "type": "object",
                                               "description": "This is a map of values to their mappings. The key is the value delivered to the webhook, the value is the value coming from the provider API.",
                                               "example": {
@@ -16103,6 +16484,7 @@
                                             }
                                           },
                                           "selectedFieldsAuto": {
+                                            "title": "Selected Fields Auto Config",
                                             "description": "If selectedFieldsAuto is set to all, all fields will be read.",
                                             "type": "string",
                                             "enum": [
@@ -16113,12 +16495,14 @@
                                             ]
                                           },
                                           "backfill": {
+                                            "title": "Backfill Config",
                                             "type": "object",
                                             "required": [
                                               "defaultPeriod"
                                             ],
                                             "properties": {
                                               "defaultPeriod": {
+                                                "title": "Default Period Config",
                                                 "type": "object",
                                                 "properties": {
                                                   "days": {
@@ -16148,12 +16532,14 @@
                                   }
                                 },
                                 "write": {
+                                  "title": "Base Write Config",
                                   "type": "object",
                                   "properties": {
                                     "objects": {
                                       "type": "object",
                                       "description": "This is a map of object names to their configuration.",
                                       "additionalProperties": {
+                                        "title": "Base Write Config Object",
                                         "type": "object",
                                         "properties": {
                                           "objectName": {
@@ -16169,8 +16555,10 @@
                                             "description": "This is a map of field names to default values. These values will be used when writing to the object.",
                                             "x-go-type-skip-optional-pointer": true,
                                             "additionalProperties": {
+                                              "title": "Value Default",
                                               "oneOf": [
                                                 {
+                                                  "title": "Value Default String",
                                                   "type": "object",
                                                   "required": [
                                                     "value"
@@ -16191,6 +16579,7 @@
                                                   }
                                                 },
                                                 {
+                                                  "title": "Value Default Integer",
                                                   "type": "object",
                                                   "required": [
                                                     "value"
@@ -16211,6 +16600,7 @@
                                                   }
                                                 },
                                                 {
+                                                  "title": "Value Default Boolean",
                                                   "type": "object",
                                                   "required": [
                                                     "value"
@@ -16239,6 +16629,7 @@
                                   }
                                 },
                                 "proxy": {
+                                  "title": "Base Proxy Config",
                                   "type": "object",
                                   "properties": {
                                     "enabled": {
@@ -16276,12 +16667,15 @@
             "content": {
               "application/problem+json": {
                 "schema": {
+                  "title": "Input Validation Problem",
                   "type": "object",
                   "allOf": [
                     {
+                      "title": "API Problem",
                       "type": "object",
                       "allOf": [
                         {
+                          "title": "Problem",
                           "description": "A Problem Details object (RFC 9457).\n\nAdditional properties specific to the problem type may be present.\n",
                           "type": "object",
                           "properties": {
@@ -16409,13 +16803,16 @@
                     "issues": {
                       "type": "array",
                       "items": {
+                        "title": "Input Validation Issue",
                         "type": "object",
                         "description": "An issue detected during input validation.\n",
                         "allOf": [
                           {
+                            "title": "API Problem",
                             "type": "object",
                             "allOf": [
                               {
+                                "title": "Problem",
                                 "description": "A Problem Details object (RFC 9457).\n\nAdditional properties specific to the problem type may be present.\n",
                                 "type": "object",
                                 "properties": {
@@ -16594,12 +16991,15 @@
             "content": {
               "application/problem+json": {
                 "schema": {
+                  "title": "Input Validation Problem",
                   "type": "object",
                   "allOf": [
                     {
+                      "title": "API Problem",
                       "type": "object",
                       "allOf": [
                         {
+                          "title": "Problem",
                           "description": "A Problem Details object (RFC 9457).\n\nAdditional properties specific to the problem type may be present.\n",
                           "type": "object",
                           "properties": {
@@ -16727,13 +17127,16 @@
                     "issues": {
                       "type": "array",
                       "items": {
+                        "title": "Input Validation Issue",
                         "type": "object",
                         "description": "An issue detected during input validation.\n",
                         "allOf": [
                           {
+                            "title": "API Problem",
                             "type": "object",
                             "allOf": [
                               {
+                                "title": "Problem",
                                 "description": "A Problem Details object (RFC 9457).\n\nAdditional properties specific to the problem type may be present.\n",
                                 "type": "object",
                                 "properties": {
@@ -16912,9 +17315,11 @@
             "content": {
               "application/problem+json": {
                 "schema": {
+                  "title": "API Problem",
                   "type": "object",
                   "allOf": [
                     {
+                      "title": "Problem",
                       "description": "A Problem Details object (RFC 9457).\n\nAdditional properties specific to the problem type may be present.\n",
                       "type": "object",
                       "properties": {
@@ -17096,6 +17501,7 @@
             "content": {
               "application/json": {
                 "schema": {
+                  "title": "Object Metadata",
                   "type": "object",
                   "required": [
                     "name",
@@ -17120,6 +17526,7 @@
                       "type": "object",
                       "description": "Map of field metadata keyed by field name",
                       "additionalProperties": {
+                        "title": "Field Metadata",
                         "type": "object",
                         "required": [
                           "fieldName",
@@ -17169,6 +17576,7 @@
                             "description": "If the valueType is singleSelect or multiSelect, this is a list of possible values",
                             "x-go-type-skip-optional-pointer": true,
                             "items": {
+                              "title": "Field Value",
                               "type": "object",
                               "required": [
                                 "value",
@@ -17202,9 +17610,11 @@
             "content": {
               "application/problem+json": {
                 "schema": {
+                  "title": "API Problem",
                   "type": "object",
                   "allOf": [
                     {
+                      "title": "Problem",
                       "description": "A Problem Details object (RFC 9457).\n\nAdditional properties specific to the problem type may be present.\n",
                       "type": "object",
                       "properties": {
@@ -17385,6 +17795,7 @@
             "content": {
               "application/json": {
                 "schema": {
+                  "title": "Object Metadata",
                   "type": "object",
                   "required": [
                     "name",
@@ -17409,6 +17820,7 @@
                       "type": "object",
                       "description": "Map of field metadata keyed by field name",
                       "additionalProperties": {
+                        "title": "Field Metadata",
                         "type": "object",
                         "required": [
                           "fieldName",
@@ -17458,6 +17870,7 @@
                             "description": "If the valueType is singleSelect or multiSelect, this is a list of possible values",
                             "x-go-type-skip-optional-pointer": true,
                             "items": {
+                              "title": "Field Value",
                               "type": "object",
                               "required": [
                                 "value",
@@ -17491,9 +17904,11 @@
             "content": {
               "application/problem+json": {
                 "schema": {
+                  "title": "API Problem",
                   "type": "object",
                   "allOf": [
                     {
+                      "title": "Problem",
                       "description": "A Problem Details object (RFC 9457).\n\nAdditional properties specific to the problem type may be present.\n",
                       "type": "object",
                       "properties": {
@@ -17689,6 +18104,7 @@
                     "results": {
                       "type": "array",
                       "items": {
+                        "title": "Operation",
                         "required": [
                           "projectId",
                           "integrationId",
@@ -17755,6 +18171,7 @@
                       }
                     },
                     "pagination": {
+                      "title": "Pagination Information",
                       "type": "object",
                       "required": [
                         "done"
@@ -17782,12 +18199,15 @@
             "content": {
               "application/problem+json": {
                 "schema": {
+                  "title": "Input Validation Problem",
                   "type": "object",
                   "allOf": [
                     {
+                      "title": "API Problem",
                       "type": "object",
                       "allOf": [
                         {
+                          "title": "Problem",
                           "description": "A Problem Details object (RFC 9457).\n\nAdditional properties specific to the problem type may be present.\n",
                           "type": "object",
                           "properties": {
@@ -17915,13 +18335,16 @@
                     "issues": {
                       "type": "array",
                       "items": {
+                        "title": "Input Validation Issue",
                         "type": "object",
                         "description": "An issue detected during input validation.\n",
                         "allOf": [
                           {
+                            "title": "API Problem",
                             "type": "object",
                             "allOf": [
                               {
+                                "title": "Problem",
                                 "description": "A Problem Details object (RFC 9457).\n\nAdditional properties specific to the problem type may be present.\n",
                                 "type": "object",
                                 "properties": {
@@ -18100,12 +18523,15 @@
             "content": {
               "application/problem+json": {
                 "schema": {
+                  "title": "Input Validation Problem",
                   "type": "object",
                   "allOf": [
                     {
+                      "title": "API Problem",
                       "type": "object",
                       "allOf": [
                         {
+                          "title": "Problem",
                           "description": "A Problem Details object (RFC 9457).\n\nAdditional properties specific to the problem type may be present.\n",
                           "type": "object",
                           "properties": {
@@ -18233,13 +18659,16 @@
                     "issues": {
                       "type": "array",
                       "items": {
+                        "title": "Input Validation Issue",
                         "type": "object",
                         "description": "An issue detected during input validation.\n",
                         "allOf": [
                           {
+                            "title": "API Problem",
                             "type": "object",
                             "allOf": [
                               {
+                                "title": "Problem",
                                 "description": "A Problem Details object (RFC 9457).\n\nAdditional properties specific to the problem type may be present.\n",
                                 "type": "object",
                                 "properties": {
@@ -18418,9 +18847,11 @@
             "content": {
               "application/problem+json": {
                 "schema": {
+                  "title": "API Problem",
                   "type": "object",
                   "allOf": [
                     {
+                      "title": "Problem",
                       "description": "A Problem Details object (RFC 9457).\n\nAdditional properties specific to the problem type may be present.\n",
                       "type": "object",
                       "properties": {
@@ -18580,6 +19011,7 @@
             "content": {
               "application/json": {
                 "schema": {
+                  "title": "Operation",
                   "required": [
                     "projectId",
                     "integrationId",
@@ -18652,12 +19084,15 @@
             "content": {
               "application/problem+json": {
                 "schema": {
+                  "title": "Input Validation Problem",
                   "type": "object",
                   "allOf": [
                     {
+                      "title": "API Problem",
                       "type": "object",
                       "allOf": [
                         {
+                          "title": "Problem",
                           "description": "A Problem Details object (RFC 9457).\n\nAdditional properties specific to the problem type may be present.\n",
                           "type": "object",
                           "properties": {
@@ -18785,13 +19220,16 @@
                     "issues": {
                       "type": "array",
                       "items": {
+                        "title": "Input Validation Issue",
                         "type": "object",
                         "description": "An issue detected during input validation.\n",
                         "allOf": [
                           {
+                            "title": "API Problem",
                             "type": "object",
                             "allOf": [
                               {
+                                "title": "Problem",
                                 "description": "A Problem Details object (RFC 9457).\n\nAdditional properties specific to the problem type may be present.\n",
                                 "type": "object",
                                 "properties": {
@@ -18970,12 +19408,15 @@
             "content": {
               "application/problem+json": {
                 "schema": {
+                  "title": "Input Validation Problem",
                   "type": "object",
                   "allOf": [
                     {
+                      "title": "API Problem",
                       "type": "object",
                       "allOf": [
                         {
+                          "title": "Problem",
                           "description": "A Problem Details object (RFC 9457).\n\nAdditional properties specific to the problem type may be present.\n",
                           "type": "object",
                           "properties": {
@@ -19103,13 +19544,16 @@
                     "issues": {
                       "type": "array",
                       "items": {
+                        "title": "Input Validation Issue",
                         "type": "object",
                         "description": "An issue detected during input validation.\n",
                         "allOf": [
                           {
+                            "title": "API Problem",
                             "type": "object",
                             "allOf": [
                               {
+                                "title": "Problem",
                                 "description": "A Problem Details object (RFC 9457).\n\nAdditional properties specific to the problem type may be present.\n",
                                 "type": "object",
                                 "properties": {
@@ -19288,9 +19732,11 @@
             "content": {
               "application/problem+json": {
                 "schema": {
+                  "title": "API Problem",
                   "type": "object",
                   "allOf": [
                     {
+                      "title": "Problem",
                       "description": "A Problem Details object (RFC 9457).\n\nAdditional properties specific to the problem type may be present.\n",
                       "type": "object",
                       "properties": {
@@ -19452,6 +19898,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
+                    "title": "Log",
                     "type": "object",
                     "required": [
                       "timestamp",
@@ -19502,12 +19949,15 @@
             "content": {
               "application/problem+json": {
                 "schema": {
+                  "title": "Input Validation Problem",
                   "type": "object",
                   "allOf": [
                     {
+                      "title": "API Problem",
                       "type": "object",
                       "allOf": [
                         {
+                          "title": "Problem",
                           "description": "A Problem Details object (RFC 9457).\n\nAdditional properties specific to the problem type may be present.\n",
                           "type": "object",
                           "properties": {
@@ -19635,13 +20085,16 @@
                     "issues": {
                       "type": "array",
                       "items": {
+                        "title": "Input Validation Issue",
                         "type": "object",
                         "description": "An issue detected during input validation.\n",
                         "allOf": [
                           {
+                            "title": "API Problem",
                             "type": "object",
                             "allOf": [
                               {
+                                "title": "Problem",
                                 "description": "A Problem Details object (RFC 9457).\n\nAdditional properties specific to the problem type may be present.\n",
                                 "type": "object",
                                 "properties": {
@@ -19820,12 +20273,15 @@
             "content": {
               "application/problem+json": {
                 "schema": {
+                  "title": "Input Validation Problem",
                   "type": "object",
                   "allOf": [
                     {
+                      "title": "API Problem",
                       "type": "object",
                       "allOf": [
                         {
+                          "title": "Problem",
                           "description": "A Problem Details object (RFC 9457).\n\nAdditional properties specific to the problem type may be present.\n",
                           "type": "object",
                           "properties": {
@@ -19953,13 +20409,16 @@
                     "issues": {
                       "type": "array",
                       "items": {
+                        "title": "Input Validation Issue",
                         "type": "object",
                         "description": "An issue detected during input validation.\n",
                         "allOf": [
                           {
+                            "title": "API Problem",
                             "type": "object",
                             "allOf": [
                               {
+                                "title": "Problem",
                                 "description": "A Problem Details object (RFC 9457).\n\nAdditional properties specific to the problem type may be present.\n",
                                 "type": "object",
                                 "properties": {
@@ -20138,9 +20597,11 @@
             "content": {
               "application/problem+json": {
                 "schema": {
+                  "title": "API Problem",
                   "type": "object",
                   "allOf": [
                     {
+                      "title": "Problem",
                       "description": "A Problem Details object (RFC 9457).\n\nAdditional properties specific to the problem type may be present.\n",
                       "type": "object",
                       "properties": {
@@ -20282,8 +20743,10 @@
             "content": {
               "application/json": {
                 "schema": {
+                  "title": "Catalog Type",
                   "type": "object",
                   "additionalProperties": {
+                    "title": "Provider Info",
                     "type": "object",
                     "required": [
                       "name",
@@ -20297,6 +20760,7 @@
                         "type": "string"
                       },
                       "authType": {
+                        "title": "Auth Type",
                         "description": "The type of authentication required by the provider.",
                         "type": "string",
                         "enum": [
@@ -20318,6 +20782,7 @@
                         }
                       },
                       "oauth2Opts": {
+                        "title": "OAuth2 Options",
                         "type": "object",
                         "description": "Configuration for OAuth2.0. Must be provided if authType is oauth2.",
                         "required": [
@@ -20373,6 +20838,7 @@
                             "x-go-type-skip-optional-pointer": true
                           },
                           "tokenMetadataFields": {
+                            "title": "Token Metadata Fields",
                             "type": "object",
                             "description": "Fields to be used to extract token metadata from the token response.",
                             "properties": {
@@ -20413,6 +20879,7 @@
                         }
                       },
                       "apiKeyOpts": {
+                        "title": "API Key Options",
                         "type": "object",
                         "description": "Configuration for API key. Must be provided if authType is apiKey.",
                         "required": [
@@ -20431,6 +20898,7 @@
                             }
                           },
                           "query": {
+                            "title": "API Key Query Options",
                             "type": "object",
                             "description": "Configuration for API key in query parameter. Must be provided if type is in-query.",
                             "required": [
@@ -20446,6 +20914,7 @@
                             }
                           },
                           "header": {
+                            "title": "API Key Header Options",
                             "type": "object",
                             "description": "Configuration for API key in header. Must be provided if type is in-header.",
                             "required": [
@@ -20475,6 +20944,7 @@
                         }
                       },
                       "basicOpts": {
+                        "title": "Basic Auth Options",
                         "type": "object",
                         "description": "Configuration for Basic Auth. Optional.",
                         "properties": {
@@ -20485,6 +20955,7 @@
                             "x-go-type-skip-optional-pointer": true
                           },
                           "apiKeyAsBasicOpts": {
+                            "title": "API Key as Basic Options",
                             "type": "object",
                             "description": "when this object is present, it means that this provider uses Basic Auth to actually collect an API key",
                             "properties": {
@@ -20519,6 +20990,7 @@
                         }
                       },
                       "support": {
+                        "title": "Support",
                         "type": "object",
                         "description": "The supported features for the provider.",
                         "x-oapi-codegen-extra-tags": {
@@ -20533,6 +21005,7 @@
                         ],
                         "properties": {
                           "bulkWrite": {
+                            "title": "Bulk Write Support",
                             "type": "object",
                             "x-oapi-codegen-extra-tags": {
                               "validate": "required"
@@ -20571,6 +21044,7 @@
                             "type": "boolean"
                           },
                           "subscribeSupport": {
+                            "title": "Subscribe Support",
                             "type": "object",
                             "properties": {
                               "create": {
@@ -20590,6 +21064,7 @@
                         }
                       },
                       "providerOpts": {
+                        "title": "Provider Options",
                         "description": "Additional provider-specific metadata.",
                         "type": "object",
                         "additionalProperties": {
@@ -20609,8 +21084,10 @@
                         "x-go-type-skip-optional-pointer": true
                       },
                       "media": {
+                        "title": "Media",
                         "properties": {
                           "regular": {
+                            "title": "Media Type Regular",
                             "type": "object",
                             "description": "Media for light/regular mode.",
                             "properties": {
@@ -20629,6 +21106,7 @@
                             }
                           },
                           "darkMode": {
+                            "title": "Media Type Dark Mode",
                             "type": "object",
                             "description": "Media to be used in dark mode.",
                             "properties": {
@@ -20649,12 +21127,14 @@
                         }
                       },
                       "labels": {
+                        "title": "Labels",
                         "type": "object",
                         "additionalProperties": {
                           "type": "string"
                         }
                       },
                       "subscribeOpts": {
+                        "title": "Subscribe Options",
                         "type": "object",
                         "required": [
                           "subscriptionScope",
@@ -20699,9 +21179,11 @@
             "content": {
               "application/problem+json": {
                 "schema": {
+                  "title": "API Problem",
                   "type": "object",
                   "allOf": [
                     {
+                      "title": "Problem",
                       "description": "A Problem Details object (RFC 9457).\n\nAdditional properties specific to the problem type may be present.\n",
                       "type": "object",
                       "properties": {
@@ -20853,6 +21335,7 @@
             "content": {
               "application/json": {
                 "schema": {
+                  "title": "Provider Info",
                   "type": "object",
                   "required": [
                     "name",
@@ -20866,6 +21349,7 @@
                       "type": "string"
                     },
                     "authType": {
+                      "title": "Auth Type",
                       "description": "The type of authentication required by the provider.",
                       "type": "string",
                       "enum": [
@@ -20887,6 +21371,7 @@
                       }
                     },
                     "oauth2Opts": {
+                      "title": "OAuth2 Options",
                       "type": "object",
                       "description": "Configuration for OAuth2.0. Must be provided if authType is oauth2.",
                       "required": [
@@ -20942,6 +21427,7 @@
                           "x-go-type-skip-optional-pointer": true
                         },
                         "tokenMetadataFields": {
+                          "title": "Token Metadata Fields",
                           "type": "object",
                           "description": "Fields to be used to extract token metadata from the token response.",
                           "properties": {
@@ -20982,6 +21468,7 @@
                       }
                     },
                     "apiKeyOpts": {
+                      "title": "API Key Options",
                       "type": "object",
                       "description": "Configuration for API key. Must be provided if authType is apiKey.",
                       "required": [
@@ -21000,6 +21487,7 @@
                           }
                         },
                         "query": {
+                          "title": "API Key Query Options",
                           "type": "object",
                           "description": "Configuration for API key in query parameter. Must be provided if type is in-query.",
                           "required": [
@@ -21015,6 +21503,7 @@
                           }
                         },
                         "header": {
+                          "title": "API Key Header Options",
                           "type": "object",
                           "description": "Configuration for API key in header. Must be provided if type is in-header.",
                           "required": [
@@ -21044,6 +21533,7 @@
                       }
                     },
                     "basicOpts": {
+                      "title": "Basic Auth Options",
                       "type": "object",
                       "description": "Configuration for Basic Auth. Optional.",
                       "properties": {
@@ -21054,6 +21544,7 @@
                           "x-go-type-skip-optional-pointer": true
                         },
                         "apiKeyAsBasicOpts": {
+                          "title": "API Key as Basic Options",
                           "type": "object",
                           "description": "when this object is present, it means that this provider uses Basic Auth to actually collect an API key",
                           "properties": {
@@ -21088,6 +21579,7 @@
                       }
                     },
                     "support": {
+                      "title": "Support",
                       "type": "object",
                       "description": "The supported features for the provider.",
                       "x-oapi-codegen-extra-tags": {
@@ -21102,6 +21594,7 @@
                       ],
                       "properties": {
                         "bulkWrite": {
+                          "title": "Bulk Write Support",
                           "type": "object",
                           "x-oapi-codegen-extra-tags": {
                             "validate": "required"
@@ -21140,6 +21633,7 @@
                           "type": "boolean"
                         },
                         "subscribeSupport": {
+                          "title": "Subscribe Support",
                           "type": "object",
                           "properties": {
                             "create": {
@@ -21159,6 +21653,7 @@
                       }
                     },
                     "providerOpts": {
+                      "title": "Provider Options",
                       "description": "Additional provider-specific metadata.",
                       "type": "object",
                       "additionalProperties": {
@@ -21178,8 +21673,10 @@
                       "x-go-type-skip-optional-pointer": true
                     },
                     "media": {
+                      "title": "Media",
                       "properties": {
                         "regular": {
+                          "title": "Media Type Regular",
                           "type": "object",
                           "description": "Media for light/regular mode.",
                           "properties": {
@@ -21198,6 +21695,7 @@
                           }
                         },
                         "darkMode": {
+                          "title": "Media Type Dark Mode",
                           "type": "object",
                           "description": "Media to be used in dark mode.",
                           "properties": {
@@ -21218,12 +21716,14 @@
                       }
                     },
                     "labels": {
+                      "title": "Labels",
                       "type": "object",
                       "additionalProperties": {
                         "type": "string"
                       }
                     },
                     "subscribeOpts": {
+                      "title": "Subscribe Options",
                       "type": "object",
                       "required": [
                         "subscriptionScope",
@@ -21267,9 +21767,11 @@
             "content": {
               "application/problem+json": {
                 "schema": {
+                  "title": "API Problem",
                   "type": "object",
                   "allOf": [
                     {
+                      "title": "Problem",
                       "description": "A Problem Details object (RFC 9457).\n\nAdditional properties specific to the problem type may be present.\n",
                       "type": "object",
                       "properties": {
@@ -21432,6 +21934,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
+                    "title": "API Key",
                     "type": "object",
                     "required": [
                       "key",
@@ -21451,6 +21954,7 @@
                         "example": "MailMonkey API Key"
                       },
                       "scopes": {
+                        "title": "API Key Scopes",
                         "type": "array",
                         "description": "The scopes for the API key.",
                         "items": {
@@ -21482,12 +21986,15 @@
             "content": {
               "application/problem+json": {
                 "schema": {
+                  "title": "Input Validation Problem",
                   "type": "object",
                   "allOf": [
                     {
+                      "title": "API Problem",
                       "type": "object",
                       "allOf": [
                         {
+                          "title": "Problem",
                           "description": "A Problem Details object (RFC 9457).\n\nAdditional properties specific to the problem type may be present.\n",
                           "type": "object",
                           "properties": {
@@ -21615,13 +22122,16 @@
                     "issues": {
                       "type": "array",
                       "items": {
+                        "title": "Input Validation Issue",
                         "type": "object",
                         "description": "An issue detected during input validation.\n",
                         "allOf": [
                           {
+                            "title": "API Problem",
                             "type": "object",
                             "allOf": [
                               {
+                                "title": "Problem",
                                 "description": "A Problem Details object (RFC 9457).\n\nAdditional properties specific to the problem type may be present.\n",
                                 "type": "object",
                                 "properties": {
@@ -21800,9 +22310,11 @@
             "content": {
               "application/problem+json": {
                 "schema": {
+                  "title": "API Problem",
                   "type": "object",
                   "allOf": [
                     {
+                      "title": "Problem",
                       "description": "A Problem Details object (RFC 9457).\n\nAdditional properties specific to the problem type may be present.\n",
                       "type": "object",
                       "properties": {
@@ -21951,6 +22463,7 @@
           "content": {
             "application/json": {
               "schema": {
+                "title": "API Key Request",
                 "type": "object",
                 "required": [
                   "label"
@@ -21962,6 +22475,7 @@
                     "example": "MailMonkey API Key"
                   },
                   "scopes": {
+                    "title": "API Key Scopes",
                     "type": "array",
                     "description": "The scopes for the API key.",
                     "items": {
@@ -21984,6 +22498,7 @@
             "content": {
               "application/json": {
                 "schema": {
+                  "title": "API Key",
                   "type": "object",
                   "required": [
                     "key",
@@ -22003,6 +22518,7 @@
                       "example": "MailMonkey API Key"
                     },
                     "scopes": {
+                      "title": "API Key Scopes",
                       "type": "array",
                       "description": "The scopes for the API key.",
                       "items": {
@@ -22033,12 +22549,15 @@
             "content": {
               "application/problem+json": {
                 "schema": {
+                  "title": "Input Validation Problem",
                   "type": "object",
                   "allOf": [
                     {
+                      "title": "API Problem",
                       "type": "object",
                       "allOf": [
                         {
+                          "title": "Problem",
                           "description": "A Problem Details object (RFC 9457).\n\nAdditional properties specific to the problem type may be present.\n",
                           "type": "object",
                           "properties": {
@@ -22166,13 +22685,16 @@
                     "issues": {
                       "type": "array",
                       "items": {
+                        "title": "Input Validation Issue",
                         "type": "object",
                         "description": "An issue detected during input validation.\n",
                         "allOf": [
                           {
+                            "title": "API Problem",
                             "type": "object",
                             "allOf": [
                               {
+                                "title": "Problem",
                                 "description": "A Problem Details object (RFC 9457).\n\nAdditional properties specific to the problem type may be present.\n",
                                 "type": "object",
                                 "properties": {
@@ -22351,9 +22873,11 @@
             "content": {
               "application/problem+json": {
                 "schema": {
+                  "title": "API Problem",
                   "type": "object",
                   "allOf": [
                     {
+                      "title": "Problem",
                       "description": "A Problem Details object (RFC 9457).\n\nAdditional properties specific to the problem type may be present.\n",
                       "type": "object",
                       "properties": {
@@ -22515,6 +23039,7 @@
             "content": {
               "application/json": {
                 "schema": {
+                  "title": "API Key",
                   "type": "object",
                   "required": [
                     "key",
@@ -22534,6 +23059,7 @@
                       "example": "MailMonkey API Key"
                     },
                     "scopes": {
+                      "title": "API Key Scopes",
                       "type": "array",
                       "description": "The scopes for the API key.",
                       "items": {
@@ -22564,12 +23090,15 @@
             "content": {
               "application/problem+json": {
                 "schema": {
+                  "title": "Input Validation Problem",
                   "type": "object",
                   "allOf": [
                     {
+                      "title": "API Problem",
                       "type": "object",
                       "allOf": [
                         {
+                          "title": "Problem",
                           "description": "A Problem Details object (RFC 9457).\n\nAdditional properties specific to the problem type may be present.\n",
                           "type": "object",
                           "properties": {
@@ -22697,13 +23226,16 @@
                     "issues": {
                       "type": "array",
                       "items": {
+                        "title": "Input Validation Issue",
                         "type": "object",
                         "description": "An issue detected during input validation.\n",
                         "allOf": [
                           {
+                            "title": "API Problem",
                             "type": "object",
                             "allOf": [
                               {
+                                "title": "Problem",
                                 "description": "A Problem Details object (RFC 9457).\n\nAdditional properties specific to the problem type may be present.\n",
                                 "type": "object",
                                 "properties": {
@@ -22882,9 +23414,11 @@
             "content": {
               "application/problem+json": {
                 "schema": {
+                  "title": "API Problem",
                   "type": "object",
                   "allOf": [
                     {
+                      "title": "Problem",
                       "description": "A Problem Details object (RFC 9457).\n\nAdditional properties specific to the problem type may be present.\n",
                       "type": "object",
                       "properties": {
@@ -23046,12 +23580,15 @@
             "content": {
               "application/problem+json": {
                 "schema": {
+                  "title": "Input Validation Problem",
                   "type": "object",
                   "allOf": [
                     {
+                      "title": "API Problem",
                       "type": "object",
                       "allOf": [
                         {
+                          "title": "Problem",
                           "description": "A Problem Details object (RFC 9457).\n\nAdditional properties specific to the problem type may be present.\n",
                           "type": "object",
                           "properties": {
@@ -23179,13 +23716,16 @@
                     "issues": {
                       "type": "array",
                       "items": {
+                        "title": "Input Validation Issue",
                         "type": "object",
                         "description": "An issue detected during input validation.\n",
                         "allOf": [
                           {
+                            "title": "API Problem",
                             "type": "object",
                             "allOf": [
                               {
+                                "title": "Problem",
                                 "description": "A Problem Details object (RFC 9457).\n\nAdditional properties specific to the problem type may be present.\n",
                                 "type": "object",
                                 "properties": {
@@ -23390,6 +23930,7 @@
           "content": {
             "application/json": {
               "schema": {
+                "title": "Patch API Key Request",
                 "type": "object",
                 "required": [
                   "updateMask",
@@ -23423,6 +23964,7 @@
                         "example": true
                       },
                       "scopes": {
+                        "title": "API Key Scopes",
                         "type": "array",
                         "description": "The scopes for the API key.",
                         "items": {
@@ -23447,6 +23989,7 @@
             "content": {
               "application/json": {
                 "schema": {
+                  "title": "API Key",
                   "type": "object",
                   "required": [
                     "key",
@@ -23466,6 +24009,7 @@
                       "example": "MailMonkey API Key"
                     },
                     "scopes": {
+                      "title": "API Key Scopes",
                       "type": "array",
                       "description": "The scopes for the API key.",
                       "items": {
@@ -23496,12 +24040,15 @@
             "content": {
               "application/problem+json": {
                 "schema": {
+                  "title": "Input Validation Problem",
                   "type": "object",
                   "allOf": [
                     {
+                      "title": "API Problem",
                       "type": "object",
                       "allOf": [
                         {
+                          "title": "Problem",
                           "description": "A Problem Details object (RFC 9457).\n\nAdditional properties specific to the problem type may be present.\n",
                           "type": "object",
                           "properties": {
@@ -23629,13 +24176,16 @@
                     "issues": {
                       "type": "array",
                       "items": {
+                        "title": "Input Validation Issue",
                         "type": "object",
                         "description": "An issue detected during input validation.\n",
                         "allOf": [
                           {
+                            "title": "API Problem",
                             "type": "object",
                             "allOf": [
                               {
+                                "title": "Problem",
                                 "description": "A Problem Details object (RFC 9457).\n\nAdditional properties specific to the problem type may be present.\n",
                                 "type": "object",
                                 "properties": {
@@ -23814,12 +24364,15 @@
             "content": {
               "application/problem+json": {
                 "schema": {
+                  "title": "Input Validation Problem",
                   "type": "object",
                   "allOf": [
                     {
+                      "title": "API Problem",
                       "type": "object",
                       "allOf": [
                         {
+                          "title": "Problem",
                           "description": "A Problem Details object (RFC 9457).\n\nAdditional properties specific to the problem type may be present.\n",
                           "type": "object",
                           "properties": {
@@ -23947,13 +24500,16 @@
                     "issues": {
                       "type": "array",
                       "items": {
+                        "title": "Input Validation Issue",
                         "type": "object",
                         "description": "An issue detected during input validation.\n",
                         "allOf": [
                           {
+                            "title": "API Problem",
                             "type": "object",
                             "allOf": [
                               {
+                                "title": "Problem",
                                 "description": "A Problem Details object (RFC 9457).\n\nAdditional properties specific to the problem type may be present.\n",
                                 "type": "object",
                                 "properties": {
@@ -24132,12 +24688,15 @@
             "content": {
               "application/problem+json": {
                 "schema": {
+                  "title": "Input Validation Problem",
                   "type": "object",
                   "allOf": [
                     {
+                      "title": "API Problem",
                       "type": "object",
                       "allOf": [
                         {
+                          "title": "Problem",
                           "description": "A Problem Details object (RFC 9457).\n\nAdditional properties specific to the problem type may be present.\n",
                           "type": "object",
                           "properties": {
@@ -24265,13 +24824,16 @@
                     "issues": {
                       "type": "array",
                       "items": {
+                        "title": "Input Validation Issue",
                         "type": "object",
                         "description": "An issue detected during input validation.\n",
                         "allOf": [
                           {
+                            "title": "API Problem",
                             "type": "object",
                             "allOf": [
                               {
+                                "title": "Problem",
                                 "description": "A Problem Details object (RFC 9457).\n\nAdditional properties specific to the problem type may be present.\n",
                                 "type": "object",
                                 "properties": {
@@ -24450,9 +25012,11 @@
             "content": {
               "application/problem+json": {
                 "schema": {
+                  "title": "API Problem",
                   "type": "object",
                   "allOf": [
                     {
+                      "title": "Problem",
                       "description": "A Problem Details object (RFC 9457).\n\nAdditional properties specific to the problem type may be present.\n",
                       "type": "object",
                       "properties": {
@@ -24630,6 +25194,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
+                    "title": "Connection",
                     "required": [
                       "id",
                       "createTime",
@@ -24658,6 +25223,7 @@
                         "example": "salesforce"
                       },
                       "providerApp": {
+                        "title": "Provider App",
                         "required": [
                           "clientId",
                           "createTime",
@@ -24717,6 +25283,7 @@
                         }
                       },
                       "group": {
+                        "title": "Group",
                         "required": [
                           "createTime",
                           "groupName",
@@ -24755,6 +25322,7 @@
                         }
                       },
                       "consumer": {
+                        "title": "Consumer",
                         "required": [
                           "consumerName",
                           "consumerRef",
@@ -24839,6 +25407,7 @@
                         ]
                       },
                       "oauth2AuthorizationCode": {
+                        "title": "OAuth2 AuthorizationCode Token",
                         "type": "object",
                         "properties": {
                           "accessToken": {
@@ -24890,12 +25459,15 @@
             "content": {
               "application/problem+json": {
                 "schema": {
+                  "title": "Input Validation Problem",
                   "type": "object",
                   "allOf": [
                     {
+                      "title": "API Problem",
                       "type": "object",
                       "allOf": [
                         {
+                          "title": "Problem",
                           "description": "A Problem Details object (RFC 9457).\n\nAdditional properties specific to the problem type may be present.\n",
                           "type": "object",
                           "properties": {
@@ -25023,13 +25595,16 @@
                     "issues": {
                       "type": "array",
                       "items": {
+                        "title": "Input Validation Issue",
                         "type": "object",
                         "description": "An issue detected during input validation.\n",
                         "allOf": [
                           {
+                            "title": "API Problem",
                             "type": "object",
                             "allOf": [
                               {
+                                "title": "Problem",
                                 "description": "A Problem Details object (RFC 9457).\n\nAdditional properties specific to the problem type may be present.\n",
                                 "type": "object",
                                 "properties": {
@@ -25208,9 +25783,11 @@
             "content": {
               "application/problem+json": {
                 "schema": {
+                  "title": "API Problem",
                   "type": "object",
                   "allOf": [
                     {
+                      "title": "Problem",
                       "description": "A Problem Details object (RFC 9457).\n\nAdditional properties specific to the problem type may be present.\n",
                       "type": "object",
                       "properties": {
@@ -25472,6 +26049,7 @@
                     }
                   },
                   "oauth2AuthorizationCode": {
+                    "title": "OAuth2 Authorization Code",
                     "type": "object",
                     "properties": {
                       "accessToken": {
@@ -25534,6 +26112,7 @@
             "content": {
               "application/json": {
                 "schema": {
+                  "title": "Connection",
                   "required": [
                     "id",
                     "createTime",
@@ -25562,6 +26141,7 @@
                       "example": "salesforce"
                     },
                     "providerApp": {
+                      "title": "Provider App",
                       "required": [
                         "clientId",
                         "createTime",
@@ -25621,6 +26201,7 @@
                       }
                     },
                     "group": {
+                      "title": "Group",
                       "required": [
                         "createTime",
                         "groupName",
@@ -25659,6 +26240,7 @@
                       }
                     },
                     "consumer": {
+                      "title": "Consumer",
                       "required": [
                         "consumerName",
                         "consumerRef",
@@ -25743,6 +26325,7 @@
                       ]
                     },
                     "oauth2AuthorizationCode": {
+                      "title": "OAuth2 AuthorizationCode Token",
                       "type": "object",
                       "properties": {
                         "accessToken": {
@@ -25793,12 +26376,15 @@
             "content": {
               "application/problem+json": {
                 "schema": {
+                  "title": "Input Validation Problem",
                   "type": "object",
                   "allOf": [
                     {
+                      "title": "API Problem",
                       "type": "object",
                       "allOf": [
                         {
+                          "title": "Problem",
                           "description": "A Problem Details object (RFC 9457).\n\nAdditional properties specific to the problem type may be present.\n",
                           "type": "object",
                           "properties": {
@@ -25926,13 +26512,16 @@
                     "issues": {
                       "type": "array",
                       "items": {
+                        "title": "Input Validation Issue",
                         "type": "object",
                         "description": "An issue detected during input validation.\n",
                         "allOf": [
                           {
+                            "title": "API Problem",
                             "type": "object",
                             "allOf": [
                               {
+                                "title": "Problem",
                                 "description": "A Problem Details object (RFC 9457).\n\nAdditional properties specific to the problem type may be present.\n",
                                 "type": "object",
                                 "properties": {
@@ -26111,12 +26700,15 @@
             "content": {
               "application/problem+json": {
                 "schema": {
+                  "title": "Input Validation Problem",
                   "type": "object",
                   "allOf": [
                     {
+                      "title": "API Problem",
                       "type": "object",
                       "allOf": [
                         {
+                          "title": "Problem",
                           "description": "A Problem Details object (RFC 9457).\n\nAdditional properties specific to the problem type may be present.\n",
                           "type": "object",
                           "properties": {
@@ -26244,13 +26836,16 @@
                     "issues": {
                       "type": "array",
                       "items": {
+                        "title": "Input Validation Issue",
                         "type": "object",
                         "description": "An issue detected during input validation.\n",
                         "allOf": [
                           {
+                            "title": "API Problem",
                             "type": "object",
                             "allOf": [
                               {
+                                "title": "Problem",
                                 "description": "A Problem Details object (RFC 9457).\n\nAdditional properties specific to the problem type may be present.\n",
                                 "type": "object",
                                 "properties": {
@@ -26429,9 +27024,11 @@
             "content": {
               "application/problem+json": {
                 "schema": {
+                  "title": "API Problem",
                   "type": "object",
                   "allOf": [
                     {
+                      "title": "Problem",
                       "description": "A Problem Details object (RFC 9457).\n\nAdditional properties specific to the problem type may be present.\n",
                       "type": "object",
                       "properties": {
@@ -26620,6 +27217,7 @@
             "content": {
               "application/json": {
                 "schema": {
+                  "title": "Connection",
                   "required": [
                     "id",
                     "createTime",
@@ -26648,6 +27246,7 @@
                       "example": "salesforce"
                     },
                     "providerApp": {
+                      "title": "Provider App",
                       "required": [
                         "clientId",
                         "createTime",
@@ -26707,6 +27306,7 @@
                       }
                     },
                     "group": {
+                      "title": "Group",
                       "required": [
                         "createTime",
                         "groupName",
@@ -26745,6 +27345,7 @@
                       }
                     },
                     "consumer": {
+                      "title": "Consumer",
                       "required": [
                         "consumerName",
                         "consumerRef",
@@ -26829,6 +27430,7 @@
                       ]
                     },
                     "oauth2AuthorizationCode": {
+                      "title": "OAuth2 AuthorizationCode Token",
                       "type": "object",
                       "properties": {
                         "accessToken": {
@@ -26879,12 +27481,15 @@
             "content": {
               "application/problem+json": {
                 "schema": {
+                  "title": "Input Validation Problem",
                   "type": "object",
                   "allOf": [
                     {
+                      "title": "API Problem",
                       "type": "object",
                       "allOf": [
                         {
+                          "title": "Problem",
                           "description": "A Problem Details object (RFC 9457).\n\nAdditional properties specific to the problem type may be present.\n",
                           "type": "object",
                           "properties": {
@@ -27012,13 +27617,16 @@
                     "issues": {
                       "type": "array",
                       "items": {
+                        "title": "Input Validation Issue",
                         "type": "object",
                         "description": "An issue detected during input validation.\n",
                         "allOf": [
                           {
+                            "title": "API Problem",
                             "type": "object",
                             "allOf": [
                               {
+                                "title": "Problem",
                                 "description": "A Problem Details object (RFC 9457).\n\nAdditional properties specific to the problem type may be present.\n",
                                 "type": "object",
                                 "properties": {
@@ -27197,9 +27805,11 @@
             "content": {
               "application/problem+json": {
                 "schema": {
+                  "title": "API Problem",
                   "type": "object",
                   "allOf": [
                     {
+                      "title": "Problem",
                       "description": "A Problem Details object (RFC 9457).\n\nAdditional properties specific to the problem type may be present.\n",
                       "type": "object",
                       "properties": {
@@ -27360,9 +27970,11 @@
             "content": {
               "application/problem+json": {
                 "schema": {
+                  "title": "API Problem",
                   "type": "object",
                   "allOf": [
                     {
+                      "title": "Problem",
                       "description": "A Problem Details object (RFC 9457).\n\nAdditional properties specific to the problem type may be present.\n",
                       "type": "object",
                       "properties": {
@@ -27544,12 +28156,15 @@
             "content": {
               "application/problem+json": {
                 "schema": {
+                  "title": "Input Validation Problem",
                   "type": "object",
                   "allOf": [
                     {
+                      "title": "API Problem",
                       "type": "object",
                       "allOf": [
                         {
+                          "title": "Problem",
                           "description": "A Problem Details object (RFC 9457).\n\nAdditional properties specific to the problem type may be present.\n",
                           "type": "object",
                           "properties": {
@@ -27677,13 +28292,16 @@
                     "issues": {
                       "type": "array",
                       "items": {
+                        "title": "Input Validation Issue",
                         "type": "object",
                         "description": "An issue detected during input validation.\n",
                         "allOf": [
                           {
+                            "title": "API Problem",
                             "type": "object",
                             "allOf": [
                               {
+                                "title": "Problem",
                                 "description": "A Problem Details object (RFC 9457).\n\nAdditional properties specific to the problem type may be present.\n",
                                 "type": "object",
                                 "properties": {
@@ -27862,9 +28480,11 @@
             "content": {
               "application/problem+json": {
                 "schema": {
+                  "title": "API Problem",
                   "type": "object",
                   "allOf": [
                     {
+                      "title": "Problem",
                       "description": "A Problem Details object (RFC 9457).\n\nAdditional properties specific to the problem type may be present.\n",
                       "type": "object",
                       "properties": {
@@ -28047,12 +28667,15 @@
             "content": {
               "application/problem+json": {
                 "schema": {
+                  "title": "Input Validation Problem",
                   "type": "object",
                   "allOf": [
                     {
+                      "title": "API Problem",
                       "type": "object",
                       "allOf": [
                         {
+                          "title": "Problem",
                           "description": "A Problem Details object (RFC 9457).\n\nAdditional properties specific to the problem type may be present.\n",
                           "type": "object",
                           "properties": {
@@ -28180,13 +28803,16 @@
                     "issues": {
                       "type": "array",
                       "items": {
+                        "title": "Input Validation Issue",
                         "type": "object",
                         "description": "An issue detected during input validation.\n",
                         "allOf": [
                           {
+                            "title": "API Problem",
                             "type": "object",
                             "allOf": [
                               {
+                                "title": "Problem",
                                 "description": "A Problem Details object (RFC 9457).\n\nAdditional properties specific to the problem type may be present.\n",
                                 "type": "object",
                                 "properties": {
@@ -28365,9 +28991,11 @@
             "content": {
               "application/problem+json": {
                 "schema": {
+                  "title": "API Problem",
                   "type": "object",
                   "allOf": [
                     {
+                      "title": "Problem",
                       "description": "A Problem Details object (RFC 9457).\n\nAdditional properties specific to the problem type may be present.\n",
                       "type": "object",
                       "properties": {
@@ -28545,6 +29173,7 @@
                         "example": "https://webhooks.mailmonkey.com/salesforce-lead-converted"
                       },
                       "headers": {
+                        "title": "Webhook Headers",
                         "type": "object",
                         "nullable": true,
                         "description": "Additional headers to add when Ampersand sends a webhook message",
@@ -28569,6 +29198,7 @@
             "content": {
               "application/json": {
                 "schema": {
+                  "title": "Destination",
                   "required": [
                     "id",
                     "name",
@@ -28601,6 +29231,7 @@
                           "example": "https://webhooks.mailmonkey.com/salesforce-lead-converted"
                         },
                         "headers": {
+                          "title": "Webhook Headers",
                           "type": "object",
                           "nullable": true,
                           "description": "Additional headers to add when Ampersand sends a webhook message",
@@ -28634,12 +29265,15 @@
             "content": {
               "application/problem+json": {
                 "schema": {
+                  "title": "Input Validation Problem",
                   "type": "object",
                   "allOf": [
                     {
+                      "title": "API Problem",
                       "type": "object",
                       "allOf": [
                         {
+                          "title": "Problem",
                           "description": "A Problem Details object (RFC 9457).\n\nAdditional properties specific to the problem type may be present.\n",
                           "type": "object",
                           "properties": {
@@ -28767,13 +29401,16 @@
                     "issues": {
                       "type": "array",
                       "items": {
+                        "title": "Input Validation Issue",
                         "type": "object",
                         "description": "An issue detected during input validation.\n",
                         "allOf": [
                           {
+                            "title": "API Problem",
                             "type": "object",
                             "allOf": [
                               {
+                                "title": "Problem",
                                 "description": "A Problem Details object (RFC 9457).\n\nAdditional properties specific to the problem type may be present.\n",
                                 "type": "object",
                                 "properties": {
@@ -28952,12 +29589,15 @@
             "content": {
               "application/problem+json": {
                 "schema": {
+                  "title": "Input Validation Problem",
                   "type": "object",
                   "allOf": [
                     {
+                      "title": "API Problem",
                       "type": "object",
                       "allOf": [
                         {
+                          "title": "Problem",
                           "description": "A Problem Details object (RFC 9457).\n\nAdditional properties specific to the problem type may be present.\n",
                           "type": "object",
                           "properties": {
@@ -29085,13 +29725,16 @@
                     "issues": {
                       "type": "array",
                       "items": {
+                        "title": "Input Validation Issue",
                         "type": "object",
                         "description": "An issue detected during input validation.\n",
                         "allOf": [
                           {
+                            "title": "API Problem",
                             "type": "object",
                             "allOf": [
                               {
+                                "title": "Problem",
                                 "description": "A Problem Details object (RFC 9457).\n\nAdditional properties specific to the problem type may be present.\n",
                                 "type": "object",
                                 "properties": {
@@ -29270,9 +29913,11 @@
             "content": {
               "application/problem+json": {
                 "schema": {
+                  "title": "API Problem",
                   "type": "object",
                   "allOf": [
                     {
+                      "title": "Problem",
                       "description": "A Problem Details object (RFC 9457).\n\nAdditional properties specific to the problem type may be present.\n",
                       "type": "object",
                       "properties": {
@@ -29425,6 +30070,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
+                    "title": "Destination",
                     "required": [
                       "id",
                       "name",
@@ -29457,6 +30103,7 @@
                             "example": "https://webhooks.mailmonkey.com/salesforce-lead-converted"
                           },
                           "headers": {
+                            "title": "Webhook Headers",
                             "type": "object",
                             "nullable": true,
                             "description": "Additional headers to add when Ampersand sends a webhook message",
@@ -29491,9 +30138,11 @@
             "content": {
               "application/problem+json": {
                 "schema": {
+                  "title": "API Problem",
                   "type": "object",
                   "allOf": [
                     {
+                      "title": "Problem",
                       "description": "A Problem Details object (RFC 9457).\n\nAdditional properties specific to the problem type may be present.\n",
                       "type": "object",
                       "properties": {
@@ -29654,6 +30303,7 @@
             "content": {
               "application/json": {
                 "schema": {
+                  "title": "Destination",
                   "required": [
                     "id",
                     "name",
@@ -29686,6 +30336,7 @@
                           "example": "https://webhooks.mailmonkey.com/salesforce-lead-converted"
                         },
                         "headers": {
+                          "title": "Webhook Headers",
                           "type": "object",
                           "nullable": true,
                           "description": "Additional headers to add when Ampersand sends a webhook message",
@@ -29719,12 +30370,15 @@
             "content": {
               "application/problem+json": {
                 "schema": {
+                  "title": "Input Validation Problem",
                   "type": "object",
                   "allOf": [
                     {
+                      "title": "API Problem",
                       "type": "object",
                       "allOf": [
                         {
+                          "title": "Problem",
                           "description": "A Problem Details object (RFC 9457).\n\nAdditional properties specific to the problem type may be present.\n",
                           "type": "object",
                           "properties": {
@@ -29852,13 +30506,16 @@
                     "issues": {
                       "type": "array",
                       "items": {
+                        "title": "Input Validation Issue",
                         "type": "object",
                         "description": "An issue detected during input validation.\n",
                         "allOf": [
                           {
+                            "title": "API Problem",
                             "type": "object",
                             "allOf": [
                               {
+                                "title": "Problem",
                                 "description": "A Problem Details object (RFC 9457).\n\nAdditional properties specific to the problem type may be present.\n",
                                 "type": "object",
                                 "properties": {
@@ -30037,9 +30694,11 @@
             "content": {
               "application/problem+json": {
                 "schema": {
+                  "title": "API Problem",
                   "type": "object",
                   "allOf": [
                     {
+                      "title": "Problem",
                       "description": "A Problem Details object (RFC 9457).\n\nAdditional properties specific to the problem type may be present.\n",
                       "type": "object",
                       "properties": {
@@ -30232,6 +30891,7 @@
                             "example": "https://webhooks.mailmonkey.com/salesforce-lead-converted"
                           },
                           "headers": {
+                            "title": "Webhook Headers",
                             "type": "object",
                             "nullable": true,
                             "description": "Additional headers to add when Ampersand sends a webhook message",
@@ -30258,6 +30918,7 @@
             "content": {
               "application/json": {
                 "schema": {
+                  "title": "Destination",
                   "required": [
                     "id",
                     "name",
@@ -30290,6 +30951,7 @@
                           "example": "https://webhooks.mailmonkey.com/salesforce-lead-converted"
                         },
                         "headers": {
+                          "title": "Webhook Headers",
                           "type": "object",
                           "nullable": true,
                           "description": "Additional headers to add when Ampersand sends a webhook message",
@@ -30323,12 +30985,15 @@
             "content": {
               "application/problem+json": {
                 "schema": {
+                  "title": "Input Validation Problem",
                   "type": "object",
                   "allOf": [
                     {
+                      "title": "API Problem",
                       "type": "object",
                       "allOf": [
                         {
+                          "title": "Problem",
                           "description": "A Problem Details object (RFC 9457).\n\nAdditional properties specific to the problem type may be present.\n",
                           "type": "object",
                           "properties": {
@@ -30456,13 +31121,16 @@
                     "issues": {
                       "type": "array",
                       "items": {
+                        "title": "Input Validation Issue",
                         "type": "object",
                         "description": "An issue detected during input validation.\n",
                         "allOf": [
                           {
+                            "title": "API Problem",
                             "type": "object",
                             "allOf": [
                               {
+                                "title": "Problem",
                                 "description": "A Problem Details object (RFC 9457).\n\nAdditional properties specific to the problem type may be present.\n",
                                 "type": "object",
                                 "properties": {
@@ -30641,12 +31309,15 @@
             "content": {
               "application/problem+json": {
                 "schema": {
+                  "title": "Input Validation Problem",
                   "type": "object",
                   "allOf": [
                     {
+                      "title": "API Problem",
                       "type": "object",
                       "allOf": [
                         {
+                          "title": "Problem",
                           "description": "A Problem Details object (RFC 9457).\n\nAdditional properties specific to the problem type may be present.\n",
                           "type": "object",
                           "properties": {
@@ -30774,13 +31445,16 @@
                     "issues": {
                       "type": "array",
                       "items": {
+                        "title": "Input Validation Issue",
                         "type": "object",
                         "description": "An issue detected during input validation.\n",
                         "allOf": [
                           {
+                            "title": "API Problem",
                             "type": "object",
                             "allOf": [
                               {
+                                "title": "Problem",
                                 "description": "A Problem Details object (RFC 9457).\n\nAdditional properties specific to the problem type may be present.\n",
                                 "type": "object",
                                 "properties": {
@@ -30959,12 +31633,15 @@
             "content": {
               "application/problem+json": {
                 "schema": {
+                  "title": "Input Validation Problem",
                   "type": "object",
                   "allOf": [
                     {
+                      "title": "API Problem",
                       "type": "object",
                       "allOf": [
                         {
+                          "title": "Problem",
                           "description": "A Problem Details object (RFC 9457).\n\nAdditional properties specific to the problem type may be present.\n",
                           "type": "object",
                           "properties": {
@@ -31092,13 +31769,16 @@
                     "issues": {
                       "type": "array",
                       "items": {
+                        "title": "Input Validation Issue",
                         "type": "object",
                         "description": "An issue detected during input validation.\n",
                         "allOf": [
                           {
+                            "title": "API Problem",
                             "type": "object",
                             "allOf": [
                               {
+                                "title": "Problem",
                                 "description": "A Problem Details object (RFC 9457).\n\nAdditional properties specific to the problem type may be present.\n",
                                 "type": "object",
                                 "properties": {
@@ -31277,9 +31957,11 @@
             "content": {
               "application/problem+json": {
                 "schema": {
+                  "title": "API Problem",
                   "type": "object",
                   "allOf": [
                     {
+                      "title": "Problem",
                       "description": "A Problem Details object (RFC 9457).\n\nAdditional properties specific to the problem type may be present.\n",
                       "type": "object",
                       "properties": {
@@ -31442,9 +32124,11 @@
             "content": {
               "application/problem+json": {
                 "schema": {
+                  "title": "API Problem",
                   "type": "object",
                   "allOf": [
                     {
+                      "title": "Problem",
                       "description": "A Problem Details object (RFC 9457).\n\nAdditional properties specific to the problem type may be present.\n",
                       "type": "object",
                       "properties": {
@@ -31586,6 +32270,7 @@
             "content": {
               "application/json": {
                 "schema": {
+                  "title": "Signed URL",
                   "type": "object",
                   "required": [
                     "url",
@@ -31615,12 +32300,15 @@
             "content": {
               "application/problem+json": {
                 "schema": {
+                  "title": "Input Validation Problem",
                   "type": "object",
                   "allOf": [
                     {
+                      "title": "API Problem",
                       "type": "object",
                       "allOf": [
                         {
+                          "title": "Problem",
                           "description": "A Problem Details object (RFC 9457).\n\nAdditional properties specific to the problem type may be present.\n",
                           "type": "object",
                           "properties": {
@@ -31748,13 +32436,16 @@
                     "issues": {
                       "type": "array",
                       "items": {
+                        "title": "Input Validation Issue",
                         "type": "object",
                         "description": "An issue detected during input validation.\n",
                         "allOf": [
                           {
+                            "title": "API Problem",
                             "type": "object",
                             "allOf": [
                               {
+                                "title": "Problem",
                                 "description": "A Problem Details object (RFC 9457).\n\nAdditional properties specific to the problem type may be present.\n",
                                 "type": "object",
                                 "properties": {
@@ -31933,9 +32624,11 @@
             "content": {
               "application/problem+json": {
                 "schema": {
+                  "title": "API Problem",
                   "type": "object",
                   "allOf": [
                     {
+                      "title": "Problem",
                       "description": "A Problem Details object (RFC 9457).\n\nAdditional properties specific to the problem type may be present.\n",
                       "type": "object",
                       "properties": {
@@ -32098,6 +32791,7 @@
             "content": {
               "application/json": {
                 "schema": {
+                  "title": "Organisation",
                   "required": [
                     "id",
                     "label",
@@ -32140,9 +32834,11 @@
             "content": {
               "application/problem+json": {
                 "schema": {
+                  "title": "API Problem",
                   "type": "object",
                   "allOf": [
                     {
+                      "title": "Problem",
                       "description": "A Problem Details object (RFC 9457).\n\nAdditional properties specific to the problem type may be present.\n",
                       "type": "object",
                       "properties": {
@@ -32296,6 +32992,7 @@
             "content": {
               "application/json": {
                 "schema": {
+                  "title": "Organisation",
                   "required": [
                     "id",
                     "label",
@@ -32338,12 +33035,15 @@
             "content": {
               "application/problem+json": {
                 "schema": {
+                  "title": "Input Validation Problem",
                   "type": "object",
                   "allOf": [
                     {
+                      "title": "API Problem",
                       "type": "object",
                       "allOf": [
                         {
+                          "title": "Problem",
                           "description": "A Problem Details object (RFC 9457).\n\nAdditional properties specific to the problem type may be present.\n",
                           "type": "object",
                           "properties": {
@@ -32471,13 +33171,16 @@
                     "issues": {
                       "type": "array",
                       "items": {
+                        "title": "Input Validation Issue",
                         "type": "object",
                         "description": "An issue detected during input validation.\n",
                         "allOf": [
                           {
+                            "title": "API Problem",
                             "type": "object",
                             "allOf": [
                               {
+                                "title": "Problem",
                                 "description": "A Problem Details object (RFC 9457).\n\nAdditional properties specific to the problem type may be present.\n",
                                 "type": "object",
                                 "properties": {
@@ -32656,9 +33359,11 @@
             "content": {
               "application/problem+json": {
                 "schema": {
+                  "title": "API Problem",
                   "type": "object",
                   "allOf": [
                     {
+                      "title": "Problem",
                       "description": "A Problem Details object (RFC 9457).\n\nAdditional properties specific to the problem type may be present.\n",
                       "type": "object",
                       "properties": {
@@ -32845,6 +33550,7 @@
             "content": {
               "application/json": {
                 "schema": {
+                  "title": "Organisation",
                   "required": [
                     "id",
                     "label",
@@ -32887,12 +33593,15 @@
             "content": {
               "application/problem+json": {
                 "schema": {
+                  "title": "Input Validation Problem",
                   "type": "object",
                   "allOf": [
                     {
+                      "title": "API Problem",
                       "type": "object",
                       "allOf": [
                         {
+                          "title": "Problem",
                           "description": "A Problem Details object (RFC 9457).\n\nAdditional properties specific to the problem type may be present.\n",
                           "type": "object",
                           "properties": {
@@ -33020,13 +33729,16 @@
                     "issues": {
                       "type": "array",
                       "items": {
+                        "title": "Input Validation Issue",
                         "type": "object",
                         "description": "An issue detected during input validation.\n",
                         "allOf": [
                           {
+                            "title": "API Problem",
                             "type": "object",
                             "allOf": [
                               {
+                                "title": "Problem",
                                 "description": "A Problem Details object (RFC 9457).\n\nAdditional properties specific to the problem type may be present.\n",
                                 "type": "object",
                                 "properties": {
@@ -33205,9 +33917,11 @@
             "content": {
               "application/problem+json": {
                 "schema": {
+                  "title": "API Problem",
                   "type": "object",
                   "allOf": [
                     {
+                      "title": "Problem",
                       "description": "A Problem Details object (RFC 9457).\n\nAdditional properties specific to the problem type may be present.\n",
                       "type": "object",
                       "properties": {
@@ -33363,6 +34077,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
+                    "title": "Builder",
                     "type": "object",
                     "required": [
                       "id",
@@ -33413,9 +34128,11 @@
             "content": {
               "application/problem+json": {
                 "schema": {
+                  "title": "API Problem",
                   "type": "object",
                   "allOf": [
                     {
+                      "title": "Problem",
                       "description": "A Problem Details object (RFC 9457).\n\nAdditional properties specific to the problem type may be present.\n",
                       "type": "object",
                       "properties": {
@@ -33587,6 +34304,7 @@
             "content": {
               "application/json": {
                 "schema": {
+                  "title": "Invite",
                   "type": "object",
                   "required": [
                     "id",
@@ -33646,12 +34364,15 @@
             "content": {
               "application/problem+json": {
                 "schema": {
+                  "title": "Input Validation Problem",
                   "type": "object",
                   "allOf": [
                     {
+                      "title": "API Problem",
                       "type": "object",
                       "allOf": [
                         {
+                          "title": "Problem",
                           "description": "A Problem Details object (RFC 9457).\n\nAdditional properties specific to the problem type may be present.\n",
                           "type": "object",
                           "properties": {
@@ -33779,13 +34500,16 @@
                     "issues": {
                       "type": "array",
                       "items": {
+                        "title": "Input Validation Issue",
                         "type": "object",
                         "description": "An issue detected during input validation.\n",
                         "allOf": [
                           {
+                            "title": "API Problem",
                             "type": "object",
                             "allOf": [
                               {
+                                "title": "Problem",
                                 "description": "A Problem Details object (RFC 9457).\n\nAdditional properties specific to the problem type may be present.\n",
                                 "type": "object",
                                 "properties": {
@@ -33964,9 +34688,11 @@
             "content": {
               "application/problem+json": {
                 "schema": {
+                  "title": "API Problem",
                   "type": "object",
                   "allOf": [
                     {
+                      "title": "Problem",
                       "description": "A Problem Details object (RFC 9457).\n\nAdditional properties specific to the problem type may be present.\n",
                       "type": "object",
                       "properties": {
@@ -34120,6 +34846,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
+                    "title": "Invite",
                     "type": "object",
                     "required": [
                       "id",
@@ -34180,9 +34907,11 @@
             "content": {
               "application/problem+json": {
                 "schema": {
+                  "title": "API Problem",
                   "type": "object",
                   "allOf": [
                     {
+                      "title": "Problem",
                       "description": "A Problem Details object (RFC 9457).\n\nAdditional properties specific to the problem type may be present.\n",
                       "type": "object",
                       "properties": {
@@ -34343,6 +35072,7 @@
             "content": {
               "application/json": {
                 "schema": {
+                  "title": "Invite",
                   "type": "object",
                   "required": [
                     "id",
@@ -34402,9 +35132,11 @@
             "content": {
               "application/problem+json": {
                 "schema": {
+                  "title": "API Problem",
                   "type": "object",
                   "allOf": [
                     {
+                      "title": "Problem",
                       "description": "A Problem Details object (RFC 9457).\n\nAdditional properties specific to the problem type may be present.\n",
                       "type": "object",
                       "properties": {
@@ -34566,12 +35298,15 @@
             "content": {
               "application/problem+json": {
                 "schema": {
+                  "title": "Input Validation Problem",
                   "type": "object",
                   "allOf": [
                     {
+                      "title": "API Problem",
                       "type": "object",
                       "allOf": [
                         {
+                          "title": "Problem",
                           "description": "A Problem Details object (RFC 9457).\n\nAdditional properties specific to the problem type may be present.\n",
                           "type": "object",
                           "properties": {
@@ -34699,13 +35434,16 @@
                     "issues": {
                       "type": "array",
                       "items": {
+                        "title": "Input Validation Issue",
                         "type": "object",
                         "description": "An issue detected during input validation.\n",
                         "allOf": [
                           {
+                            "title": "API Problem",
                             "type": "object",
                             "allOf": [
                               {
+                                "title": "Problem",
                                 "description": "A Problem Details object (RFC 9457).\n\nAdditional properties specific to the problem type may be present.\n",
                                 "type": "object",
                                 "properties": {
@@ -34884,9 +35622,11 @@
             "content": {
               "application/problem+json": {
                 "schema": {
+                  "title": "API Problem",
                   "type": "object",
                   "allOf": [
                     {
+                      "title": "Problem",
                       "description": "A Problem Details object (RFC 9457).\n\nAdditional properties specific to the problem type may be present.\n",
                       "type": "object",
                       "properties": {
@@ -35030,6 +35770,7 @@
             "content": {
               "application/json": {
                 "schema": {
+                  "title": "Builder Info",
                   "type": "object",
                   "required": [
                     "builder",
@@ -35037,6 +35778,7 @@
                   ],
                   "properties": {
                     "builder": {
+                      "title": "Builder",
                       "type": "object",
                       "required": [
                         "id",
@@ -35109,6 +35851,7 @@
                             "example": "builder-id-123"
                           },
                           "project": {
+                            "title": "Project",
                             "required": [
                               "appName",
                               "createTime",
@@ -35179,6 +35922,7 @@
                           "example": "builder-id-123"
                         },
                         "org": {
+                          "title": "Organisation",
                           "required": [
                             "id",
                             "label",
@@ -35225,9 +35969,11 @@
             "content": {
               "application/problem+json": {
                 "schema": {
+                  "title": "API Problem",
                   "type": "object",
                   "allOf": [
                     {
+                      "title": "Problem",
                       "description": "A Problem Details object (RFC 9457).\n\nAdditional properties specific to the problem type may be present.\n",
                       "type": "object",
                       "properties": {
@@ -35390,6 +36136,7 @@
             "content": {
               "application/json": {
                 "schema": {
+                  "title": "Builder Info",
                   "type": "object",
                   "required": [
                     "builder",
@@ -35397,6 +36144,7 @@
                   ],
                   "properties": {
                     "builder": {
+                      "title": "Builder",
                       "type": "object",
                       "required": [
                         "id",
@@ -35469,6 +36217,7 @@
                             "example": "builder-id-123"
                           },
                           "project": {
+                            "title": "Project",
                             "required": [
                               "appName",
                               "createTime",
@@ -35539,6 +36288,7 @@
                           "example": "builder-id-123"
                         },
                         "org": {
+                          "title": "Organisation",
                           "required": [
                             "id",
                             "label",
@@ -35585,9 +36335,11 @@
             "content": {
               "application/problem+json": {
                 "schema": {
+                  "title": "API Problem",
                   "type": "object",
                   "allOf": [
                     {
+                      "title": "Problem",
                       "description": "A Problem Details object (RFC 9457).\n\nAdditional properties specific to the problem type may be present.\n",
                       "type": "object",
                       "properties": {
@@ -35740,6 +36492,7 @@
             "content": {
               "application/json": {
                 "schema": {
+                  "title": "Billing Account",
                   "type": "object",
                   "required": [
                     "id",
@@ -35788,12 +36541,15 @@
             "content": {
               "application/problem+json": {
                 "schema": {
+                  "title": "Input Validation Problem",
                   "type": "object",
                   "allOf": [
                     {
+                      "title": "API Problem",
                       "type": "object",
                       "allOf": [
                         {
+                          "title": "Problem",
                           "description": "A Problem Details object (RFC 9457).\n\nAdditional properties specific to the problem type may be present.\n",
                           "type": "object",
                           "properties": {
@@ -35921,13 +36677,16 @@
                     "issues": {
                       "type": "array",
                       "items": {
+                        "title": "Input Validation Issue",
                         "type": "object",
                         "description": "An issue detected during input validation.\n",
                         "allOf": [
                           {
+                            "title": "API Problem",
                             "type": "object",
                             "allOf": [
                               {
+                                "title": "Problem",
                                 "description": "A Problem Details object (RFC 9457).\n\nAdditional properties specific to the problem type may be present.\n",
                                 "type": "object",
                                 "properties": {
@@ -36106,9 +36865,11 @@
             "content": {
               "application/problem+json": {
                 "schema": {
+                  "title": "API Problem",
                   "type": "object",
                   "allOf": [
                     {
+                      "title": "Problem",
                       "description": "A Problem Details object (RFC 9457).\n\nAdditional properties specific to the problem type may be present.\n",
                       "type": "object",
                       "properties": {
@@ -36306,9 +37067,11 @@
             "content": {
               "application/problem+json": {
                 "schema": {
+                  "title": "API Problem",
                   "type": "object",
                   "allOf": [
                     {
+                      "title": "Problem",
                       "description": "A Problem Details object (RFC 9457).\n\nAdditional properties specific to the problem type may be present.\n",
                       "type": "object",
                       "properties": {
@@ -36441,6 +37204,7 @@
   "components": {
     "schemas": {
       "Org": {
+        "title": "Organisation",
         "required": [
           "id",
           "label",
@@ -36476,6 +37240,7 @@
         }
       },
       "Destination": {
+        "title": "Destination",
         "required": [
           "id",
           "name",
@@ -36508,6 +37273,7 @@
                 "example": "https://webhooks.mailmonkey.com/salesforce-lead-converted"
               },
               "headers": {
+                "title": "Webhook Headers",
                 "type": "object",
                 "nullable": true,
                 "description": "Additional headers to add when Ampersand sends a webhook message",
@@ -36534,6 +37300,7 @@
         }
       },
       "Project": {
+        "title": "Project",
         "required": [
           "appName",
           "createTime",
@@ -36574,6 +37341,7 @@
         }
       },
       "ProviderApp": {
+        "title": "Provider App",
         "required": [
           "clientId",
           "createTime",
@@ -36633,6 +37401,7 @@
         }
       },
       "Integration": {
+        "title": "Integration",
         "required": [
           "createTime",
           "id",
@@ -36674,6 +37443,7 @@
             "format": "date-time"
           },
           "latestRevision": {
+            "title": "Revision",
             "required": [
               "content",
               "createTime",
@@ -36698,6 +37468,7 @@
                 "format": "date-time"
               },
               "content": {
+                "title": "Integration",
                 "type": "object",
                 "required": [
                   "name",
@@ -36714,11 +37485,13 @@
                     "type": "string"
                   },
                   "read": {
+                    "title": "Read Integration",
                     "type": "object",
                     "properties": {
                       "objects": {
                         "type": "array",
                         "items": {
+                          "title": "Integration Object",
                           "type": "object",
                           "required": [
                             "objectName",
@@ -36750,8 +37523,10 @@
                             "requiredFields": {
                               "type": "array",
                               "items": {
+                                "title": "Integration Field",
                                 "oneOf": [
                                   {
+                                    "title": "Integration Field Existent",
                                     "type": "object",
                                     "required": [
                                       "fieldName"
@@ -36775,6 +37550,7 @@
                                     }
                                   },
                                   {
+                                    "title": "Integration Field Mapping",
                                     "type": "object",
                                     "required": [
                                       "mapToName"
@@ -36800,8 +37576,10 @@
                             "optionalFields": {
                               "type": "array",
                               "items": {
+                                "title": "Integration Field",
                                 "oneOf": [
                                   {
+                                    "title": "Integration Field Existent",
                                     "type": "object",
                                     "required": [
                                       "fieldName"
@@ -36825,6 +37603,7 @@
                                     }
                                   },
                                   {
+                                    "title": "Integration Field Mapping",
                                     "type": "object",
                                     "required": [
                                       "mapToName"
@@ -36848,18 +37627,21 @@
                               }
                             },
                             "optionalFieldsAuto": {
+                              "title": "Optional Fields Auto Option",
                               "type": "string",
                               "enum": [
                                 "all"
                               ]
                             },
                             "backfill": {
+                              "title": "Backfill",
                               "type": "object",
                               "required": [
                                 "defaultPeriod"
                               ],
                               "properties": {
                                 "defaultPeriod": {
+                                  "title": "Default Period",
                                   "type": "object",
                                   "properties": {
                                     "days": {
@@ -36884,6 +37666,7 @@
                               }
                             },
                             "delivery": {
+                              "title": "Delivery",
                               "type": "object",
                               "properties": {
                                 "mode": {
@@ -36909,11 +37692,13 @@
                     }
                   },
                   "write": {
+                    "title": "Write Integration",
                     "type": "object",
                     "properties": {
                       "objects": {
                         "type": "array",
                         "items": {
+                          "title": "Integration Write Object",
                           "type": "object",
                           "required": [
                             "objectName"
@@ -36928,6 +37713,7 @@
                               "example": true
                             },
                             "valueDefaults": {
+                              "title": "Value Defaults",
                               "type": "object",
                               "description": "Configuration to set default write values for object fields.",
                               "properties": {
@@ -36944,6 +37730,7 @@
                     }
                   },
                   "proxy": {
+                    "title": "Proxy Integration",
                     "type": "object",
                     "properties": {
                       "enabled": {
@@ -36958,6 +37745,7 @@
         }
       },
       "Revision": {
+        "title": "Revision",
         "required": [
           "content",
           "createTime",
@@ -36982,6 +37770,7 @@
             "format": "date-time"
           },
           "content": {
+            "title": "Integration",
             "type": "object",
             "required": [
               "name",
@@ -36998,11 +37787,13 @@
                 "type": "string"
               },
               "read": {
+                "title": "Read Integration",
                 "type": "object",
                 "properties": {
                   "objects": {
                     "type": "array",
                     "items": {
+                      "title": "Integration Object",
                       "type": "object",
                       "required": [
                         "objectName",
@@ -37034,8 +37825,10 @@
                         "requiredFields": {
                           "type": "array",
                           "items": {
+                            "title": "Integration Field",
                             "oneOf": [
                               {
+                                "title": "Integration Field Existent",
                                 "type": "object",
                                 "required": [
                                   "fieldName"
@@ -37059,6 +37852,7 @@
                                 }
                               },
                               {
+                                "title": "Integration Field Mapping",
                                 "type": "object",
                                 "required": [
                                   "mapToName"
@@ -37084,8 +37878,10 @@
                         "optionalFields": {
                           "type": "array",
                           "items": {
+                            "title": "Integration Field",
                             "oneOf": [
                               {
+                                "title": "Integration Field Existent",
                                 "type": "object",
                                 "required": [
                                   "fieldName"
@@ -37109,6 +37905,7 @@
                                 }
                               },
                               {
+                                "title": "Integration Field Mapping",
                                 "type": "object",
                                 "required": [
                                   "mapToName"
@@ -37132,18 +37929,21 @@
                           }
                         },
                         "optionalFieldsAuto": {
+                          "title": "Optional Fields Auto Option",
                           "type": "string",
                           "enum": [
                             "all"
                           ]
                         },
                         "backfill": {
+                          "title": "Backfill",
                           "type": "object",
                           "required": [
                             "defaultPeriod"
                           ],
                           "properties": {
                             "defaultPeriod": {
+                              "title": "Default Period",
                               "type": "object",
                               "properties": {
                                 "days": {
@@ -37168,6 +37968,7 @@
                           }
                         },
                         "delivery": {
+                          "title": "Delivery",
                           "type": "object",
                           "properties": {
                             "mode": {
@@ -37193,11 +37994,13 @@
                 }
               },
               "write": {
+                "title": "Write Integration",
                 "type": "object",
                 "properties": {
                   "objects": {
                     "type": "array",
                     "items": {
+                      "title": "Integration Write Object",
                       "type": "object",
                       "required": [
                         "objectName"
@@ -37212,6 +38015,7 @@
                           "example": true
                         },
                         "valueDefaults": {
+                          "title": "Value Defaults",
                           "type": "object",
                           "description": "Configuration to set default write values for object fields.",
                           "properties": {
@@ -37228,6 +38032,7 @@
                 }
               },
               "proxy": {
+                "title": "Proxy Integration",
                 "type": "object",
                 "properties": {
                   "enabled": {
@@ -37240,6 +38045,7 @@
         }
       },
       "HydratedRevision": {
+        "title": "Hydrated Revision",
         "required": [
           "content",
           "createTime",
@@ -37264,6 +38070,7 @@
             "format": "date-time"
           },
           "content": {
+            "title": "Hydrated Integration",
             "type": "object",
             "required": [
               "name",
@@ -37280,11 +38087,13 @@
                 "type": "string"
               },
               "read": {
+                "title": "Hydrated Read Integration",
                 "type": "object",
                 "properties": {
                   "objects": {
                     "type": "array",
                     "items": {
+                      "title": "Hydrated Integration Object",
                       "type": "object",
                       "required": [
                         "objectName",
@@ -37320,6 +38129,7 @@
                         "requiredFields": {
                           "type": "array",
                           "items": {
+                            "title": "Hydrated Integration Field",
                             "oneOf": [
                               {
                                 "type": "object",
@@ -37349,6 +38159,7 @@
                                 }
                               },
                               {
+                                "title": "Integration Field Mapping",
                                 "type": "object",
                                 "required": [
                                   "mapToName"
@@ -37374,6 +38185,7 @@
                         "optionalFields": {
                           "type": "array",
                           "items": {
+                            "title": "Hydrated Integration Field",
                             "oneOf": [
                               {
                                 "type": "object",
@@ -37403,6 +38215,7 @@
                                 }
                               },
                               {
+                                "title": "Integration Field Mapping",
                                 "type": "object",
                                 "required": [
                                   "mapToName"
@@ -37426,6 +38239,7 @@
                           }
                         },
                         "optionalFieldsAuto": {
+                          "title": "Optional Fields Auto Option",
                           "type": "string",
                           "enum": [
                             "all"
@@ -37435,6 +38249,7 @@
                           "description": "This is a list of all fields on the object for a particular SaaS instance, including their display names.",
                           "type": "array",
                           "items": {
+                            "title": "Hydrated Integration Field",
                             "oneOf": [
                               {
                                 "type": "object",
@@ -37464,6 +38279,7 @@
                                 }
                               },
                               {
+                                "title": "Integration Field Mapping",
                                 "type": "object",
                                 "required": [
                                   "mapToName"
@@ -37490,6 +38306,7 @@
                           "description": "This is a map of all fields on the object including their metadata (such as display name and type), the keys of the map are the field names.",
                           "type": "object",
                           "additionalProperties": {
+                            "title": "Field Metadata",
                             "type": "object",
                             "required": [
                               "fieldName",
@@ -37539,6 +38356,7 @@
                                 "description": "If the valueType is singleSelect or multiSelect, this is a list of possible values",
                                 "x-go-type-skip-optional-pointer": true,
                                 "items": {
+                                  "title": "Field Value",
                                   "type": "object",
                                   "required": [
                                     "value",
@@ -37563,12 +38381,14 @@
                           }
                         },
                         "backfill": {
+                          "title": "Backfill",
                           "type": "object",
                           "required": [
                             "defaultPeriod"
                           ],
                           "properties": {
                             "defaultPeriod": {
+                              "title": "Default Period",
                               "type": "object",
                               "properties": {
                                 "days": {
@@ -37616,6 +38436,7 @@
                           "type": "string"
                         },
                         "valueDefaults": {
+                          "title": "Value Defaults",
                           "type": "object",
                           "description": "Configuration to set default write values for object fields.",
                           "properties": {
@@ -37632,6 +38453,7 @@
                 }
               },
               "proxy": {
+                "title": "Hydrated Proxy Integration",
                 "type": "object",
                 "properties": {
                   "enabled": {
@@ -37644,6 +38466,7 @@
         }
       },
       "Installation": {
+        "title": "Installation",
         "required": [
           "config",
           "connection",
@@ -37672,6 +38495,7 @@
             "example": "integration-123"
           },
           "group": {
+            "title": "Group",
             "required": [
               "createTime",
               "groupName",
@@ -37715,6 +38539,7 @@
             "example": "healthy"
           },
           "connection": {
+            "title": "Connection",
             "required": [
               "id",
               "createTime",
@@ -37743,6 +38568,7 @@
                 "example": "salesforce"
               },
               "providerApp": {
+                "title": "Provider App",
                 "required": [
                   "clientId",
                   "createTime",
@@ -37802,6 +38628,7 @@
                 }
               },
               "group": {
+                "title": "Group",
                 "required": [
                   "createTime",
                   "groupName",
@@ -37840,6 +38667,7 @@
                 }
               },
               "consumer": {
+                "title": "Consumer",
                 "required": [
                   "consumerName",
                   "consumerRef",
@@ -37924,6 +38752,7 @@
                 ]
               },
               "oauth2AuthorizationCode": {
+                "title": "OAuth2 AuthorizationCode Token",
                 "type": "object",
                 "properties": {
                   "accessToken": {
@@ -37982,6 +38811,7 @@
             "format": "date-time"
           },
           "config": {
+            "title": "Config",
             "required": [
               "content",
               "createTime",
@@ -38012,8 +38842,10 @@
                 "example": "builder:builder-123"
               },
               "content": {
+                "title": "Config Content",
                 "allOf": [
                   {
+                    "title": "Base Config Content",
                     "type": "object",
                     "properties": {
                       "provider": {
@@ -38022,12 +38854,14 @@
                         "type": "string"
                       },
                       "read": {
+                        "title": "Base Read Config",
                         "type": "object",
                         "properties": {
                           "objects": {
                             "type": "object",
                             "description": "This is a map of object names to their configuration.",
                             "additionalProperties": {
+                              "title": "Base Read Config Object",
                               "type": "object",
                               "properties": {
                                 "objectName": {
@@ -38068,6 +38902,7 @@
                                   },
                                   "x-go-type-skip-optional-pointer": true,
                                   "additionalProperties": {
+                                    "title": "Selected Value Mappings",
                                     "type": "object",
                                     "description": "This is a map of values to their mappings. The key is the value delivered to the webhook, the value is the value coming from the provider API.",
                                     "example": {
@@ -38090,6 +38925,7 @@
                                   }
                                 },
                                 "selectedFieldsAuto": {
+                                  "title": "Selected Fields Auto Config",
                                   "description": "If selectedFieldsAuto is set to all, all fields will be read.",
                                   "type": "string",
                                   "enum": [
@@ -38100,12 +38936,14 @@
                                   ]
                                 },
                                 "backfill": {
+                                  "title": "Backfill Config",
                                   "type": "object",
                                   "required": [
                                     "defaultPeriod"
                                   ],
                                   "properties": {
                                     "defaultPeriod": {
+                                      "title": "Default Period Config",
                                       "type": "object",
                                       "properties": {
                                         "days": {
@@ -38135,12 +38973,14 @@
                         }
                       },
                       "write": {
+                        "title": "Base Write Config",
                         "type": "object",
                         "properties": {
                           "objects": {
                             "type": "object",
                             "description": "This is a map of object names to their configuration.",
                             "additionalProperties": {
+                              "title": "Base Write Config Object",
                               "type": "object",
                               "properties": {
                                 "objectName": {
@@ -38156,8 +38996,10 @@
                                   "description": "This is a map of field names to default values. These values will be used when writing to the object.",
                                   "x-go-type-skip-optional-pointer": true,
                                   "additionalProperties": {
+                                    "title": "Value Default",
                                     "oneOf": [
                                       {
+                                        "title": "Value Default String",
                                         "type": "object",
                                         "required": [
                                           "value"
@@ -38178,6 +39020,7 @@
                                         }
                                       },
                                       {
+                                        "title": "Value Default Integer",
                                         "type": "object",
                                         "required": [
                                           "value"
@@ -38198,6 +39041,7 @@
                                         }
                                       },
                                       {
+                                        "title": "Value Default Boolean",
                                         "type": "object",
                                         "required": [
                                           "value"
@@ -38226,6 +39070,7 @@
                         }
                       },
                       "proxy": {
+                        "title": "Base Proxy Config",
                         "type": "object",
                         "properties": {
                           "enabled": {
@@ -38256,6 +39101,7 @@
         }
       },
       "Config": {
+        "title": "Config",
         "required": [
           "content",
           "createTime",
@@ -38286,8 +39132,10 @@
             "example": "builder:builder-123"
           },
           "content": {
+            "title": "Config Content",
             "allOf": [
               {
+                "title": "Base Config Content",
                 "type": "object",
                 "properties": {
                   "provider": {
@@ -38296,12 +39144,14 @@
                     "type": "string"
                   },
                   "read": {
+                    "title": "Base Read Config",
                     "type": "object",
                     "properties": {
                       "objects": {
                         "type": "object",
                         "description": "This is a map of object names to their configuration.",
                         "additionalProperties": {
+                          "title": "Base Read Config Object",
                           "type": "object",
                           "properties": {
                             "objectName": {
@@ -38342,6 +39192,7 @@
                               },
                               "x-go-type-skip-optional-pointer": true,
                               "additionalProperties": {
+                                "title": "Selected Value Mappings",
                                 "type": "object",
                                 "description": "This is a map of values to their mappings. The key is the value delivered to the webhook, the value is the value coming from the provider API.",
                                 "example": {
@@ -38364,6 +39215,7 @@
                               }
                             },
                             "selectedFieldsAuto": {
+                              "title": "Selected Fields Auto Config",
                               "description": "If selectedFieldsAuto is set to all, all fields will be read.",
                               "type": "string",
                               "enum": [
@@ -38374,12 +39226,14 @@
                               ]
                             },
                             "backfill": {
+                              "title": "Backfill Config",
                               "type": "object",
                               "required": [
                                 "defaultPeriod"
                               ],
                               "properties": {
                                 "defaultPeriod": {
+                                  "title": "Default Period Config",
                                   "type": "object",
                                   "properties": {
                                     "days": {
@@ -38409,12 +39263,14 @@
                     }
                   },
                   "write": {
+                    "title": "Base Write Config",
                     "type": "object",
                     "properties": {
                       "objects": {
                         "type": "object",
                         "description": "This is a map of object names to their configuration.",
                         "additionalProperties": {
+                          "title": "Base Write Config Object",
                           "type": "object",
                           "properties": {
                             "objectName": {
@@ -38430,8 +39286,10 @@
                               "description": "This is a map of field names to default values. These values will be used when writing to the object.",
                               "x-go-type-skip-optional-pointer": true,
                               "additionalProperties": {
+                                "title": "Value Default",
                                 "oneOf": [
                                   {
+                                    "title": "Value Default String",
                                     "type": "object",
                                     "required": [
                                       "value"
@@ -38452,6 +39310,7 @@
                                     }
                                   },
                                   {
+                                    "title": "Value Default Integer",
                                     "type": "object",
                                     "required": [
                                       "value"
@@ -38472,6 +39331,7 @@
                                     }
                                   },
                                   {
+                                    "title": "Value Default Boolean",
                                     "type": "object",
                                     "required": [
                                       "value"
@@ -38500,6 +39360,7 @@
                     }
                   },
                   "proxy": {
+                    "title": "Base Proxy Config",
                     "type": "object",
                     "properties": {
                       "enabled": {
@@ -38528,6 +39389,7 @@
         }
       },
       "Connection": {
+        "title": "Connection",
         "required": [
           "id",
           "createTime",
@@ -38556,6 +39418,7 @@
             "example": "salesforce"
           },
           "providerApp": {
+            "title": "Provider App",
             "required": [
               "clientId",
               "createTime",
@@ -38615,6 +39478,7 @@
             }
           },
           "group": {
+            "title": "Group",
             "required": [
               "createTime",
               "groupName",
@@ -38653,6 +39517,7 @@
             }
           },
           "consumer": {
+            "title": "Consumer",
             "required": [
               "consumerName",
               "consumerRef",
@@ -38737,6 +39602,7 @@
             ]
           },
           "oauth2AuthorizationCode": {
+            "title": "OAuth2 AuthorizationCode Token",
             "type": "object",
             "properties": {
               "accessToken": {
@@ -38780,6 +39646,7 @@
         }
       },
       "Oauth2AuthorizationCodeTokensOnly": {
+        "title": "OAuth2 AuthorizationCode Token",
         "type": "object",
         "properties": {
           "accessToken": {
@@ -38816,6 +39683,7 @@
         }
       },
       "Oauth2AuthorizationCode": {
+        "title": "OAuth2 Authorization Code",
         "type": "object",
         "properties": {
           "accessToken": {
@@ -38868,6 +39736,7 @@
         }
       },
       "ImportConnectionRequest": {
+        "title": "Import Connection Request",
         "required": [
           "groupRef",
           "groupName",
@@ -38922,6 +39791,7 @@
         }
       },
       "Group": {
+        "title": "Group",
         "required": [
           "createTime",
           "groupName",
@@ -38960,6 +39830,7 @@
         }
       },
       "Consumer": {
+        "title": "Consumer",
         "required": [
           "consumerName",
           "consumerRef",
@@ -38998,6 +39869,7 @@
         }
       },
       "Operation": {
+        "title": "Operation",
         "required": [
           "projectId",
           "integrationId",
@@ -39063,6 +39935,7 @@
         }
       },
       "Log": {
+        "title": "Log",
         "type": "object",
         "required": [
           "timestamp",
@@ -39105,6 +39978,7 @@
         }
       },
       "SignedUrl": {
+        "title": "Signed URL",
         "type": "object",
         "required": [
           "url",
@@ -39127,6 +40001,7 @@
         }
       },
       "ApiKeyScopes": {
+        "title": "API Key Scopes",
         "type": "array",
         "description": "The scopes for the API key.",
         "items": {
@@ -39138,6 +40013,7 @@
         }
       },
       "ApiKeyRequest": {
+        "title": "API Key Request",
         "type": "object",
         "required": [
           "label"
@@ -39149,6 +40025,7 @@
             "example": "MailMonkey API Key"
           },
           "scopes": {
+            "title": "API Key Scopes",
             "type": "array",
             "description": "The scopes for the API key.",
             "items": {
@@ -39162,6 +40039,7 @@
         }
       },
       "ApiKey": {
+        "title": "API Key",
         "type": "object",
         "required": [
           "key",
@@ -39181,6 +40059,7 @@
             "example": "MailMonkey API Key"
           },
           "scopes": {
+            "title": "API Key Scopes",
             "type": "array",
             "description": "The scopes for the API key.",
             "items": {
@@ -39204,6 +40083,7 @@
         }
       },
       "PatchApiKeyRequest": {
+        "title": "Patch API Key Request",
         "type": "object",
         "required": [
           "updateMask",
@@ -39237,6 +40117,7 @@
                 "example": true
               },
               "scopes": {
+                "title": "API Key Scopes",
                 "type": "array",
                 "description": "The scopes for the API key.",
                 "items": {
@@ -39252,6 +40133,7 @@
         }
       },
       "WebhookHeaders": {
+        "title": "Webhook Headers",
         "type": "object",
         "nullable": true,
         "description": "Additional headers to add when Ampersand sends a webhook message",
@@ -39264,6 +40146,7 @@
         }
       },
       "Invite": {
+        "title": "Invite",
         "type": "object",
         "required": [
           "id",
@@ -39316,6 +40199,7 @@
         }
       },
       "Builder": {
+        "title": "Builder",
         "type": "object",
         "required": [
           "id",
@@ -39358,6 +40242,7 @@
         }
       },
       "BillingAccount": {
+        "title": "Billing Account",
         "type": "object",
         "required": [
           "id",
@@ -39399,6 +40284,7 @@
         }
       },
       "BuilderInfo": {
+        "title": "Builder Info",
         "type": "object",
         "required": [
           "builder",
@@ -39406,6 +40292,7 @@
         ],
         "properties": {
           "builder": {
+            "title": "Builder",
             "type": "object",
             "required": [
               "id",
@@ -39478,6 +40365,7 @@
                   "example": "builder-id-123"
                 },
                 "project": {
+                  "title": "Project",
                   "required": [
                     "appName",
                     "createTime",
@@ -39548,6 +40436,7 @@
                 "example": "builder-id-123"
               },
               "org": {
+                "title": "Organisation",
                 "required": [
                   "id",
                   "label",
@@ -39587,6 +40476,7 @@
         }
       },
       "ObjectMetadata": {
+        "title": "Object Metadata",
         "type": "object",
         "required": [
           "name",
@@ -39611,6 +40501,7 @@
             "type": "object",
             "description": "Map of field metadata keyed by field name",
             "additionalProperties": {
+              "title": "Field Metadata",
               "type": "object",
               "required": [
                 "fieldName",
@@ -39660,6 +40551,7 @@
                   "description": "If the valueType is singleSelect or multiSelect, this is a list of possible values",
                   "x-go-type-skip-optional-pointer": true,
                   "items": {
+                    "title": "Field Value",
                     "type": "object",
                     "required": [
                       "value",
@@ -39686,6 +40578,7 @@
         }
       },
       "PaginationInfo": {
+        "title": "Pagination Information",
         "type": "object",
         "required": [
           "done"

--- a/api/generated/read.json
+++ b/api/generated/read.json
@@ -50,6 +50,7 @@
           "content": {
             "application/json": {
               "schema": {
+                "title": "Read Request",
                 "required": [
                   "groupRef",
                   "mode"
@@ -84,6 +85,7 @@
             "content": {
               "application/json": {
                 "schema": {
+                  "title": "Read Result Async",
                   "type": "object",
                   "required": [
                     "operationId"
@@ -104,9 +106,11 @@
             "content": {
               "application/json": {
                 "schema": {
+                  "title": "API Problem",
                   "type": "object",
                   "allOf": [
                     {
+                      "title": "Problem",
                       "description": "A Problem Details object (RFC 9457).\n\nAdditional properties specific to the problem type may be present.\n",
                       "type": "object",
                       "properties": {
@@ -237,9 +241,11 @@
             "content": {
               "application/json": {
                 "schema": {
+                  "title": "API Problem",
                   "type": "object",
                   "allOf": [
                     {
+                      "title": "Problem",
                       "description": "A Problem Details object (RFC 9457).\n\nAdditional properties specific to the problem type may be present.\n",
                       "type": "object",
                       "properties": {
@@ -370,9 +376,11 @@
             "content": {
               "application/problem+json": {
                 "schema": {
+                  "title": "API Problem",
                   "type": "object",
                   "allOf": [
                     {
+                      "title": "Problem",
                       "description": "A Problem Details object (RFC 9457).\n\nAdditional properties specific to the problem type may be present.\n",
                       "type": "object",
                       "properties": {
@@ -541,6 +549,7 @@
           "content": {
             "application/json": {
               "schema": {
+                "title": "Result Delivery Request",
                 "required": [
                   "groupRef",
                   "pages"
@@ -570,9 +579,11 @@
             "content": {
               "application/json": {
                 "schema": {
+                  "title": "API Problem",
                   "type": "object",
                   "allOf": [
                     {
+                      "title": "Problem",
                       "description": "A Problem Details object (RFC 9457).\n\nAdditional properties specific to the problem type may be present.\n",
                       "type": "object",
                       "properties": {
@@ -703,9 +714,11 @@
             "content": {
               "application/json": {
                 "schema": {
+                  "title": "API Problem",
                   "type": "object",
                   "allOf": [
                     {
+                      "title": "Problem",
                       "description": "A Problem Details object (RFC 9457).\n\nAdditional properties specific to the problem type may be present.\n",
                       "type": "object",
                       "properties": {
@@ -836,9 +849,11 @@
             "content": {
               "application/problem+json": {
                 "schema": {
+                  "title": "API Problem",
                   "type": "object",
                   "allOf": [
                     {
+                      "title": "Problem",
                       "description": "A Problem Details object (RFC 9457).\n\nAdditional properties specific to the problem type may be present.\n",
                       "type": "object",
                       "properties": {
@@ -971,6 +986,7 @@
   "components": {
     "schemas": {
       "ReadRequest": {
+        "title": "Read Request",
         "required": [
           "groupRef",
           "mode"
@@ -997,6 +1013,7 @@
         }
       },
       "ReadResultAsync": {
+        "title": "Read Result Async",
         "type": "object",
         "required": [
           "operationId"
@@ -1010,6 +1027,7 @@
         }
       },
       "ResultDeliveryRequestBody": {
+        "title": "Result Delivery Request",
         "required": [
           "groupRef",
           "pages"

--- a/api/generated/write.json
+++ b/api/generated/write.json
@@ -49,6 +49,7 @@
           "content": {
             "application/json": {
               "schema": {
+                "title": "Write Request",
                 "required": [
                   "groupRef",
                   "type"
@@ -115,6 +116,7 @@
             "content": {
               "application/json": {
                 "schema": {
+                  "title": "Sync Write Response Success",
                   "type": "object",
                   "required": [
                     "result"
@@ -122,6 +124,7 @@
                   "additionalProperties": false,
                   "properties": {
                     "result": {
+                      "title": "Write Result",
                       "type": "object",
                       "required": [
                         "success"
@@ -168,6 +171,7 @@
             "content": {
               "application/json": {
                 "schema": {
+                  "title": "Sync Write Response Failure",
                   "type": "object",
                   "required": [
                     "errors"
@@ -184,6 +188,7 @@
                       }
                     },
                     "result": {
+                      "title": "Write Result",
                       "type": "object",
                       "required": [
                         "success"
@@ -233,9 +238,11 @@
             "content": {
               "application/problem+json": {
                 "schema": {
+                  "title": "API Problem",
                   "type": "object",
                   "allOf": [
                     {
+                      "title": "Problem",
                       "description": "A Problem Details object (RFC 9457).\n\nAdditional properties specific to the problem type may be present.\n",
                       "type": "object",
                       "properties": {
@@ -368,6 +375,7 @@
   "components": {
     "schemas": {
       "WriteRequest": {
+        "title": "Write Request",
         "required": [
           "groupRef",
           "type"
@@ -426,6 +434,7 @@
         }
       },
       "WriteResponseSingleSuccess": {
+        "title": "Sync Write Response Success",
         "type": "object",
         "required": [
           "result"
@@ -433,6 +442,7 @@
         "additionalProperties": false,
         "properties": {
           "result": {
+            "title": "Write Result",
             "type": "object",
             "required": [
               "success"
@@ -461,6 +471,7 @@
         }
       },
       "WriteResponseSingleFail": {
+        "title": "Sync Write Response Failure",
         "type": "object",
         "required": [
           "errors"
@@ -477,6 +488,7 @@
             }
           },
           "result": {
+            "title": "Write Result",
             "type": "object",
             "required": [
               "success"
@@ -519,6 +531,7 @@
         }
       },
       "WriteResult": {
+        "title": "Write Result",
         "type": "object",
         "required": [
           "success"

--- a/api/read.yaml
+++ b/api/read.yaml
@@ -116,6 +116,7 @@ paths:
 components:
   schemas:
     ReadRequest:
+      title: Read Request
       required:
         - groupRef
         - mode
@@ -136,6 +137,7 @@ components:
           description: The UTC timestamp from which to read data. If omitted, we will read all data.
           example: "2024-07-01T18:22:30.323771761Z"
     ReadResultAsync:
+      title: Read Result Async
       type: object
       required:
         - operationId
@@ -145,6 +147,7 @@ components:
           description: The operation ID
           example: 60deaf48-3856-4a2b-bfd4-3de85125eca8
     ResultDeliveryRequestBody:
+      title: Result Delivery Request
       required:
         - groupRef
         - pages

--- a/api/write.yaml
+++ b/api/write.yaml
@@ -62,6 +62,7 @@ paths:
 components:
   schemas:
     WriteRequest:
+      title: Write Request
       required:
         - groupRef
         - type
@@ -113,6 +114,7 @@ components:
         #             "warmthScore": "ready-for-close",
         #           }]
     WriteResponseSingleSuccess:
+      title: Sync Write Response Success
       type: object
       required:
         - result
@@ -121,6 +123,7 @@ components:
         result:
           $ref: "#/components/schemas/WriteResult"
     WriteResponseSingleFail:
+      title: Sync Write Response Failure
       type: object
       required:
         - errors
@@ -147,6 +150,7 @@ components:
           description: The operation ID
           example: acb0d75a-1b59-4aad-a191-48c5b75ea9e4
     WriteResult:
+      title: Write Result
       type: object
       required:
         - success

--- a/catalog/catalog.yaml
+++ b/catalog/catalog.yaml
@@ -18,6 +18,7 @@ paths: {}
 components:
   schemas:
     AuthType:
+      title: Auth Type
       description: The type of authentication required by the provider.
       type: string
       enum: [oauth2, apiKey, basic, jwt, none]
@@ -25,6 +26,7 @@ components:
         validate: required
 
     Support:
+      title: Support
       type: object
       description: The supported features for the provider.
       x-oapi-codegen-extra-tags:
@@ -50,6 +52,7 @@ components:
           $ref: '#/components/schemas/SubscribeSupport'
 
     BulkWriteSupport:
+      title: Bulk Write Support
       type: object
       x-oapi-codegen-extra-tags:
         validate: required
@@ -68,6 +71,7 @@ components:
         delete:
           type: boolean
     TokenMetadataFields:
+      title: Token Metadata Fields
       type: object
       description: Fields to be used to extract token metadata from the token response.
       properties:
@@ -85,6 +89,7 @@ components:
           x-go-type-skip-optional-pointer: true
 
     Media:
+      title: Media
       properties:
         regular:
           $ref: '#/components/schemas/MediaTypeRegular'
@@ -92,6 +97,7 @@ components:
           $ref: '#/components/schemas/MediaTypeDarkMode'
 
     MediaTypeDarkMode:
+      title: Media Type Dark Mode
       type: object
       description: Media to be used in dark mode.
       properties:
@@ -107,6 +113,7 @@ components:
           x-go-type-skip-optional-pointer: true
 
     MediaTypeRegular:
+      title: Media Type Regular
       type: object
       description: Media for light/regular mode.
       properties:
@@ -120,13 +127,15 @@ components:
           example: https://example.com/logo.png
           description: URL to the logo for the provider.
           x-go-type-skip-optional-pointer: true
-    
+
     Labels:
+      title: Labels
       type: object
       additionalProperties:
         type: string
 
     Oauth2Opts:
+      title: OAuth2 Options
       type: object
       description: Configuration for OAuth2.0. Must be provided if authType is oauth2.
       required:
@@ -182,6 +191,7 @@ components:
             duration: permanent
 
     ApiKeyOpts:
+      title: API Key Options
       type: object
       description: Configuration for API key. Must be provided if authType is apiKey.
       required:
@@ -204,6 +214,7 @@ components:
           x-go-type-skip-optional-pointer: true
 
     ApiKeyOptsQuery:
+      title: API Key Query Options
       type: object
       description: Configuration for API key in query parameter. Must be provided if type is in-query.
       required:
@@ -216,6 +227,7 @@ components:
           x-go-type-skip-optional-pointer: true
 
     ApiKeyOptsHeader:
+      title: API Key Header Options
       type: object
       description: Configuration for API key in header. Must be provided if type is in-header.
       required:
@@ -233,6 +245,7 @@ components:
           x-go-type-skip-optional-pointer: true
 
     ApiKeyAsBasicOpts:
+      title: API Key as Basic Options
       type: object
       description: when this object is present, it means that this provider uses Basic Auth to actually collect an API key
       properties:
@@ -252,6 +265,7 @@ components:
           x-go-type-skip-optional-pointer: true
 
     BasicAuthOpts:
+      title: Basic Auth Options
       type: object
       description: Configuration for Basic Auth. Optional.
       properties:
@@ -269,16 +283,19 @@ components:
           x-go-type-skip-optional-pointer: true
 
     ProviderOpts:
+      title: Provider Options
       description: Additional provider-specific metadata.
       type: object
       additionalProperties:
         type: string
 
     Provider:
+      title: Provider
       type: string
       example: salesforce
 
     ProviderInfo:
+      title: Provider Info
       type: object
       required:
         - name
@@ -324,8 +341,9 @@ components:
           $ref: '#/components/schemas/Labels'
         subscribeOpts:
           $ref: '#/components/schemas/SubscribeOpts'
-          
+
     CatalogWrapper:
+      title: Catalog Wrapper
       type: object
       required:
         - timestamp
@@ -341,11 +359,13 @@ components:
           $ref: '#/components/schemas/CatalogType'
 
     CatalogType:
+      title: Catalog Type
       type: object
       additionalProperties:
         $ref: '#/components/schemas/ProviderInfo'
 
     SubscribeOpts:
+      title: Subscribe Options
       type: object
       required:
         - subscriptionScope
@@ -365,6 +385,7 @@ components:
           description: The timing of the registration.
 
     SubscribeSupport:
+      title: Subscribe Support
       type: object
       properties:
         create:

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -13,6 +13,7 @@ paths: {}
 components:
   schemas:
     BaseConfigContent:
+      title: Base Config Content
       type: object
       properties:
         provider:
@@ -27,12 +28,14 @@ components:
           $ref: '#/components/schemas/BaseProxyConfig'
 
     BaseProxyConfig:
+      title: Base Proxy Config
       type: object
       properties:
         enabled:
           type: boolean
 
     BaseReadConfig:
+      title: Base Read Config
       type: object
       properties:
         objects:
@@ -42,6 +45,7 @@ components:
             $ref: '#/components/schemas/BaseReadConfigObject'
 
     BaseReadConfigObject:
+      title: Base Read Config Object
       type: object
       properties:
         objectName:
@@ -89,6 +93,7 @@ components:
           $ref: '#/components/schemas/BackfillConfig'
 
     SelectedValueMappings:
+      title: Selected Value Mappings
       type: object
       description: This is a map of values to their mappings. The key is the value delivered to the webhook, the value is the value coming from the provider API.
       example:
@@ -100,6 +105,7 @@ components:
         type: string
 
     BaseWriteConfig:
+      title: Base Write Config
       type: object
       properties:
         objects:
@@ -109,6 +115,7 @@ components:
             $ref: '#/components/schemas/BaseWriteConfigObject'
 
     BaseWriteConfigObject:
+      title: Base Write Config Object
       type: object
       properties:
         objectName:
@@ -125,6 +132,7 @@ components:
             $ref: '#/components/schemas/ValueDefault'
 
     ConfigContent:
+      title: Config Content
       allOf:
         - $ref: '#/components/schemas/BaseConfigContent'
         - type: object
@@ -137,6 +145,7 @@ components:
               x-go-type: WriteConfig
 
     ReadConfig:
+      title: Read Config
       allOf:
         - $ref: '#/components/schemas/BaseReadConfig'
         - type: object
@@ -148,6 +157,7 @@ components:
                 x-go-type: ReadConfigObject
 
     ReadConfigObject:
+      title: Read Config Object
       allOf:
         - $ref: '#/components/schemas/BaseReadConfigObject'
         - type: object
@@ -159,6 +169,7 @@ components:
             - selectedFieldMappings
 
     WriteConfig:
+      title: Write Config
       allOf:
         - $ref: '#/components/schemas/BaseWriteConfig'
         - type: object
@@ -168,6 +179,7 @@ components:
                 x-go-type: WriteConfigObject
 
     WriteConfigObject:
+      title: Write Config Object
       allOf:
         - $ref: '#/components/schemas/BaseWriteConfigObject'
         - type: object
@@ -175,18 +187,22 @@ components:
             - objectName
 
     UpdateInstallationConfigContent:
+      title: Update Installation Config Content
       allOf:
         - $ref: '#/components/schemas/BaseConfigContent'
 
     UpdateInstallationReadConfig:
+      title: Update Installation Read Config
       allOf:
         - $ref: '#/components/schemas/BaseReadConfig'
 
     UpdateInstallationReadConfigObject:
+      title: Update Installation Read Config Object
       allOf:
         - $ref: '#/components/schemas/BaseReadConfigObject'
 
     SelectedFieldsAutoConfig:
+      title: Selected Fields Auto Config
       description: If selectedFieldsAuto is set to all, all fields will be read.
       type: string
       enum: [ all ]
@@ -194,6 +210,7 @@ components:
         - SelectedFieldsAll
 
     BackfillConfig:
+      title: Backfill Config
       type: object
       required:
         - defaultPeriod
@@ -202,6 +219,7 @@ components:
           $ref: '#/components/schemas/DefaultPeriodConfig'
 
     DefaultPeriodConfig:
+      title: Default Period Config
       type: object
       properties:
         days:
@@ -219,12 +237,14 @@ components:
             validate: required_without=Days
 
     ValueDefault:
+      title: Value Default
       oneOf:
         - $ref: '#/components/schemas/ValueDefaultString'
         - $ref: '#/components/schemas/ValueDefaultInteger'
         - $ref: '#/components/schemas/ValueDefaultBoolean'
 
     ValueDefaultString:
+      title: Value Default String
       type: object
       required:
         - value
@@ -243,6 +263,7 @@ components:
             If unspecified, then `always` is assumed.
 
     ValueDefaultInteger:
+      title: Value Default Integer
       type: object
       required:
         - value
@@ -261,6 +282,7 @@ components:
               If unspecified, then `always` is assumed.
 
     ValueDefaultBoolean:
+      title: Value Default Boolean
       type: object
       required:
         - value

--- a/manifest/manifest.yaml
+++ b/manifest/manifest.yaml
@@ -13,6 +13,7 @@ paths: {}
 components:
   schemas:
     Manifest:
+      title: Integration Manifest
       type: object
       description: This is the schema of the manifest file that is used to define the integrations of the project.
       required:
@@ -28,6 +29,7 @@ components:
             $ref: '#/components/schemas/Integration'
 
     Integration:
+      title: Integration
       type: object
       required:
         - name
@@ -47,12 +49,14 @@ components:
           $ref: '#/components/schemas/IntegrationProxy'
 
     IntegrationProxy:
+      title: Proxy Integration
       type: object
       properties:
         enabled:
           type: boolean
 
     IntegrationRead:
+      title: Read Integration
       type: object
       properties:
         objects:
@@ -61,6 +65,7 @@ components:
             $ref: '#/components/schemas/IntegrationObject'
 
     IntegrationWrite:
+      title: Write Integration
       type: object
       properties:
         objects:
@@ -72,6 +77,7 @@ components:
     # Once we figure out whether to share the same type for both read and write, or use
     # different types, we can rename this to IntegrationReadObject if appropriate.
     IntegrationObject:
+      title: Integration Object
       type: object
       required:
         - objectName
@@ -113,6 +119,7 @@ components:
     # but for now we're introducing a new type to keep them separate, and not renaming the
     # existing IntegrationObject.
     IntegrationWriteObject:
+      title: Integration Write Object
       type: object
       required:
         - objectName
@@ -127,6 +134,7 @@ components:
           $ref: '#/components/schemas/ValueDefaults'
 
     HydratedIntegration:
+      title: Hydrated Integration
       type: object
       required:
         - name
@@ -146,12 +154,14 @@ components:
           $ref: '#/components/schemas/HydratedIntegrationProxy'
 
     HydratedIntegrationProxy:
+      title: Hydrated Proxy Integration
       type: object
       properties:
         enabled:
           type: boolean
 
     HydratedIntegrationRead:
+      title: Hydrated Read Integration
       type: object
       properties:
         objects:
@@ -171,6 +181,7 @@ components:
     # Once we figure out whether to share the same type for both read and write, or use
     # different types, we can rename this to HydratedIntegrationReadObject if appropriate.
     HydratedIntegrationObject:
+      title: Hydrated Integration Object
       type: object
       required:
         - objectName
@@ -236,15 +247,18 @@ components:
           $ref: '#/components/schemas/ValueDefaults'
 
     OptionalFieldsAutoOption:
+      title: Optional Fields Auto Option
       type: string
       enum: [all]
 
     IntegrationField:
+      title: Integration Field
       oneOf:
         - $ref: '#/components/schemas/IntegrationFieldExistent'
         - $ref: '#/components/schemas/IntegrationFieldMapping'
 
     IntegrationFieldExistent:
+      title: Integration Field Existent
       type: object
       required:
         - fieldName
@@ -263,6 +277,7 @@ components:
           x-go-type-skip-optional-pointer: true
 
     IntegrationFieldMapping:
+      title: Integration Field Mapping
       type: object
       required:
         - mapToName
@@ -277,11 +292,13 @@ components:
           type: string
 
     HydratedIntegrationField:
+      title: Hydrated Integration Field
       oneOf:
         - $ref: '#/components/schemas/HydratedIntegrationFieldExistent'
         - $ref: '#/components/schemas/IntegrationFieldMapping'
 
     FieldMetadata:
+      title: Field Metadata
       type: object
       required:
         - fieldName
@@ -327,6 +344,7 @@ components:
             $ref: '#/components/schemas/FieldValue'
 
     FieldValue:
+      title: Field Value
       type: object
       required:
         - value
@@ -364,6 +382,7 @@ components:
           x-go-type-skip-optional-pointer: true
 
     Backfill:
+      title: Backfill
       type: object
       required:
         - defaultPeriod
@@ -372,6 +391,7 @@ components:
           $ref: '#/components/schemas/DefaultPeriod'
 
     DefaultPeriod:
+      title: Default Period
       type: object
       properties:
         days:
@@ -389,6 +409,7 @@ components:
             validate: required_without=Days
 
     Delivery:
+      title: Delivery
       type: object
       properties:
         mode:
@@ -403,6 +424,7 @@ components:
             maximum: 500
 
     ValueDefaults:
+      title: Value Defaults
       type: object
       description: Configuration to set default write values for object fields.
       properties:

--- a/problem/problem.yaml
+++ b/problem/problem.yaml
@@ -23,6 +23,7 @@ components:
       description: A problem caused by invalid input
   schemas:
     Problem:
+      title: Problem
       description: |
         A Problem Details object (RFC 9457).
 
@@ -65,6 +66,7 @@ components:
         detail: Description of specific occurrence of the problem
         instance: urn:uuid:123e4567-e89b-12d3-a456-426614174000
     ApiProblem:
+      title: API Problem
       type: object
       allOf:
         - $ref: "#/components/schemas/Problem"
@@ -129,6 +131,7 @@ components:
           example:
             name: "Rick Sanchez"
     InputValidationProblem:
+      title: Input Validation Problem
       type: object
       allOf:
         - $ref: "#/components/schemas/ApiProblem"
@@ -156,6 +159,7 @@ components:
             name: items[0].examplePropertyWithPattern # location within the body
             value: "a2345678901"
     InputValidationIssue:
+      title: Input Validation Issue
       type: object
       description: |
         An issue detected during input validation.

--- a/webhook/webhook.yaml
+++ b/webhook/webhook.yaml
@@ -12,6 +12,7 @@ paths: {}
 components:
   schemas:
     WebhookMessage:
+      title: Webhook Message
       type: object
       required:
         - action
@@ -65,6 +66,7 @@ components:
           items:
             $ref: '#/components/schemas/ResultEntry'
     Association:
+      title: Association
       type: object
       properties:
         id:
@@ -72,6 +74,7 @@ components:
           type: string
           x-go-type-skip-optional-pointer: true
     ResultEntry:
+      title: Result Entry
       type: object
       description: Each ResultEntry corresponds with a record in the SaaS provider (e.g. a Salesforce Account).
       properties:
@@ -122,6 +125,7 @@ components:
           type: string
 
     ResultInfo:
+      title: Result Info
       type: object
       description: Information about the result contained in the webhook message.
       required:
@@ -129,8 +133,8 @@ components:
         - numRecords
       properties:
         type:
-          description: "The type of the result. Can be 'url' or 'inline'. If url, a downloadUrl field will also be 
-          present, which contains a URL to download the result. Else, the result is contained in the message itself in 
+          description: "The type of the result. Can be 'url' or 'inline'. If url, a downloadUrl field will also be
+          present, which contains a URL to download the result. Else, the result is contained in the message itself in
           the 'result' field."
           type: string
           enum: [url, inline]


### PR DESCRIPTION
Speakeasy uses titles for generating class names, adding these to make the class names better