### PR TITLE
feat: Add credentialsHealthCheck

### DIFF
--- a/api/generated/api.json
+++ b/api/generated/api.json
@@ -25547,6 +25547,39 @@
                           "type": "string"
                         }
                       },
+                      "credentialsHealthCheck": {
+                        "title": "Credentials Health Check",
+                        "type": "object",
+                        "description": "An endpoint to check the health of a provider's credentials. It's used to see if the credentials are valid and if the provider is reachable.",
+                        "required": [
+                          "endpoint"
+                        ],
+                        "properties": {
+                          "endpoint": {
+                            "type": "string",
+                            "description": "a no-op endpoint to check the health of the credentials. The endpoint MUST not mutate any state. If the provider doesn't have such an endpoint, then don't provide credentialsHealthCheck.",
+                            "example": "https://api.example.com/health-check"
+                          },
+                          "method": {
+                            "type": "string",
+                            "description": "The HTTP method to use for the health check. If not set, defaults to GET.",
+                            "example": "GET",
+                            "x-go-type-skip-optional-pointer": true
+                          },
+                          "successStatusCodes": {
+                            "type": "array",
+                            "items": {
+                              "type": "integer"
+                            },
+                            "description": "The HTTP status codes that indicate a successful health check. If not set, defaults to 200 and 204.",
+                            "example": [
+                              200,
+                              204
+                            ],
+                            "x-go-type-skip-optional-pointer": true
+                          }
+                        }
+                      },
                       "displayName": {
                         "type": "string",
                         "example": "Zendesk Chat",
@@ -26323,6 +26356,39 @@
                       "type": "object",
                       "additionalProperties": {
                         "type": "string"
+                      }
+                    },
+                    "credentialsHealthCheck": {
+                      "title": "Credentials Health Check",
+                      "type": "object",
+                      "description": "An endpoint to check the health of a provider's credentials. It's used to see if the credentials are valid and if the provider is reachable.",
+                      "required": [
+                        "endpoint"
+                      ],
+                      "properties": {
+                        "endpoint": {
+                          "type": "string",
+                          "description": "a no-op endpoint to check the health of the credentials. The endpoint MUST not mutate any state. If the provider doesn't have such an endpoint, then don't provide credentialsHealthCheck.",
+                          "example": "https://api.example.com/health-check"
+                        },
+                        "method": {
+                          "type": "string",
+                          "description": "The HTTP method to use for the health check. If not set, defaults to GET.",
+                          "example": "GET",
+                          "x-go-type-skip-optional-pointer": true
+                        },
+                        "successStatusCodes": {
+                          "type": "array",
+                          "items": {
+                            "type": "integer"
+                          },
+                          "description": "The HTTP status codes that indicate a successful health check. If not set, defaults to 200 and 204.",
+                          "example": [
+                            200,
+                            204
+                          ],
+                          "x-go-type-skip-optional-pointer": true
+                        }
                       }
                     },
                     "displayName": {

--- a/api/generated/api.json
+++ b/api/generated/api.json
@@ -25547,17 +25547,17 @@
                           "type": "string"
                         }
                       },
-                      "credentialsHealthCheck": {
-                        "title": "Credentials Health Check",
+                      "authHealthCheck": {
+                        "title": "Auth Health Check",
                         "type": "object",
-                        "description": "An endpoint to check the health of a provider's credentials. It's used to see if the credentials are valid and if the provider is reachable.",
+                        "description": "A URL to check the health of a provider's credentials. It's used to see if the credentials are valid and if the provider is reachable.",
                         "required": [
-                          "endpoint"
+                          "url"
                         ],
                         "properties": {
-                          "endpoint": {
+                          "url": {
                             "type": "string",
-                            "description": "a no-op endpoint to check the health of the credentials. The endpoint MUST not mutate any state. If the provider doesn't have such an endpoint, then don't provide credentialsHealthCheck.",
+                            "description": "a no-op URL to check the health of the credentials. The URL MUST not mutate any state. If the provider doesn't have such an endpoint, then don't provide credentialsHealthCheck.",
                             "example": "https://api.example.com/health-check"
                           },
                           "method": {
@@ -26358,17 +26358,17 @@
                         "type": "string"
                       }
                     },
-                    "credentialsHealthCheck": {
-                      "title": "Credentials Health Check",
+                    "authHealthCheck": {
+                      "title": "Auth Health Check",
                       "type": "object",
-                      "description": "An endpoint to check the health of a provider's credentials. It's used to see if the credentials are valid and if the provider is reachable.",
+                      "description": "A URL to check the health of a provider's credentials. It's used to see if the credentials are valid and if the provider is reachable.",
                       "required": [
-                        "endpoint"
+                        "url"
                       ],
                       "properties": {
-                        "endpoint": {
+                        "url": {
                           "type": "string",
-                          "description": "a no-op endpoint to check the health of the credentials. The endpoint MUST not mutate any state. If the provider doesn't have such an endpoint, then don't provide credentialsHealthCheck.",
+                          "description": "a no-op URL to check the health of the credentials. The URL MUST not mutate any state. If the provider doesn't have such an endpoint, then don't provide credentialsHealthCheck.",
                           "example": "https://api.example.com/health-check"
                         },
                         "method": {

--- a/catalog/catalog.yaml
+++ b/catalog/catalog.yaml
@@ -309,6 +309,30 @@ components:
           example: https://docs.example.com/api-key
           x-go-type-skip-optional-pointer: true
 
+    CredentialsHealthCheck:
+      title: Credentials Health Check
+      type: object
+      description: An endpoint to check the health of a provider's credentials. It's used to see if the credentials are valid and if the provider is reachable.
+      required:
+        - endpoint
+      properties:
+        endpoint:
+          type: string
+          description: a no-op endpoint to check the health of the credentials. The endpoint MUST not mutate any state. If the provider doesn't have such an endpoint, then don't provide credentialsHealthCheck.
+          example: https://api.example.com/health-check
+        method:
+          type: string
+          description: The HTTP method to use for the health check. If not set, defaults to GET.
+          example: GET
+          x-go-type-skip-optional-pointer: true
+        successStatusCodes:
+          type: array
+          items:
+            type: integer
+          description: The HTTP status codes that indicate a successful health check. If not set, defaults to 200 and 204.
+          example: [200, 204]
+          x-go-type-skip-optional-pointer: true
+
     Modules:
       title: Modules that this provider supports
       type: object
@@ -377,6 +401,8 @@ components:
           $ref: '#/components/schemas/Support'
         providerOpts:
           $ref: '#/components/schemas/ProviderOpts'
+        credentialsHealthCheck:
+          $ref: '#/components/schemas/CredentialsHealthCheck'
         displayName:
           type: string
           example: Zendesk Chat

--- a/catalog/catalog.yaml
+++ b/catalog/catalog.yaml
@@ -309,16 +309,16 @@ components:
           example: https://docs.example.com/api-key
           x-go-type-skip-optional-pointer: true
 
-    CredentialsHealthCheck:
-      title: Credentials Health Check
+    AuthHealthCheck:
+      title: Auth Health Check
       type: object
-      description: An endpoint to check the health of a provider's credentials. It's used to see if the credentials are valid and if the provider is reachable.
+      description: A URL to check the health of a provider's credentials. It's used to see if the credentials are valid and if the provider is reachable.
       required:
-        - endpoint
+        - url
       properties:
-        endpoint:
+        url:
           type: string
-          description: a no-op endpoint to check the health of the credentials. The endpoint MUST not mutate any state. If the provider doesn't have such an endpoint, then don't provide credentialsHealthCheck.
+          description: a no-op URL to check the health of the credentials. The URL MUST not mutate any state. If the provider doesn't have such an endpoint, then don't provide credentialsHealthCheck.
           example: https://api.example.com/health-check
         method:
           type: string
@@ -401,8 +401,8 @@ components:
           $ref: '#/components/schemas/Support'
         providerOpts:
           $ref: '#/components/schemas/ProviderOpts'
-        credentialsHealthCheck:
-          $ref: '#/components/schemas/CredentialsHealthCheck'
+        authHealthCheck:
+          $ref: '#/components/schemas/AuthHealthCheck'
         displayName:
           type: string
           example: Zendesk Chat

--- a/catalog/generated/catalog.json
+++ b/catalog/generated/catalog.json
@@ -604,6 +604,39 @@
           }
         }
       },
+      "CredentialsHealthCheck": {
+        "title": "Credentials Health Check",
+        "type": "object",
+        "description": "An endpoint to check the health of a provider's credentials. It's used to see if the credentials are valid and if the provider is reachable.",
+        "required": [
+          "endpoint"
+        ],
+        "properties": {
+          "endpoint": {
+            "type": "string",
+            "description": "a no-op endpoint to check the health of the credentials. The endpoint MUST not mutate any state. If the provider doesn't have such an endpoint, then don't provide credentialsHealthCheck.",
+            "example": "https://api.example.com/health-check"
+          },
+          "method": {
+            "type": "string",
+            "description": "The HTTP method to use for the health check. If not set, defaults to GET.",
+            "example": "GET",
+            "x-go-type-skip-optional-pointer": true
+          },
+          "successStatusCodes": {
+            "type": "array",
+            "items": {
+              "type": "integer"
+            },
+            "description": "The HTTP status codes that indicate a successful health check. If not set, defaults to 200 and 204.",
+            "example": [
+              200,
+              204
+            ],
+            "x-go-type-skip-optional-pointer": true
+          }
+        }
+      },
       "Modules": {
         "title": "Modules that this provider supports",
         "type": "object",
@@ -1163,6 +1196,39 @@
             "type": "object",
             "additionalProperties": {
               "type": "string"
+            }
+          },
+          "credentialsHealthCheck": {
+            "title": "Credentials Health Check",
+            "type": "object",
+            "description": "An endpoint to check the health of a provider's credentials. It's used to see if the credentials are valid and if the provider is reachable.",
+            "required": [
+              "endpoint"
+            ],
+            "properties": {
+              "endpoint": {
+                "type": "string",
+                "description": "a no-op endpoint to check the health of the credentials. The endpoint MUST not mutate any state. If the provider doesn't have such an endpoint, then don't provide credentialsHealthCheck.",
+                "example": "https://api.example.com/health-check"
+              },
+              "method": {
+                "type": "string",
+                "description": "The HTTP method to use for the health check. If not set, defaults to GET.",
+                "example": "GET",
+                "x-go-type-skip-optional-pointer": true
+              },
+              "successStatusCodes": {
+                "type": "array",
+                "items": {
+                  "type": "integer"
+                },
+                "description": "The HTTP status codes that indicate a successful health check. If not set, defaults to 200 and 204.",
+                "example": [
+                  200,
+                  204
+                ],
+                "x-go-type-skip-optional-pointer": true
+              }
             }
           },
           "displayName": {
@@ -1796,6 +1862,39 @@
                     "type": "string"
                   }
                 },
+                "credentialsHealthCheck": {
+                  "title": "Credentials Health Check",
+                  "type": "object",
+                  "description": "An endpoint to check the health of a provider's credentials. It's used to see if the credentials are valid and if the provider is reachable.",
+                  "required": [
+                    "endpoint"
+                  ],
+                  "properties": {
+                    "endpoint": {
+                      "type": "string",
+                      "description": "a no-op endpoint to check the health of the credentials. The endpoint MUST not mutate any state. If the provider doesn't have such an endpoint, then don't provide credentialsHealthCheck.",
+                      "example": "https://api.example.com/health-check"
+                    },
+                    "method": {
+                      "type": "string",
+                      "description": "The HTTP method to use for the health check. If not set, defaults to GET.",
+                      "example": "GET",
+                      "x-go-type-skip-optional-pointer": true
+                    },
+                    "successStatusCodes": {
+                      "type": "array",
+                      "items": {
+                        "type": "integer"
+                      },
+                      "description": "The HTTP status codes that indicate a successful health check. If not set, defaults to 200 and 204.",
+                      "example": [
+                        200,
+                        204
+                      ],
+                      "x-go-type-skip-optional-pointer": true
+                    }
+                  }
+                },
                 "displayName": {
                   "type": "string",
                   "example": "Zendesk Chat",
@@ -2412,6 +2511,39 @@
               "type": "object",
               "additionalProperties": {
                 "type": "string"
+              }
+            },
+            "credentialsHealthCheck": {
+              "title": "Credentials Health Check",
+              "type": "object",
+              "description": "An endpoint to check the health of a provider's credentials. It's used to see if the credentials are valid and if the provider is reachable.",
+              "required": [
+                "endpoint"
+              ],
+              "properties": {
+                "endpoint": {
+                  "type": "string",
+                  "description": "a no-op endpoint to check the health of the credentials. The endpoint MUST not mutate any state. If the provider doesn't have such an endpoint, then don't provide credentialsHealthCheck.",
+                  "example": "https://api.example.com/health-check"
+                },
+                "method": {
+                  "type": "string",
+                  "description": "The HTTP method to use for the health check. If not set, defaults to GET.",
+                  "example": "GET",
+                  "x-go-type-skip-optional-pointer": true
+                },
+                "successStatusCodes": {
+                  "type": "array",
+                  "items": {
+                    "type": "integer"
+                  },
+                  "description": "The HTTP status codes that indicate a successful health check. If not set, defaults to 200 and 204.",
+                  "example": [
+                    200,
+                    204
+                  ],
+                  "x-go-type-skip-optional-pointer": true
+                }
               }
             },
             "displayName": {

--- a/catalog/generated/catalog.json
+++ b/catalog/generated/catalog.json
@@ -604,17 +604,17 @@
           }
         }
       },
-      "CredentialsHealthCheck": {
-        "title": "Credentials Health Check",
+      "AuthHealthCheck": {
+        "title": "Auth Health Check",
         "type": "object",
-        "description": "An endpoint to check the health of a provider's credentials. It's used to see if the credentials are valid and if the provider is reachable.",
+        "description": "A URL to check the health of a provider's credentials. It's used to see if the credentials are valid and if the provider is reachable.",
         "required": [
-          "endpoint"
+          "url"
         ],
         "properties": {
-          "endpoint": {
+          "url": {
             "type": "string",
-            "description": "a no-op endpoint to check the health of the credentials. The endpoint MUST not mutate any state. If the provider doesn't have such an endpoint, then don't provide credentialsHealthCheck.",
+            "description": "a no-op URL to check the health of the credentials. The URL MUST not mutate any state. If the provider doesn't have such an endpoint, then don't provide credentialsHealthCheck.",
             "example": "https://api.example.com/health-check"
           },
           "method": {
@@ -1198,17 +1198,17 @@
               "type": "string"
             }
           },
-          "credentialsHealthCheck": {
-            "title": "Credentials Health Check",
+          "authHealthCheck": {
+            "title": "Auth Health Check",
             "type": "object",
-            "description": "An endpoint to check the health of a provider's credentials. It's used to see if the credentials are valid and if the provider is reachable.",
+            "description": "A URL to check the health of a provider's credentials. It's used to see if the credentials are valid and if the provider is reachable.",
             "required": [
-              "endpoint"
+              "url"
             ],
             "properties": {
-              "endpoint": {
+              "url": {
                 "type": "string",
-                "description": "a no-op endpoint to check the health of the credentials. The endpoint MUST not mutate any state. If the provider doesn't have such an endpoint, then don't provide credentialsHealthCheck.",
+                "description": "a no-op URL to check the health of the credentials. The URL MUST not mutate any state. If the provider doesn't have such an endpoint, then don't provide credentialsHealthCheck.",
                 "example": "https://api.example.com/health-check"
               },
               "method": {
@@ -1862,17 +1862,17 @@
                     "type": "string"
                   }
                 },
-                "credentialsHealthCheck": {
-                  "title": "Credentials Health Check",
+                "authHealthCheck": {
+                  "title": "Auth Health Check",
                   "type": "object",
-                  "description": "An endpoint to check the health of a provider's credentials. It's used to see if the credentials are valid and if the provider is reachable.",
+                  "description": "A URL to check the health of a provider's credentials. It's used to see if the credentials are valid and if the provider is reachable.",
                   "required": [
-                    "endpoint"
+                    "url"
                   ],
                   "properties": {
-                    "endpoint": {
+                    "url": {
                       "type": "string",
-                      "description": "a no-op endpoint to check the health of the credentials. The endpoint MUST not mutate any state. If the provider doesn't have such an endpoint, then don't provide credentialsHealthCheck.",
+                      "description": "a no-op URL to check the health of the credentials. The URL MUST not mutate any state. If the provider doesn't have such an endpoint, then don't provide credentialsHealthCheck.",
                       "example": "https://api.example.com/health-check"
                     },
                     "method": {
@@ -2513,17 +2513,17 @@
                 "type": "string"
               }
             },
-            "credentialsHealthCheck": {
-              "title": "Credentials Health Check",
+            "authHealthCheck": {
+              "title": "Auth Health Check",
               "type": "object",
-              "description": "An endpoint to check the health of a provider's credentials. It's used to see if the credentials are valid and if the provider is reachable.",
+              "description": "A URL to check the health of a provider's credentials. It's used to see if the credentials are valid and if the provider is reachable.",
               "required": [
-                "endpoint"
+                "url"
               ],
               "properties": {
-                "endpoint": {
+                "url": {
                   "type": "string",
-                  "description": "a no-op endpoint to check the health of the credentials. The endpoint MUST not mutate any state. If the provider doesn't have such an endpoint, then don't provide credentialsHealthCheck.",
+                  "description": "a no-op URL to check the health of the credentials. The URL MUST not mutate any state. If the provider doesn't have such an endpoint, then don't provide credentialsHealthCheck.",
                   "example": "https://api.example.com/health-check"
                 },
                 "method": {


### PR DESCRIPTION
Something I've noticed is that customers will authenticate, and the oauth flow will complete, but they gave us the wrong workspace name. We won't notice this until after the auth process (e.g. during a read, or during a subscribe webhook). This is obviously inconvenient to debug, and un-intuitive from a UX perspective. It would be much more intuitive to take the credentials and then immediately try an endpoint, to know for 100% certain that all the details we have are going to work. And obviously if it fails, we can return a 4xx status to let the caller know that there's something wrong and the connection won't work.

This adds an optional endpoint the catalog can specify which will eventually be used during the auth process. Once we get a token (or an API key or whatever) we can hit this endpoint to test that everything is working.

It would also be handy to have this so that we can run a scheduled job to test credentials, to make sure they're still valid (would obviously also do the obligatory refreshes as needed). This is different than the current scheduled job because it would work for all credential types.

Worth noting this is optional. If a provider doesn't specify this, we just act the way we do right now.