### PR TITLE
chore: use two keys for token metadata extraction

### DIFF
--- a/api/generated/api.json
+++ b/api/generated/api.json
@@ -22286,7 +22286,7 @@
                                   "required": [
                                     "name",
                                     "displayName",
-                                    "jqValueSelector"
+                                    "path"
                                   ],
                                   "properties": {
                                     "name": {
@@ -22299,10 +22299,16 @@
                                       "description": "The human-readable name of the field",
                                       "x-go-type-skip-optional-pointer": true
                                     },
-                                    "jqValueSelector": {
+                                    "path": {
                                       "type": "string",
-                                      "description": "jq expression that extracts and transforms the value from the token response",
-                                      "example": ".instance_url | capture(\"https://([^.]+)\\.docusign\\.net\") | .[0]",
+                                      "description": "The path to the field in the token response (accepts dot notation for nested fields)",
+                                      "example": "owner.siteId",
+                                      "x-go-type-skip-optional-pointer": true
+                                    },
+                                    "capture": {
+                                      "type": "string",
+                                      "description": "A regex expression to capture the value that we need from the path",
+                                      "example": "https:\\/\\/([^.]+)\\.docusign\\.net",
                                       "x-go-type-skip-optional-pointer": true
                                     }
                                   }
@@ -23064,7 +23070,7 @@
                                 "required": [
                                   "name",
                                   "displayName",
-                                  "jqValueSelector"
+                                  "path"
                                 ],
                                 "properties": {
                                   "name": {
@@ -23077,10 +23083,16 @@
                                     "description": "The human-readable name of the field",
                                     "x-go-type-skip-optional-pointer": true
                                   },
-                                  "jqValueSelector": {
+                                  "path": {
                                     "type": "string",
-                                    "description": "jq expression that extracts and transforms the value from the token response",
-                                    "example": ".instance_url | capture(\"https://([^.]+)\\.docusign\\.net\") | .[0]",
+                                    "description": "The path to the field in the token response (accepts dot notation for nested fields)",
+                                    "example": "owner.siteId",
+                                    "x-go-type-skip-optional-pointer": true
+                                  },
+                                  "capture": {
+                                    "type": "string",
+                                    "description": "A regex expression to capture the value that we need from the path",
+                                    "example": "https:\\/\\/([^.]+)\\.docusign\\.net",
                                     "x-go-type-skip-optional-pointer": true
                                   }
                                 }

--- a/catalog/catalog.yaml
+++ b/catalog/catalog.yaml
@@ -107,7 +107,7 @@ components:
         required:
           - name
           - displayName
-          - jqValueSelector
+          - path
         properties:
           name:
             type: string
@@ -117,10 +117,15 @@ components:
             type: string
             description: The human-readable name of the field
             x-go-type-skip-optional-pointer: true
-          jqValueSelector:
+          path:
             type: string
-            description: jq expression that extracts and transforms the value from the token response
-            example: ".instance_url | capture(\"https://([^.]+)\\.docusign\\.net\") | .[0]"
+            description: The path to the field in the token response (accepts dot notation for nested fields)
+            example: "owner.siteId"
+            x-go-type-skip-optional-pointer: true
+          capture:
+            type: string
+            description: A regex expression to capture the value that we need from the path
+            example: https:\/\/([^.]+)\.docusign\.net
             x-go-type-skip-optional-pointer: true
 
     MediaTypeDarkMode:
@@ -490,7 +495,6 @@ components:
           description: URL with more information about how to locate this value
           example: https://example.com/how-to-find-subdomain
           x-go-type-skip-optional-pointer: true
-
     MetadataItemPostAuthentication:
       title: Metadata Item (fetched post authentication)
       type: object

--- a/catalog/generated/catalog.json
+++ b/catalog/generated/catalog.json
@@ -157,7 +157,7 @@
               "required": [
                 "name",
                 "displayName",
-                "jqValueSelector"
+                "path"
               ],
               "properties": {
                 "name": {
@@ -170,10 +170,16 @@
                   "description": "The human-readable name of the field",
                   "x-go-type-skip-optional-pointer": true
                 },
-                "jqValueSelector": {
+                "path": {
                   "type": "string",
-                  "description": "jq expression that extracts and transforms the value from the token response",
-                  "example": ".instance_url | capture(\"https://([^.]+)\\.docusign\\.net\") | .[0]",
+                  "description": "The path to the field in the token response (accepts dot notation for nested fields)",
+                  "example": "owner.siteId",
+                  "x-go-type-skip-optional-pointer": true
+                },
+                "capture": {
+                  "type": "string",
+                  "description": "A regex expression to capture the value that we need from the path",
+                  "example": "https:\\/\\/([^.]+)\\.docusign\\.net",
                   "x-go-type-skip-optional-pointer": true
                 }
               }
@@ -233,7 +239,7 @@
           "required": [
             "name",
             "displayName",
-            "jqValueSelector"
+            "path"
           ],
           "properties": {
             "name": {
@@ -246,10 +252,16 @@
               "description": "The human-readable name of the field",
               "x-go-type-skip-optional-pointer": true
             },
-            "jqValueSelector": {
+            "path": {
               "type": "string",
-              "description": "jq expression that extracts and transforms the value from the token response",
-              "example": ".instance_url | capture(\"https://([^.]+)\\.docusign\\.net\") | .[0]",
+              "description": "The path to the field in the token response (accepts dot notation for nested fields)",
+              "example": "owner.siteId",
+              "x-go-type-skip-optional-pointer": true
+            },
+            "capture": {
+              "type": "string",
+              "description": "A regex expression to capture the value that we need from the path",
+              "example": "https:\\/\\/([^.]+)\\.docusign\\.net",
               "x-go-type-skip-optional-pointer": true
             }
           }
@@ -385,7 +397,7 @@
                   "required": [
                     "name",
                     "displayName",
-                    "jqValueSelector"
+                    "path"
                   ],
                   "properties": {
                     "name": {
@@ -398,10 +410,16 @@
                       "description": "The human-readable name of the field",
                       "x-go-type-skip-optional-pointer": true
                     },
-                    "jqValueSelector": {
+                    "path": {
                       "type": "string",
-                      "description": "jq expression that extracts and transforms the value from the token response",
-                      "example": ".instance_url | capture(\"https://([^.]+)\\.docusign\\.net\") | .[0]",
+                      "description": "The path to the field in the token response (accepts dot notation for nested fields)",
+                      "example": "owner.siteId",
+                      "x-go-type-skip-optional-pointer": true
+                    },
+                    "capture": {
+                      "type": "string",
+                      "description": "A regex expression to capture the value that we need from the path",
+                      "example": "https:\\/\\/([^.]+)\\.docusign\\.net",
                       "x-go-type-skip-optional-pointer": true
                     }
                   }
@@ -929,7 +947,7 @@
                       "required": [
                         "name",
                         "displayName",
-                        "jqValueSelector"
+                        "path"
                       ],
                       "properties": {
                         "name": {
@@ -942,10 +960,16 @@
                           "description": "The human-readable name of the field",
                           "x-go-type-skip-optional-pointer": true
                         },
-                        "jqValueSelector": {
+                        "path": {
                           "type": "string",
-                          "description": "jq expression that extracts and transforms the value from the token response",
-                          "example": ".instance_url | capture(\"https://([^.]+)\\.docusign\\.net\") | .[0]",
+                          "description": "The path to the field in the token response (accepts dot notation for nested fields)",
+                          "example": "owner.siteId",
+                          "x-go-type-skip-optional-pointer": true
+                        },
+                        "capture": {
+                          "type": "string",
+                          "description": "A regex expression to capture the value that we need from the path",
+                          "example": "https:\\/\\/([^.]+)\\.docusign\\.net",
                           "x-go-type-skip-optional-pointer": true
                         }
                       }
@@ -1560,7 +1584,7 @@
                             "required": [
                               "name",
                               "displayName",
-                              "jqValueSelector"
+                              "path"
                             ],
                             "properties": {
                               "name": {
@@ -1573,10 +1597,16 @@
                                 "description": "The human-readable name of the field",
                                 "x-go-type-skip-optional-pointer": true
                               },
-                              "jqValueSelector": {
+                              "path": {
                                 "type": "string",
-                                "description": "jq expression that extracts and transforms the value from the token response",
-                                "example": ".instance_url | capture(\"https://([^.]+)\\.docusign\\.net\") | .[0]",
+                                "description": "The path to the field in the token response (accepts dot notation for nested fields)",
+                                "example": "owner.siteId",
+                                "x-go-type-skip-optional-pointer": true
+                              },
+                              "capture": {
+                                "type": "string",
+                                "description": "A regex expression to capture the value that we need from the path",
+                                "example": "https:\\/\\/([^.]+)\\.docusign\\.net",
                                 "x-go-type-skip-optional-pointer": true
                               }
                             }
@@ -2178,7 +2208,7 @@
                         "required": [
                           "name",
                           "displayName",
-                          "jqValueSelector"
+                          "path"
                         ],
                         "properties": {
                           "name": {
@@ -2191,10 +2221,16 @@
                             "description": "The human-readable name of the field",
                             "x-go-type-skip-optional-pointer": true
                           },
-                          "jqValueSelector": {
+                          "path": {
                             "type": "string",
-                            "description": "jq expression that extracts and transforms the value from the token response",
-                            "example": ".instance_url | capture(\"https://([^.]+)\\.docusign\\.net\") | .[0]",
+                            "description": "The path to the field in the token response (accepts dot notation for nested fields)",
+                            "example": "owner.siteId",
+                            "x-go-type-skip-optional-pointer": true
+                          },
+                          "capture": {
+                            "type": "string",
+                            "description": "A regex expression to capture the value that we need from the path",
+                            "example": "https:\\/\\/([^.]+)\\.docusign\\.net",
                             "x-go-type-skip-optional-pointer": true
                           }
                         }


### PR DESCRIPTION
Unfortunately, the oauth2 package doesn't expose the raw token, so we cannot do a nice jq selection over it. We have to use a dot notation to access a specific field using the `token.Extra(metadataFieldPath)` helper that the package gives us, and then transform it.