### PR TITLE
fix: oauth-update patch request

### DIFF
--- a/api/api.yaml
+++ b/api/api.yaml
@@ -80,8 +80,8 @@ paths:
               schema:
                 $ref: "../problem/problem.yaml#/components/schemas/ApiProblem"
       x-codegen-request-body-name: connectOAuthParams
-  /projects/{projectIdOrName}/connections/{connectionId}/oauth-update:
-    post:
+  /projects/{projectIdOrName}/connections/{connectionId}:oauth-update:
+    patch:
       operationId: oauthUpdate
       summary: Get URL for updating OAuth connection
       description: Generate a URL for the browser to render to kick off OAuth flow that updates an existing connection.

--- a/api/generated/api.json
+++ b/api/generated/api.json
@@ -554,8 +554,8 @@
         "x-codegen-request-body-name": "connectOAuthParams"
       }
     },
-    "/projects/{projectIdOrName}/connections/{connectionId}/oauth-update": {
-      "post": {
+    "/projects/{projectIdOrName}/connections/{connectionId}:oauth-update": {
+      "patch": {
         "operationId": "oauthUpdate",
         "summary": "Get URL for updating OAuth connection",
         "description": "Generate a URL for the browser to render to kick off OAuth flow that updates an existing connection.",


### PR DESCRIPTION
 ### Summary 
switches oauth update to use a patch requests and updates path.
- relaxes pnpm dep to allow version 10