### PR TITLE
Revert "Revert "fix: use $ref for read and write config""

### DIFF
--- a/api/generated/api.json
+++ b/api/generated/api.json
@@ -13283,10 +13283,581 @@
                                 ],
                                 "properties": {
                                   "read": {
-                                    "x-go-type": "ReadConfig"
+                                    "title": "Read Config",
+                                    "allOf": [
+                                      {
+                                        "title": "Base Read Config",
+                                        "type": "object",
+                                        "properties": {
+                                          "objects": {
+                                            "type": "object",
+                                            "description": "This is a map of object names to their configuration.",
+                                            "additionalProperties": {
+                                              "title": "Base Read Config Object",
+                                              "type": "object",
+                                              "properties": {
+                                                "objectName": {
+                                                  "description": "The name of the object to read from.",
+                                                  "example": "account",
+                                                  "type": "string",
+                                                  "x-oapi-codegen-extra-tags": {
+                                                    "validate": "required"
+                                                  }
+                                                },
+                                                "schedule": {
+                                                  "type": "string",
+                                                  "description": "The schedule for reading the object, in cron syntax.",
+                                                  "example": "*/15 * * * *"
+                                                },
+                                                "destination": {
+                                                  "description": "The name of the destination that the result should be sent to.",
+                                                  "example": "accountWebhook",
+                                                  "type": "string"
+                                                },
+                                                "selectedFields": {
+                                                  "type": "object",
+                                                  "description": "This is a map of field names to booleans indicating whether they should be read. If a field is already included in `selectedFieldMappings`, it does not need to be included here.",
+                                                  "example": "{ phone: true, fax: true }",
+                                                  "additionalProperties": {
+                                                    "type": "boolean"
+                                                  }
+                                                },
+                                                "selectedValueMappings": {
+                                                  "type": "object",
+                                                  "description": "This is a map of field names to their value mappings.",
+                                                  "example": {
+                                                    "stage": {
+                                                      "open": "scheduled",
+                                                      "closedWon": "won",
+                                                      "closedLost": "lost"
+                                                    }
+                                                  },
+                                                  "x-go-type-skip-optional-pointer": true,
+                                                  "additionalProperties": {
+                                                    "title": "Selected Value Mappings",
+                                                    "type": "object",
+                                                    "description": "This is a map of values to their mappings. The key is the value delivered to the webhook, the value is the value coming from the provider API.",
+                                                    "example": {
+                                                      "open": "scheduled",
+                                                      "closedWon": "won",
+                                                      "closedLost": "lost"
+                                                    },
+                                                    "x-go-type-skip-optional-pointer": true,
+                                                    "additionalProperties": {
+                                                      "type": "string"
+                                                    }
+                                                  }
+                                                },
+                                                "selectedFieldMappings": {
+                                                  "type": "object",
+                                                  "description": "This is a map of mapToNames to field names. (A mapTo name is the name the builder wants to map a field to when it lands in their destination.)",
+                                                  "example": "{ phoneNumber: phone, faxNumber: fax }",
+                                                  "additionalProperties": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "selectedFieldsAuto": {
+                                                  "title": "Selected Fields Auto Config",
+                                                  "description": "If selectedFieldsAuto is set to all, all fields will be read.",
+                                                  "type": "string",
+                                                  "enum": [
+                                                    "all"
+                                                  ],
+                                                  "x-enum-varnames": [
+                                                    "SelectedFieldsAll"
+                                                  ]
+                                                },
+                                                "backfill": {
+                                                  "title": "Backfill Config",
+                                                  "type": "object",
+                                                  "required": [
+                                                    "defaultPeriod"
+                                                  ],
+                                                  "properties": {
+                                                    "defaultPeriod": {
+                                                      "title": "Default Period Config",
+                                                      "type": "object",
+                                                      "properties": {
+                                                        "days": {
+                                                          "type": "integer",
+                                                          "description": "Number of days in past to backfill from. 0 is no backfill. e.g) if 10, then backfill last 10 days of data. Required if fullHistory is not set.",
+                                                          "minimum": 0,
+                                                          "example": 30,
+                                                          "x-oapi-codegen-extra-tags": {
+                                                            "validate": "required_without=FullHistory,omitempty,min=0"
+                                                          }
+                                                        },
+                                                        "fullHistory": {
+                                                          "type": "boolean",
+                                                          "description": "If true, backfill all history. Required if days is not set.",
+                                                          "example": false,
+                                                          "x-oapi-codegen-extra-tags": {
+                                                            "validate": "required_without=Days"
+                                                          }
+                                                        }
+                                                      }
+                                                    }
+                                                  }
+                                                }
+                                              }
+                                            }
+                                          }
+                                        }
+                                      },
+                                      {
+                                        "type": "object",
+                                        "required": [
+                                          "objects"
+                                        ],
+                                        "properties": {
+                                          "objects": {
+                                            "additionalProperties": {
+                                              "title": "Read Config Object",
+                                              "allOf": [
+                                                {
+                                                  "title": "Base Read Config Object",
+                                                  "type": "object",
+                                                  "properties": {
+                                                    "objectName": {
+                                                      "description": "The name of the object to read from.",
+                                                      "example": "account",
+                                                      "type": "string",
+                                                      "x-oapi-codegen-extra-tags": {
+                                                        "validate": "required"
+                                                      }
+                                                    },
+                                                    "schedule": {
+                                                      "type": "string",
+                                                      "description": "The schedule for reading the object, in cron syntax.",
+                                                      "example": "*/15 * * * *"
+                                                    },
+                                                    "destination": {
+                                                      "description": "The name of the destination that the result should be sent to.",
+                                                      "example": "accountWebhook",
+                                                      "type": "string"
+                                                    },
+                                                    "selectedFields": {
+                                                      "type": "object",
+                                                      "description": "This is a map of field names to booleans indicating whether they should be read. If a field is already included in `selectedFieldMappings`, it does not need to be included here.",
+                                                      "example": "{ phone: true, fax: true }",
+                                                      "additionalProperties": {
+                                                        "type": "boolean"
+                                                      }
+                                                    },
+                                                    "selectedValueMappings": {
+                                                      "type": "object",
+                                                      "description": "This is a map of field names to their value mappings.",
+                                                      "example": {
+                                                        "stage": {
+                                                          "open": "scheduled",
+                                                          "closedWon": "won",
+                                                          "closedLost": "lost"
+                                                        }
+                                                      },
+                                                      "x-go-type-skip-optional-pointer": true,
+                                                      "additionalProperties": {
+                                                        "title": "Selected Value Mappings",
+                                                        "type": "object",
+                                                        "description": "This is a map of values to their mappings. The key is the value delivered to the webhook, the value is the value coming from the provider API.",
+                                                        "example": {
+                                                          "open": "scheduled",
+                                                          "closedWon": "won",
+                                                          "closedLost": "lost"
+                                                        },
+                                                        "x-go-type-skip-optional-pointer": true,
+                                                        "additionalProperties": {
+                                                          "type": "string"
+                                                        }
+                                                      }
+                                                    },
+                                                    "selectedFieldMappings": {
+                                                      "type": "object",
+                                                      "description": "This is a map of mapToNames to field names. (A mapTo name is the name the builder wants to map a field to when it lands in their destination.)",
+                                                      "example": "{ phoneNumber: phone, faxNumber: fax }",
+                                                      "additionalProperties": {
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "selectedFieldsAuto": {
+                                                      "title": "Selected Fields Auto Config",
+                                                      "description": "If selectedFieldsAuto is set to all, all fields will be read.",
+                                                      "type": "string",
+                                                      "enum": [
+                                                        "all"
+                                                      ],
+                                                      "x-enum-varnames": [
+                                                        "SelectedFieldsAll"
+                                                      ]
+                                                    },
+                                                    "backfill": {
+                                                      "title": "Backfill Config",
+                                                      "type": "object",
+                                                      "required": [
+                                                        "defaultPeriod"
+                                                      ],
+                                                      "properties": {
+                                                        "defaultPeriod": {
+                                                          "title": "Default Period Config",
+                                                          "type": "object",
+                                                          "properties": {
+                                                            "days": {
+                                                              "type": "integer",
+                                                              "description": "Number of days in past to backfill from. 0 is no backfill. e.g) if 10, then backfill last 10 days of data. Required if fullHistory is not set.",
+                                                              "minimum": 0,
+                                                              "example": 30,
+                                                              "x-oapi-codegen-extra-tags": {
+                                                                "validate": "required_without=FullHistory,omitempty,min=0"
+                                                              }
+                                                            },
+                                                            "fullHistory": {
+                                                              "type": "boolean",
+                                                              "description": "If true, backfill all history. Required if days is not set.",
+                                                              "example": false,
+                                                              "x-oapi-codegen-extra-tags": {
+                                                                "validate": "required_without=Days"
+                                                              }
+                                                            }
+                                                          }
+                                                        }
+                                                      }
+                                                    }
+                                                  }
+                                                },
+                                                {
+                                                  "type": "object",
+                                                  "required": [
+                                                    "objectName",
+                                                    "schedule",
+                                                    "destination",
+                                                    "selectedFields",
+                                                    "selectedFieldMappings"
+                                                  ]
+                                                }
+                                              ]
+                                            }
+                                          }
+                                        }
+                                      }
+                                    ]
                                   },
                                   "write": {
-                                    "x-go-type": "WriteConfig"
+                                    "title": "Write Config",
+                                    "allOf": [
+                                      {
+                                        "title": "Base Write Config",
+                                        "type": "object",
+                                        "properties": {
+                                          "objects": {
+                                            "type": "object",
+                                            "description": "This is a map of object names to their configuration.",
+                                            "additionalProperties": {
+                                              "title": "Base Write Config Object",
+                                              "type": "object",
+                                              "required": [
+                                                "objectName"
+                                              ],
+                                              "properties": {
+                                                "objectName": {
+                                                  "description": "The name of the object to write to.",
+                                                  "example": "account",
+                                                  "type": "string",
+                                                  "x-oapi-codegen-extra-tags": {
+                                                    "validate": "required"
+                                                  }
+                                                },
+                                                "selectedValueDefaults": {
+                                                  "type": "object",
+                                                  "deprecated": true,
+                                                  "description": "This is a map of field names to default values. These values will be used when writing to the object.",
+                                                  "x-go-type-skip-optional-pointer": true,
+                                                  "additionalProperties": {
+                                                    "title": "Value Default (Legacy)",
+                                                    "deprecated": true,
+                                                    "x-go-type": "any",
+                                                    "oneOf": [
+                                                      {
+                                                        "title": "Value Default String",
+                                                        "type": "object",
+                                                        "required": [
+                                                          "value"
+                                                        ],
+                                                        "properties": {
+                                                          "value": {
+                                                            "type": "string",
+                                                            "description": "The value to be used as a default."
+                                                          },
+                                                          "applyOnUpdate": {
+                                                            "type": "string",
+                                                            "enum": [
+                                                              "always",
+                                                              "never"
+                                                            ],
+                                                            "description": "Whether the default value should be applied when updating a record.\nIf set to `always`, the default value will be applied when updating a record.\nIf set to `never`, the default value will not be applied when updating a record,\nonly when creating a record.\nIf unspecified, then `always` is assumed.\n"
+                                                          }
+                                                        }
+                                                      },
+                                                      {
+                                                        "title": "Value Default Integer",
+                                                        "type": "object",
+                                                        "required": [
+                                                          "value"
+                                                        ],
+                                                        "properties": {
+                                                          "value": {
+                                                            "type": "integer",
+                                                            "description": "The value to be used as a default."
+                                                          },
+                                                          "applyOnUpdate": {
+                                                            "type": "string",
+                                                            "enum": [
+                                                              "always",
+                                                              "never"
+                                                            ],
+                                                            "description": "Whether the default value should be applied when updating a record.\nIf set to `always`, the default value will be applied when updating a record.\nIf set to `never`, the default value will not be applied when updating a record,\nonly when creating a record.\nIf unspecified, then `always` is assumed.\n"
+                                                          }
+                                                        }
+                                                      },
+                                                      {
+                                                        "title": "Value Default Boolean",
+                                                        "type": "object",
+                                                        "required": [
+                                                          "value"
+                                                        ],
+                                                        "properties": {
+                                                          "value": {
+                                                            "type": "boolean",
+                                                            "description": "The value to be used as a default."
+                                                          },
+                                                          "applyOnUpdate": {
+                                                            "type": "string",
+                                                            "enum": [
+                                                              "always",
+                                                              "never"
+                                                            ],
+                                                            "description": "Whether the default value should be applied when updating a record.\nIf set to `always`, the default value will be applied when updating a record.\nIf set to `never`, the default value will not be applied when updating a record,\nonly when creating a record.\nIf unspecified, then `always` is assumed.\n"
+                                                          }
+                                                        }
+                                                      }
+                                                    ]
+                                                  }
+                                                },
+                                                "selectedFieldSettings": {
+                                                  "type": "object",
+                                                  "description": "This is a map of field names to their settings.",
+                                                  "x-go-type-skip-optional-pointer": true,
+                                                  "additionalProperties": {
+                                                    "title": "Field setting",
+                                                    "type": "object",
+                                                    "properties": {
+                                                      "default": {
+                                                        "title": "Default value for a field",
+                                                        "description": "Only use one of stringValue, integerValue, booleanValue.",
+                                                        "type": "object",
+                                                        "properties": {
+                                                          "stringValue": {
+                                                            "type": "string",
+                                                            "description": "The default string value to apply to a field"
+                                                          },
+                                                          "integerValue": {
+                                                            "type": "integer",
+                                                            "description": "The default integer value to apply to a field"
+                                                          },
+                                                          "booleanValue": {
+                                                            "type": "boolean",
+                                                            "description": "The default boolean value to apply to a field"
+                                                          }
+                                                        }
+                                                      },
+                                                      "writeOnCreate": {
+                                                        "type": "string",
+                                                        "enum": [
+                                                          "always",
+                                                          "never"
+                                                        ],
+                                                        "default": "always",
+                                                        "x-go-type-skip-optional-pointer": true,
+                                                        "description": "Whether the default value should be applied when creating a record."
+                                                      },
+                                                      "writeOnUpdate": {
+                                                        "type": "string",
+                                                        "enum": [
+                                                          "always",
+                                                          "never"
+                                                        ],
+                                                        "default": "always",
+                                                        "x-go-type-skip-optional-pointer": true,
+                                                        "description": "Whether the default value should be applied when updating a record."
+                                                      }
+                                                    }
+                                                  }
+                                                }
+                                              }
+                                            }
+                                          }
+                                        }
+                                      },
+                                      {
+                                        "type": "object",
+                                        "properties": {
+                                          "objects": {
+                                            "additionalProperties": {
+                                              "title": "Write Config Object",
+                                              "allOf": [
+                                                {
+                                                  "title": "Base Write Config Object",
+                                                  "type": "object",
+                                                  "required": [
+                                                    "objectName"
+                                                  ],
+                                                  "properties": {
+                                                    "objectName": {
+                                                      "description": "The name of the object to write to.",
+                                                      "example": "account",
+                                                      "type": "string",
+                                                      "x-oapi-codegen-extra-tags": {
+                                                        "validate": "required"
+                                                      }
+                                                    },
+                                                    "selectedValueDefaults": {
+                                                      "type": "object",
+                                                      "deprecated": true,
+                                                      "description": "This is a map of field names to default values. These values will be used when writing to the object.",
+                                                      "x-go-type-skip-optional-pointer": true,
+                                                      "additionalProperties": {
+                                                        "title": "Value Default (Legacy)",
+                                                        "deprecated": true,
+                                                        "x-go-type": "any",
+                                                        "oneOf": [
+                                                          {
+                                                            "title": "Value Default String",
+                                                            "type": "object",
+                                                            "required": [
+                                                              "value"
+                                                            ],
+                                                            "properties": {
+                                                              "value": {
+                                                                "type": "string",
+                                                                "description": "The value to be used as a default."
+                                                              },
+                                                              "applyOnUpdate": {
+                                                                "type": "string",
+                                                                "enum": [
+                                                                  "always",
+                                                                  "never"
+                                                                ],
+                                                                "description": "Whether the default value should be applied when updating a record.\nIf set to `always`, the default value will be applied when updating a record.\nIf set to `never`, the default value will not be applied when updating a record,\nonly when creating a record.\nIf unspecified, then `always` is assumed.\n"
+                                                              }
+                                                            }
+                                                          },
+                                                          {
+                                                            "title": "Value Default Integer",
+                                                            "type": "object",
+                                                            "required": [
+                                                              "value"
+                                                            ],
+                                                            "properties": {
+                                                              "value": {
+                                                                "type": "integer",
+                                                                "description": "The value to be used as a default."
+                                                              },
+                                                              "applyOnUpdate": {
+                                                                "type": "string",
+                                                                "enum": [
+                                                                  "always",
+                                                                  "never"
+                                                                ],
+                                                                "description": "Whether the default value should be applied when updating a record.\nIf set to `always`, the default value will be applied when updating a record.\nIf set to `never`, the default value will not be applied when updating a record,\nonly when creating a record.\nIf unspecified, then `always` is assumed.\n"
+                                                              }
+                                                            }
+                                                          },
+                                                          {
+                                                            "title": "Value Default Boolean",
+                                                            "type": "object",
+                                                            "required": [
+                                                              "value"
+                                                            ],
+                                                            "properties": {
+                                                              "value": {
+                                                                "type": "boolean",
+                                                                "description": "The value to be used as a default."
+                                                              },
+                                                              "applyOnUpdate": {
+                                                                "type": "string",
+                                                                "enum": [
+                                                                  "always",
+                                                                  "never"
+                                                                ],
+                                                                "description": "Whether the default value should be applied when updating a record.\nIf set to `always`, the default value will be applied when updating a record.\nIf set to `never`, the default value will not be applied when updating a record,\nonly when creating a record.\nIf unspecified, then `always` is assumed.\n"
+                                                              }
+                                                            }
+                                                          }
+                                                        ]
+                                                      }
+                                                    },
+                                                    "selectedFieldSettings": {
+                                                      "type": "object",
+                                                      "description": "This is a map of field names to their settings.",
+                                                      "x-go-type-skip-optional-pointer": true,
+                                                      "additionalProperties": {
+                                                        "title": "Field setting",
+                                                        "type": "object",
+                                                        "properties": {
+                                                          "default": {
+                                                            "title": "Default value for a field",
+                                                            "description": "Only use one of stringValue, integerValue, booleanValue.",
+                                                            "type": "object",
+                                                            "properties": {
+                                                              "stringValue": {
+                                                                "type": "string",
+                                                                "description": "The default string value to apply to a field"
+                                                              },
+                                                              "integerValue": {
+                                                                "type": "integer",
+                                                                "description": "The default integer value to apply to a field"
+                                                              },
+                                                              "booleanValue": {
+                                                                "type": "boolean",
+                                                                "description": "The default boolean value to apply to a field"
+                                                              }
+                                                            }
+                                                          },
+                                                          "writeOnCreate": {
+                                                            "type": "string",
+                                                            "enum": [
+                                                              "always",
+                                                              "never"
+                                                            ],
+                                                            "default": "always",
+                                                            "x-go-type-skip-optional-pointer": true,
+                                                            "description": "Whether the default value should be applied when creating a record."
+                                                          },
+                                                          "writeOnUpdate": {
+                                                            "type": "string",
+                                                            "enum": [
+                                                              "always",
+                                                              "never"
+                                                            ],
+                                                            "default": "always",
+                                                            "x-go-type-skip-optional-pointer": true,
+                                                            "description": "Whether the default value should be applied when updating a record."
+                                                          }
+                                                        }
+                                                      }
+                                                    }
+                                                  }
+                                                },
+                                                {
+                                                  "type": "object",
+                                                  "required": [
+                                                    "objectName"
+                                                  ]
+                                                }
+                                              ]
+                                            }
+                                          }
+                                        }
+                                      }
+                                    ]
                                   }
                                 }
                               }
@@ -14124,10 +14695,581 @@
                             ],
                             "properties": {
                               "read": {
-                                "x-go-type": "ReadConfig"
+                                "title": "Read Config",
+                                "allOf": [
+                                  {
+                                    "title": "Base Read Config",
+                                    "type": "object",
+                                    "properties": {
+                                      "objects": {
+                                        "type": "object",
+                                        "description": "This is a map of object names to their configuration.",
+                                        "additionalProperties": {
+                                          "title": "Base Read Config Object",
+                                          "type": "object",
+                                          "properties": {
+                                            "objectName": {
+                                              "description": "The name of the object to read from.",
+                                              "example": "account",
+                                              "type": "string",
+                                              "x-oapi-codegen-extra-tags": {
+                                                "validate": "required"
+                                              }
+                                            },
+                                            "schedule": {
+                                              "type": "string",
+                                              "description": "The schedule for reading the object, in cron syntax.",
+                                              "example": "*/15 * * * *"
+                                            },
+                                            "destination": {
+                                              "description": "The name of the destination that the result should be sent to.",
+                                              "example": "accountWebhook",
+                                              "type": "string"
+                                            },
+                                            "selectedFields": {
+                                              "type": "object",
+                                              "description": "This is a map of field names to booleans indicating whether they should be read. If a field is already included in `selectedFieldMappings`, it does not need to be included here.",
+                                              "example": "{ phone: true, fax: true }",
+                                              "additionalProperties": {
+                                                "type": "boolean"
+                                              }
+                                            },
+                                            "selectedValueMappings": {
+                                              "type": "object",
+                                              "description": "This is a map of field names to their value mappings.",
+                                              "example": {
+                                                "stage": {
+                                                  "open": "scheduled",
+                                                  "closedWon": "won",
+                                                  "closedLost": "lost"
+                                                }
+                                              },
+                                              "x-go-type-skip-optional-pointer": true,
+                                              "additionalProperties": {
+                                                "title": "Selected Value Mappings",
+                                                "type": "object",
+                                                "description": "This is a map of values to their mappings. The key is the value delivered to the webhook, the value is the value coming from the provider API.",
+                                                "example": {
+                                                  "open": "scheduled",
+                                                  "closedWon": "won",
+                                                  "closedLost": "lost"
+                                                },
+                                                "x-go-type-skip-optional-pointer": true,
+                                                "additionalProperties": {
+                                                  "type": "string"
+                                                }
+                                              }
+                                            },
+                                            "selectedFieldMappings": {
+                                              "type": "object",
+                                              "description": "This is a map of mapToNames to field names. (A mapTo name is the name the builder wants to map a field to when it lands in their destination.)",
+                                              "example": "{ phoneNumber: phone, faxNumber: fax }",
+                                              "additionalProperties": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "selectedFieldsAuto": {
+                                              "title": "Selected Fields Auto Config",
+                                              "description": "If selectedFieldsAuto is set to all, all fields will be read.",
+                                              "type": "string",
+                                              "enum": [
+                                                "all"
+                                              ],
+                                              "x-enum-varnames": [
+                                                "SelectedFieldsAll"
+                                              ]
+                                            },
+                                            "backfill": {
+                                              "title": "Backfill Config",
+                                              "type": "object",
+                                              "required": [
+                                                "defaultPeriod"
+                                              ],
+                                              "properties": {
+                                                "defaultPeriod": {
+                                                  "title": "Default Period Config",
+                                                  "type": "object",
+                                                  "properties": {
+                                                    "days": {
+                                                      "type": "integer",
+                                                      "description": "Number of days in past to backfill from. 0 is no backfill. e.g) if 10, then backfill last 10 days of data. Required if fullHistory is not set.",
+                                                      "minimum": 0,
+                                                      "example": 30,
+                                                      "x-oapi-codegen-extra-tags": {
+                                                        "validate": "required_without=FullHistory,omitempty,min=0"
+                                                      }
+                                                    },
+                                                    "fullHistory": {
+                                                      "type": "boolean",
+                                                      "description": "If true, backfill all history. Required if days is not set.",
+                                                      "example": false,
+                                                      "x-oapi-codegen-extra-tags": {
+                                                        "validate": "required_without=Days"
+                                                      }
+                                                    }
+                                                  }
+                                                }
+                                              }
+                                            }
+                                          }
+                                        }
+                                      }
+                                    }
+                                  },
+                                  {
+                                    "type": "object",
+                                    "required": [
+                                      "objects"
+                                    ],
+                                    "properties": {
+                                      "objects": {
+                                        "additionalProperties": {
+                                          "title": "Read Config Object",
+                                          "allOf": [
+                                            {
+                                              "title": "Base Read Config Object",
+                                              "type": "object",
+                                              "properties": {
+                                                "objectName": {
+                                                  "description": "The name of the object to read from.",
+                                                  "example": "account",
+                                                  "type": "string",
+                                                  "x-oapi-codegen-extra-tags": {
+                                                    "validate": "required"
+                                                  }
+                                                },
+                                                "schedule": {
+                                                  "type": "string",
+                                                  "description": "The schedule for reading the object, in cron syntax.",
+                                                  "example": "*/15 * * * *"
+                                                },
+                                                "destination": {
+                                                  "description": "The name of the destination that the result should be sent to.",
+                                                  "example": "accountWebhook",
+                                                  "type": "string"
+                                                },
+                                                "selectedFields": {
+                                                  "type": "object",
+                                                  "description": "This is a map of field names to booleans indicating whether they should be read. If a field is already included in `selectedFieldMappings`, it does not need to be included here.",
+                                                  "example": "{ phone: true, fax: true }",
+                                                  "additionalProperties": {
+                                                    "type": "boolean"
+                                                  }
+                                                },
+                                                "selectedValueMappings": {
+                                                  "type": "object",
+                                                  "description": "This is a map of field names to their value mappings.",
+                                                  "example": {
+                                                    "stage": {
+                                                      "open": "scheduled",
+                                                      "closedWon": "won",
+                                                      "closedLost": "lost"
+                                                    }
+                                                  },
+                                                  "x-go-type-skip-optional-pointer": true,
+                                                  "additionalProperties": {
+                                                    "title": "Selected Value Mappings",
+                                                    "type": "object",
+                                                    "description": "This is a map of values to their mappings. The key is the value delivered to the webhook, the value is the value coming from the provider API.",
+                                                    "example": {
+                                                      "open": "scheduled",
+                                                      "closedWon": "won",
+                                                      "closedLost": "lost"
+                                                    },
+                                                    "x-go-type-skip-optional-pointer": true,
+                                                    "additionalProperties": {
+                                                      "type": "string"
+                                                    }
+                                                  }
+                                                },
+                                                "selectedFieldMappings": {
+                                                  "type": "object",
+                                                  "description": "This is a map of mapToNames to field names. (A mapTo name is the name the builder wants to map a field to when it lands in their destination.)",
+                                                  "example": "{ phoneNumber: phone, faxNumber: fax }",
+                                                  "additionalProperties": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "selectedFieldsAuto": {
+                                                  "title": "Selected Fields Auto Config",
+                                                  "description": "If selectedFieldsAuto is set to all, all fields will be read.",
+                                                  "type": "string",
+                                                  "enum": [
+                                                    "all"
+                                                  ],
+                                                  "x-enum-varnames": [
+                                                    "SelectedFieldsAll"
+                                                  ]
+                                                },
+                                                "backfill": {
+                                                  "title": "Backfill Config",
+                                                  "type": "object",
+                                                  "required": [
+                                                    "defaultPeriod"
+                                                  ],
+                                                  "properties": {
+                                                    "defaultPeriod": {
+                                                      "title": "Default Period Config",
+                                                      "type": "object",
+                                                      "properties": {
+                                                        "days": {
+                                                          "type": "integer",
+                                                          "description": "Number of days in past to backfill from. 0 is no backfill. e.g) if 10, then backfill last 10 days of data. Required if fullHistory is not set.",
+                                                          "minimum": 0,
+                                                          "example": 30,
+                                                          "x-oapi-codegen-extra-tags": {
+                                                            "validate": "required_without=FullHistory,omitempty,min=0"
+                                                          }
+                                                        },
+                                                        "fullHistory": {
+                                                          "type": "boolean",
+                                                          "description": "If true, backfill all history. Required if days is not set.",
+                                                          "example": false,
+                                                          "x-oapi-codegen-extra-tags": {
+                                                            "validate": "required_without=Days"
+                                                          }
+                                                        }
+                                                      }
+                                                    }
+                                                  }
+                                                }
+                                              }
+                                            },
+                                            {
+                                              "type": "object",
+                                              "required": [
+                                                "objectName",
+                                                "schedule",
+                                                "destination",
+                                                "selectedFields",
+                                                "selectedFieldMappings"
+                                              ]
+                                            }
+                                          ]
+                                        }
+                                      }
+                                    }
+                                  }
+                                ]
                               },
                               "write": {
-                                "x-go-type": "WriteConfig"
+                                "title": "Write Config",
+                                "allOf": [
+                                  {
+                                    "title": "Base Write Config",
+                                    "type": "object",
+                                    "properties": {
+                                      "objects": {
+                                        "type": "object",
+                                        "description": "This is a map of object names to their configuration.",
+                                        "additionalProperties": {
+                                          "title": "Base Write Config Object",
+                                          "type": "object",
+                                          "required": [
+                                            "objectName"
+                                          ],
+                                          "properties": {
+                                            "objectName": {
+                                              "description": "The name of the object to write to.",
+                                              "example": "account",
+                                              "type": "string",
+                                              "x-oapi-codegen-extra-tags": {
+                                                "validate": "required"
+                                              }
+                                            },
+                                            "selectedValueDefaults": {
+                                              "type": "object",
+                                              "deprecated": true,
+                                              "description": "This is a map of field names to default values. These values will be used when writing to the object.",
+                                              "x-go-type-skip-optional-pointer": true,
+                                              "additionalProperties": {
+                                                "title": "Value Default (Legacy)",
+                                                "deprecated": true,
+                                                "x-go-type": "any",
+                                                "oneOf": [
+                                                  {
+                                                    "title": "Value Default String",
+                                                    "type": "object",
+                                                    "required": [
+                                                      "value"
+                                                    ],
+                                                    "properties": {
+                                                      "value": {
+                                                        "type": "string",
+                                                        "description": "The value to be used as a default."
+                                                      },
+                                                      "applyOnUpdate": {
+                                                        "type": "string",
+                                                        "enum": [
+                                                          "always",
+                                                          "never"
+                                                        ],
+                                                        "description": "Whether the default value should be applied when updating a record.\nIf set to `always`, the default value will be applied when updating a record.\nIf set to `never`, the default value will not be applied when updating a record,\nonly when creating a record.\nIf unspecified, then `always` is assumed.\n"
+                                                      }
+                                                    }
+                                                  },
+                                                  {
+                                                    "title": "Value Default Integer",
+                                                    "type": "object",
+                                                    "required": [
+                                                      "value"
+                                                    ],
+                                                    "properties": {
+                                                      "value": {
+                                                        "type": "integer",
+                                                        "description": "The value to be used as a default."
+                                                      },
+                                                      "applyOnUpdate": {
+                                                        "type": "string",
+                                                        "enum": [
+                                                          "always",
+                                                          "never"
+                                                        ],
+                                                        "description": "Whether the default value should be applied when updating a record.\nIf set to `always`, the default value will be applied when updating a record.\nIf set to `never`, the default value will not be applied when updating a record,\nonly when creating a record.\nIf unspecified, then `always` is assumed.\n"
+                                                      }
+                                                    }
+                                                  },
+                                                  {
+                                                    "title": "Value Default Boolean",
+                                                    "type": "object",
+                                                    "required": [
+                                                      "value"
+                                                    ],
+                                                    "properties": {
+                                                      "value": {
+                                                        "type": "boolean",
+                                                        "description": "The value to be used as a default."
+                                                      },
+                                                      "applyOnUpdate": {
+                                                        "type": "string",
+                                                        "enum": [
+                                                          "always",
+                                                          "never"
+                                                        ],
+                                                        "description": "Whether the default value should be applied when updating a record.\nIf set to `always`, the default value will be applied when updating a record.\nIf set to `never`, the default value will not be applied when updating a record,\nonly when creating a record.\nIf unspecified, then `always` is assumed.\n"
+                                                      }
+                                                    }
+                                                  }
+                                                ]
+                                              }
+                                            },
+                                            "selectedFieldSettings": {
+                                              "type": "object",
+                                              "description": "This is a map of field names to their settings.",
+                                              "x-go-type-skip-optional-pointer": true,
+                                              "additionalProperties": {
+                                                "title": "Field setting",
+                                                "type": "object",
+                                                "properties": {
+                                                  "default": {
+                                                    "title": "Default value for a field",
+                                                    "description": "Only use one of stringValue, integerValue, booleanValue.",
+                                                    "type": "object",
+                                                    "properties": {
+                                                      "stringValue": {
+                                                        "type": "string",
+                                                        "description": "The default string value to apply to a field"
+                                                      },
+                                                      "integerValue": {
+                                                        "type": "integer",
+                                                        "description": "The default integer value to apply to a field"
+                                                      },
+                                                      "booleanValue": {
+                                                        "type": "boolean",
+                                                        "description": "The default boolean value to apply to a field"
+                                                      }
+                                                    }
+                                                  },
+                                                  "writeOnCreate": {
+                                                    "type": "string",
+                                                    "enum": [
+                                                      "always",
+                                                      "never"
+                                                    ],
+                                                    "default": "always",
+                                                    "x-go-type-skip-optional-pointer": true,
+                                                    "description": "Whether the default value should be applied when creating a record."
+                                                  },
+                                                  "writeOnUpdate": {
+                                                    "type": "string",
+                                                    "enum": [
+                                                      "always",
+                                                      "never"
+                                                    ],
+                                                    "default": "always",
+                                                    "x-go-type-skip-optional-pointer": true,
+                                                    "description": "Whether the default value should be applied when updating a record."
+                                                  }
+                                                }
+                                              }
+                                            }
+                                          }
+                                        }
+                                      }
+                                    }
+                                  },
+                                  {
+                                    "type": "object",
+                                    "properties": {
+                                      "objects": {
+                                        "additionalProperties": {
+                                          "title": "Write Config Object",
+                                          "allOf": [
+                                            {
+                                              "title": "Base Write Config Object",
+                                              "type": "object",
+                                              "required": [
+                                                "objectName"
+                                              ],
+                                              "properties": {
+                                                "objectName": {
+                                                  "description": "The name of the object to write to.",
+                                                  "example": "account",
+                                                  "type": "string",
+                                                  "x-oapi-codegen-extra-tags": {
+                                                    "validate": "required"
+                                                  }
+                                                },
+                                                "selectedValueDefaults": {
+                                                  "type": "object",
+                                                  "deprecated": true,
+                                                  "description": "This is a map of field names to default values. These values will be used when writing to the object.",
+                                                  "x-go-type-skip-optional-pointer": true,
+                                                  "additionalProperties": {
+                                                    "title": "Value Default (Legacy)",
+                                                    "deprecated": true,
+                                                    "x-go-type": "any",
+                                                    "oneOf": [
+                                                      {
+                                                        "title": "Value Default String",
+                                                        "type": "object",
+                                                        "required": [
+                                                          "value"
+                                                        ],
+                                                        "properties": {
+                                                          "value": {
+                                                            "type": "string",
+                                                            "description": "The value to be used as a default."
+                                                          },
+                                                          "applyOnUpdate": {
+                                                            "type": "string",
+                                                            "enum": [
+                                                              "always",
+                                                              "never"
+                                                            ],
+                                                            "description": "Whether the default value should be applied when updating a record.\nIf set to `always`, the default value will be applied when updating a record.\nIf set to `never`, the default value will not be applied when updating a record,\nonly when creating a record.\nIf unspecified, then `always` is assumed.\n"
+                                                          }
+                                                        }
+                                                      },
+                                                      {
+                                                        "title": "Value Default Integer",
+                                                        "type": "object",
+                                                        "required": [
+                                                          "value"
+                                                        ],
+                                                        "properties": {
+                                                          "value": {
+                                                            "type": "integer",
+                                                            "description": "The value to be used as a default."
+                                                          },
+                                                          "applyOnUpdate": {
+                                                            "type": "string",
+                                                            "enum": [
+                                                              "always",
+                                                              "never"
+                                                            ],
+                                                            "description": "Whether the default value should be applied when updating a record.\nIf set to `always`, the default value will be applied when updating a record.\nIf set to `never`, the default value will not be applied when updating a record,\nonly when creating a record.\nIf unspecified, then `always` is assumed.\n"
+                                                          }
+                                                        }
+                                                      },
+                                                      {
+                                                        "title": "Value Default Boolean",
+                                                        "type": "object",
+                                                        "required": [
+                                                          "value"
+                                                        ],
+                                                        "properties": {
+                                                          "value": {
+                                                            "type": "boolean",
+                                                            "description": "The value to be used as a default."
+                                                          },
+                                                          "applyOnUpdate": {
+                                                            "type": "string",
+                                                            "enum": [
+                                                              "always",
+                                                              "never"
+                                                            ],
+                                                            "description": "Whether the default value should be applied when updating a record.\nIf set to `always`, the default value will be applied when updating a record.\nIf set to `never`, the default value will not be applied when updating a record,\nonly when creating a record.\nIf unspecified, then `always` is assumed.\n"
+                                                          }
+                                                        }
+                                                      }
+                                                    ]
+                                                  }
+                                                },
+                                                "selectedFieldSettings": {
+                                                  "type": "object",
+                                                  "description": "This is a map of field names to their settings.",
+                                                  "x-go-type-skip-optional-pointer": true,
+                                                  "additionalProperties": {
+                                                    "title": "Field setting",
+                                                    "type": "object",
+                                                    "properties": {
+                                                      "default": {
+                                                        "title": "Default value for a field",
+                                                        "description": "Only use one of stringValue, integerValue, booleanValue.",
+                                                        "type": "object",
+                                                        "properties": {
+                                                          "stringValue": {
+                                                            "type": "string",
+                                                            "description": "The default string value to apply to a field"
+                                                          },
+                                                          "integerValue": {
+                                                            "type": "integer",
+                                                            "description": "The default integer value to apply to a field"
+                                                          },
+                                                          "booleanValue": {
+                                                            "type": "boolean",
+                                                            "description": "The default boolean value to apply to a field"
+                                                          }
+                                                        }
+                                                      },
+                                                      "writeOnCreate": {
+                                                        "type": "string",
+                                                        "enum": [
+                                                          "always",
+                                                          "never"
+                                                        ],
+                                                        "default": "always",
+                                                        "x-go-type-skip-optional-pointer": true,
+                                                        "description": "Whether the default value should be applied when creating a record."
+                                                      },
+                                                      "writeOnUpdate": {
+                                                        "type": "string",
+                                                        "enum": [
+                                                          "always",
+                                                          "never"
+                                                        ],
+                                                        "default": "always",
+                                                        "x-go-type-skip-optional-pointer": true,
+                                                        "description": "Whether the default value should be applied when updating a record."
+                                                      }
+                                                    }
+                                                  }
+                                                }
+                                              }
+                                            },
+                                            {
+                                              "type": "object",
+                                              "required": [
+                                                "objectName"
+                                              ]
+                                            }
+                                          ]
+                                        }
+                                      }
+                                    }
+                                  }
+                                ]
                               }
                             }
                           }
@@ -14877,10 +16019,581 @@
                               ],
                               "properties": {
                                 "read": {
-                                  "x-go-type": "ReadConfig"
+                                  "title": "Read Config",
+                                  "allOf": [
+                                    {
+                                      "title": "Base Read Config",
+                                      "type": "object",
+                                      "properties": {
+                                        "objects": {
+                                          "type": "object",
+                                          "description": "This is a map of object names to their configuration.",
+                                          "additionalProperties": {
+                                            "title": "Base Read Config Object",
+                                            "type": "object",
+                                            "properties": {
+                                              "objectName": {
+                                                "description": "The name of the object to read from.",
+                                                "example": "account",
+                                                "type": "string",
+                                                "x-oapi-codegen-extra-tags": {
+                                                  "validate": "required"
+                                                }
+                                              },
+                                              "schedule": {
+                                                "type": "string",
+                                                "description": "The schedule for reading the object, in cron syntax.",
+                                                "example": "*/15 * * * *"
+                                              },
+                                              "destination": {
+                                                "description": "The name of the destination that the result should be sent to.",
+                                                "example": "accountWebhook",
+                                                "type": "string"
+                                              },
+                                              "selectedFields": {
+                                                "type": "object",
+                                                "description": "This is a map of field names to booleans indicating whether they should be read. If a field is already included in `selectedFieldMappings`, it does not need to be included here.",
+                                                "example": "{ phone: true, fax: true }",
+                                                "additionalProperties": {
+                                                  "type": "boolean"
+                                                }
+                                              },
+                                              "selectedValueMappings": {
+                                                "type": "object",
+                                                "description": "This is a map of field names to their value mappings.",
+                                                "example": {
+                                                  "stage": {
+                                                    "open": "scheduled",
+                                                    "closedWon": "won",
+                                                    "closedLost": "lost"
+                                                  }
+                                                },
+                                                "x-go-type-skip-optional-pointer": true,
+                                                "additionalProperties": {
+                                                  "title": "Selected Value Mappings",
+                                                  "type": "object",
+                                                  "description": "This is a map of values to their mappings. The key is the value delivered to the webhook, the value is the value coming from the provider API.",
+                                                  "example": {
+                                                    "open": "scheduled",
+                                                    "closedWon": "won",
+                                                    "closedLost": "lost"
+                                                  },
+                                                  "x-go-type-skip-optional-pointer": true,
+                                                  "additionalProperties": {
+                                                    "type": "string"
+                                                  }
+                                                }
+                                              },
+                                              "selectedFieldMappings": {
+                                                "type": "object",
+                                                "description": "This is a map of mapToNames to field names. (A mapTo name is the name the builder wants to map a field to when it lands in their destination.)",
+                                                "example": "{ phoneNumber: phone, faxNumber: fax }",
+                                                "additionalProperties": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "selectedFieldsAuto": {
+                                                "title": "Selected Fields Auto Config",
+                                                "description": "If selectedFieldsAuto is set to all, all fields will be read.",
+                                                "type": "string",
+                                                "enum": [
+                                                  "all"
+                                                ],
+                                                "x-enum-varnames": [
+                                                  "SelectedFieldsAll"
+                                                ]
+                                              },
+                                              "backfill": {
+                                                "title": "Backfill Config",
+                                                "type": "object",
+                                                "required": [
+                                                  "defaultPeriod"
+                                                ],
+                                                "properties": {
+                                                  "defaultPeriod": {
+                                                    "title": "Default Period Config",
+                                                    "type": "object",
+                                                    "properties": {
+                                                      "days": {
+                                                        "type": "integer",
+                                                        "description": "Number of days in past to backfill from. 0 is no backfill. e.g) if 10, then backfill last 10 days of data. Required if fullHistory is not set.",
+                                                        "minimum": 0,
+                                                        "example": 30,
+                                                        "x-oapi-codegen-extra-tags": {
+                                                          "validate": "required_without=FullHistory,omitempty,min=0"
+                                                        }
+                                                      },
+                                                      "fullHistory": {
+                                                        "type": "boolean",
+                                                        "description": "If true, backfill all history. Required if days is not set.",
+                                                        "example": false,
+                                                        "x-oapi-codegen-extra-tags": {
+                                                          "validate": "required_without=Days"
+                                                        }
+                                                      }
+                                                    }
+                                                  }
+                                                }
+                                              }
+                                            }
+                                          }
+                                        }
+                                      }
+                                    },
+                                    {
+                                      "type": "object",
+                                      "required": [
+                                        "objects"
+                                      ],
+                                      "properties": {
+                                        "objects": {
+                                          "additionalProperties": {
+                                            "title": "Read Config Object",
+                                            "allOf": [
+                                              {
+                                                "title": "Base Read Config Object",
+                                                "type": "object",
+                                                "properties": {
+                                                  "objectName": {
+                                                    "description": "The name of the object to read from.",
+                                                    "example": "account",
+                                                    "type": "string",
+                                                    "x-oapi-codegen-extra-tags": {
+                                                      "validate": "required"
+                                                    }
+                                                  },
+                                                  "schedule": {
+                                                    "type": "string",
+                                                    "description": "The schedule for reading the object, in cron syntax.",
+                                                    "example": "*/15 * * * *"
+                                                  },
+                                                  "destination": {
+                                                    "description": "The name of the destination that the result should be sent to.",
+                                                    "example": "accountWebhook",
+                                                    "type": "string"
+                                                  },
+                                                  "selectedFields": {
+                                                    "type": "object",
+                                                    "description": "This is a map of field names to booleans indicating whether they should be read. If a field is already included in `selectedFieldMappings`, it does not need to be included here.",
+                                                    "example": "{ phone: true, fax: true }",
+                                                    "additionalProperties": {
+                                                      "type": "boolean"
+                                                    }
+                                                  },
+                                                  "selectedValueMappings": {
+                                                    "type": "object",
+                                                    "description": "This is a map of field names to their value mappings.",
+                                                    "example": {
+                                                      "stage": {
+                                                        "open": "scheduled",
+                                                        "closedWon": "won",
+                                                        "closedLost": "lost"
+                                                      }
+                                                    },
+                                                    "x-go-type-skip-optional-pointer": true,
+                                                    "additionalProperties": {
+                                                      "title": "Selected Value Mappings",
+                                                      "type": "object",
+                                                      "description": "This is a map of values to their mappings. The key is the value delivered to the webhook, the value is the value coming from the provider API.",
+                                                      "example": {
+                                                        "open": "scheduled",
+                                                        "closedWon": "won",
+                                                        "closedLost": "lost"
+                                                      },
+                                                      "x-go-type-skip-optional-pointer": true,
+                                                      "additionalProperties": {
+                                                        "type": "string"
+                                                      }
+                                                    }
+                                                  },
+                                                  "selectedFieldMappings": {
+                                                    "type": "object",
+                                                    "description": "This is a map of mapToNames to field names. (A mapTo name is the name the builder wants to map a field to when it lands in their destination.)",
+                                                    "example": "{ phoneNumber: phone, faxNumber: fax }",
+                                                    "additionalProperties": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "selectedFieldsAuto": {
+                                                    "title": "Selected Fields Auto Config",
+                                                    "description": "If selectedFieldsAuto is set to all, all fields will be read.",
+                                                    "type": "string",
+                                                    "enum": [
+                                                      "all"
+                                                    ],
+                                                    "x-enum-varnames": [
+                                                      "SelectedFieldsAll"
+                                                    ]
+                                                  },
+                                                  "backfill": {
+                                                    "title": "Backfill Config",
+                                                    "type": "object",
+                                                    "required": [
+                                                      "defaultPeriod"
+                                                    ],
+                                                    "properties": {
+                                                      "defaultPeriod": {
+                                                        "title": "Default Period Config",
+                                                        "type": "object",
+                                                        "properties": {
+                                                          "days": {
+                                                            "type": "integer",
+                                                            "description": "Number of days in past to backfill from. 0 is no backfill. e.g) if 10, then backfill last 10 days of data. Required if fullHistory is not set.",
+                                                            "minimum": 0,
+                                                            "example": 30,
+                                                            "x-oapi-codegen-extra-tags": {
+                                                              "validate": "required_without=FullHistory,omitempty,min=0"
+                                                            }
+                                                          },
+                                                          "fullHistory": {
+                                                            "type": "boolean",
+                                                            "description": "If true, backfill all history. Required if days is not set.",
+                                                            "example": false,
+                                                            "x-oapi-codegen-extra-tags": {
+                                                              "validate": "required_without=Days"
+                                                            }
+                                                          }
+                                                        }
+                                                      }
+                                                    }
+                                                  }
+                                                }
+                                              },
+                                              {
+                                                "type": "object",
+                                                "required": [
+                                                  "objectName",
+                                                  "schedule",
+                                                  "destination",
+                                                  "selectedFields",
+                                                  "selectedFieldMappings"
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        }
+                                      }
+                                    }
+                                  ]
                                 },
                                 "write": {
-                                  "x-go-type": "WriteConfig"
+                                  "title": "Write Config",
+                                  "allOf": [
+                                    {
+                                      "title": "Base Write Config",
+                                      "type": "object",
+                                      "properties": {
+                                        "objects": {
+                                          "type": "object",
+                                          "description": "This is a map of object names to their configuration.",
+                                          "additionalProperties": {
+                                            "title": "Base Write Config Object",
+                                            "type": "object",
+                                            "required": [
+                                              "objectName"
+                                            ],
+                                            "properties": {
+                                              "objectName": {
+                                                "description": "The name of the object to write to.",
+                                                "example": "account",
+                                                "type": "string",
+                                                "x-oapi-codegen-extra-tags": {
+                                                  "validate": "required"
+                                                }
+                                              },
+                                              "selectedValueDefaults": {
+                                                "type": "object",
+                                                "deprecated": true,
+                                                "description": "This is a map of field names to default values. These values will be used when writing to the object.",
+                                                "x-go-type-skip-optional-pointer": true,
+                                                "additionalProperties": {
+                                                  "title": "Value Default (Legacy)",
+                                                  "deprecated": true,
+                                                  "x-go-type": "any",
+                                                  "oneOf": [
+                                                    {
+                                                      "title": "Value Default String",
+                                                      "type": "object",
+                                                      "required": [
+                                                        "value"
+                                                      ],
+                                                      "properties": {
+                                                        "value": {
+                                                          "type": "string",
+                                                          "description": "The value to be used as a default."
+                                                        },
+                                                        "applyOnUpdate": {
+                                                          "type": "string",
+                                                          "enum": [
+                                                            "always",
+                                                            "never"
+                                                          ],
+                                                          "description": "Whether the default value should be applied when updating a record.\nIf set to `always`, the default value will be applied when updating a record.\nIf set to `never`, the default value will not be applied when updating a record,\nonly when creating a record.\nIf unspecified, then `always` is assumed.\n"
+                                                        }
+                                                      }
+                                                    },
+                                                    {
+                                                      "title": "Value Default Integer",
+                                                      "type": "object",
+                                                      "required": [
+                                                        "value"
+                                                      ],
+                                                      "properties": {
+                                                        "value": {
+                                                          "type": "integer",
+                                                          "description": "The value to be used as a default."
+                                                        },
+                                                        "applyOnUpdate": {
+                                                          "type": "string",
+                                                          "enum": [
+                                                            "always",
+                                                            "never"
+                                                          ],
+                                                          "description": "Whether the default value should be applied when updating a record.\nIf set to `always`, the default value will be applied when updating a record.\nIf set to `never`, the default value will not be applied when updating a record,\nonly when creating a record.\nIf unspecified, then `always` is assumed.\n"
+                                                        }
+                                                      }
+                                                    },
+                                                    {
+                                                      "title": "Value Default Boolean",
+                                                      "type": "object",
+                                                      "required": [
+                                                        "value"
+                                                      ],
+                                                      "properties": {
+                                                        "value": {
+                                                          "type": "boolean",
+                                                          "description": "The value to be used as a default."
+                                                        },
+                                                        "applyOnUpdate": {
+                                                          "type": "string",
+                                                          "enum": [
+                                                            "always",
+                                                            "never"
+                                                          ],
+                                                          "description": "Whether the default value should be applied when updating a record.\nIf set to `always`, the default value will be applied when updating a record.\nIf set to `never`, the default value will not be applied when updating a record,\nonly when creating a record.\nIf unspecified, then `always` is assumed.\n"
+                                                        }
+                                                      }
+                                                    }
+                                                  ]
+                                                }
+                                              },
+                                              "selectedFieldSettings": {
+                                                "type": "object",
+                                                "description": "This is a map of field names to their settings.",
+                                                "x-go-type-skip-optional-pointer": true,
+                                                "additionalProperties": {
+                                                  "title": "Field setting",
+                                                  "type": "object",
+                                                  "properties": {
+                                                    "default": {
+                                                      "title": "Default value for a field",
+                                                      "description": "Only use one of stringValue, integerValue, booleanValue.",
+                                                      "type": "object",
+                                                      "properties": {
+                                                        "stringValue": {
+                                                          "type": "string",
+                                                          "description": "The default string value to apply to a field"
+                                                        },
+                                                        "integerValue": {
+                                                          "type": "integer",
+                                                          "description": "The default integer value to apply to a field"
+                                                        },
+                                                        "booleanValue": {
+                                                          "type": "boolean",
+                                                          "description": "The default boolean value to apply to a field"
+                                                        }
+                                                      }
+                                                    },
+                                                    "writeOnCreate": {
+                                                      "type": "string",
+                                                      "enum": [
+                                                        "always",
+                                                        "never"
+                                                      ],
+                                                      "default": "always",
+                                                      "x-go-type-skip-optional-pointer": true,
+                                                      "description": "Whether the default value should be applied when creating a record."
+                                                    },
+                                                    "writeOnUpdate": {
+                                                      "type": "string",
+                                                      "enum": [
+                                                        "always",
+                                                        "never"
+                                                      ],
+                                                      "default": "always",
+                                                      "x-go-type-skip-optional-pointer": true,
+                                                      "description": "Whether the default value should be applied when updating a record."
+                                                    }
+                                                  }
+                                                }
+                                              }
+                                            }
+                                          }
+                                        }
+                                      }
+                                    },
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "objects": {
+                                          "additionalProperties": {
+                                            "title": "Write Config Object",
+                                            "allOf": [
+                                              {
+                                                "title": "Base Write Config Object",
+                                                "type": "object",
+                                                "required": [
+                                                  "objectName"
+                                                ],
+                                                "properties": {
+                                                  "objectName": {
+                                                    "description": "The name of the object to write to.",
+                                                    "example": "account",
+                                                    "type": "string",
+                                                    "x-oapi-codegen-extra-tags": {
+                                                      "validate": "required"
+                                                    }
+                                                  },
+                                                  "selectedValueDefaults": {
+                                                    "type": "object",
+                                                    "deprecated": true,
+                                                    "description": "This is a map of field names to default values. These values will be used when writing to the object.",
+                                                    "x-go-type-skip-optional-pointer": true,
+                                                    "additionalProperties": {
+                                                      "title": "Value Default (Legacy)",
+                                                      "deprecated": true,
+                                                      "x-go-type": "any",
+                                                      "oneOf": [
+                                                        {
+                                                          "title": "Value Default String",
+                                                          "type": "object",
+                                                          "required": [
+                                                            "value"
+                                                          ],
+                                                          "properties": {
+                                                            "value": {
+                                                              "type": "string",
+                                                              "description": "The value to be used as a default."
+                                                            },
+                                                            "applyOnUpdate": {
+                                                              "type": "string",
+                                                              "enum": [
+                                                                "always",
+                                                                "never"
+                                                              ],
+                                                              "description": "Whether the default value should be applied when updating a record.\nIf set to `always`, the default value will be applied when updating a record.\nIf set to `never`, the default value will not be applied when updating a record,\nonly when creating a record.\nIf unspecified, then `always` is assumed.\n"
+                                                            }
+                                                          }
+                                                        },
+                                                        {
+                                                          "title": "Value Default Integer",
+                                                          "type": "object",
+                                                          "required": [
+                                                            "value"
+                                                          ],
+                                                          "properties": {
+                                                            "value": {
+                                                              "type": "integer",
+                                                              "description": "The value to be used as a default."
+                                                            },
+                                                            "applyOnUpdate": {
+                                                              "type": "string",
+                                                              "enum": [
+                                                                "always",
+                                                                "never"
+                                                              ],
+                                                              "description": "Whether the default value should be applied when updating a record.\nIf set to `always`, the default value will be applied when updating a record.\nIf set to `never`, the default value will not be applied when updating a record,\nonly when creating a record.\nIf unspecified, then `always` is assumed.\n"
+                                                            }
+                                                          }
+                                                        },
+                                                        {
+                                                          "title": "Value Default Boolean",
+                                                          "type": "object",
+                                                          "required": [
+                                                            "value"
+                                                          ],
+                                                          "properties": {
+                                                            "value": {
+                                                              "type": "boolean",
+                                                              "description": "The value to be used as a default."
+                                                            },
+                                                            "applyOnUpdate": {
+                                                              "type": "string",
+                                                              "enum": [
+                                                                "always",
+                                                                "never"
+                                                              ],
+                                                              "description": "Whether the default value should be applied when updating a record.\nIf set to `always`, the default value will be applied when updating a record.\nIf set to `never`, the default value will not be applied when updating a record,\nonly when creating a record.\nIf unspecified, then `always` is assumed.\n"
+                                                            }
+                                                          }
+                                                        }
+                                                      ]
+                                                    }
+                                                  },
+                                                  "selectedFieldSettings": {
+                                                    "type": "object",
+                                                    "description": "This is a map of field names to their settings.",
+                                                    "x-go-type-skip-optional-pointer": true,
+                                                    "additionalProperties": {
+                                                      "title": "Field setting",
+                                                      "type": "object",
+                                                      "properties": {
+                                                        "default": {
+                                                          "title": "Default value for a field",
+                                                          "description": "Only use one of stringValue, integerValue, booleanValue.",
+                                                          "type": "object",
+                                                          "properties": {
+                                                            "stringValue": {
+                                                              "type": "string",
+                                                              "description": "The default string value to apply to a field"
+                                                            },
+                                                            "integerValue": {
+                                                              "type": "integer",
+                                                              "description": "The default integer value to apply to a field"
+                                                            },
+                                                            "booleanValue": {
+                                                              "type": "boolean",
+                                                              "description": "The default boolean value to apply to a field"
+                                                            }
+                                                          }
+                                                        },
+                                                        "writeOnCreate": {
+                                                          "type": "string",
+                                                          "enum": [
+                                                            "always",
+                                                            "never"
+                                                          ],
+                                                          "default": "always",
+                                                          "x-go-type-skip-optional-pointer": true,
+                                                          "description": "Whether the default value should be applied when creating a record."
+                                                        },
+                                                        "writeOnUpdate": {
+                                                          "type": "string",
+                                                          "enum": [
+                                                            "always",
+                                                            "never"
+                                                          ],
+                                                          "default": "always",
+                                                          "x-go-type-skip-optional-pointer": true,
+                                                          "description": "Whether the default value should be applied when updating a record."
+                                                        }
+                                                      }
+                                                    }
+                                                  }
+                                                }
+                                              },
+                                              {
+                                                "type": "object",
+                                                "required": [
+                                                  "objectName"
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        }
+                                      }
+                                    }
+                                  ]
                                 }
                               }
                             }
@@ -16452,10 +18165,581 @@
                               ],
                               "properties": {
                                 "read": {
-                                  "x-go-type": "ReadConfig"
+                                  "title": "Read Config",
+                                  "allOf": [
+                                    {
+                                      "title": "Base Read Config",
+                                      "type": "object",
+                                      "properties": {
+                                        "objects": {
+                                          "type": "object",
+                                          "description": "This is a map of object names to their configuration.",
+                                          "additionalProperties": {
+                                            "title": "Base Read Config Object",
+                                            "type": "object",
+                                            "properties": {
+                                              "objectName": {
+                                                "description": "The name of the object to read from.",
+                                                "example": "account",
+                                                "type": "string",
+                                                "x-oapi-codegen-extra-tags": {
+                                                  "validate": "required"
+                                                }
+                                              },
+                                              "schedule": {
+                                                "type": "string",
+                                                "description": "The schedule for reading the object, in cron syntax.",
+                                                "example": "*/15 * * * *"
+                                              },
+                                              "destination": {
+                                                "description": "The name of the destination that the result should be sent to.",
+                                                "example": "accountWebhook",
+                                                "type": "string"
+                                              },
+                                              "selectedFields": {
+                                                "type": "object",
+                                                "description": "This is a map of field names to booleans indicating whether they should be read. If a field is already included in `selectedFieldMappings`, it does not need to be included here.",
+                                                "example": "{ phone: true, fax: true }",
+                                                "additionalProperties": {
+                                                  "type": "boolean"
+                                                }
+                                              },
+                                              "selectedValueMappings": {
+                                                "type": "object",
+                                                "description": "This is a map of field names to their value mappings.",
+                                                "example": {
+                                                  "stage": {
+                                                    "open": "scheduled",
+                                                    "closedWon": "won",
+                                                    "closedLost": "lost"
+                                                  }
+                                                },
+                                                "x-go-type-skip-optional-pointer": true,
+                                                "additionalProperties": {
+                                                  "title": "Selected Value Mappings",
+                                                  "type": "object",
+                                                  "description": "This is a map of values to their mappings. The key is the value delivered to the webhook, the value is the value coming from the provider API.",
+                                                  "example": {
+                                                    "open": "scheduled",
+                                                    "closedWon": "won",
+                                                    "closedLost": "lost"
+                                                  },
+                                                  "x-go-type-skip-optional-pointer": true,
+                                                  "additionalProperties": {
+                                                    "type": "string"
+                                                  }
+                                                }
+                                              },
+                                              "selectedFieldMappings": {
+                                                "type": "object",
+                                                "description": "This is a map of mapToNames to field names. (A mapTo name is the name the builder wants to map a field to when it lands in their destination.)",
+                                                "example": "{ phoneNumber: phone, faxNumber: fax }",
+                                                "additionalProperties": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "selectedFieldsAuto": {
+                                                "title": "Selected Fields Auto Config",
+                                                "description": "If selectedFieldsAuto is set to all, all fields will be read.",
+                                                "type": "string",
+                                                "enum": [
+                                                  "all"
+                                                ],
+                                                "x-enum-varnames": [
+                                                  "SelectedFieldsAll"
+                                                ]
+                                              },
+                                              "backfill": {
+                                                "title": "Backfill Config",
+                                                "type": "object",
+                                                "required": [
+                                                  "defaultPeriod"
+                                                ],
+                                                "properties": {
+                                                  "defaultPeriod": {
+                                                    "title": "Default Period Config",
+                                                    "type": "object",
+                                                    "properties": {
+                                                      "days": {
+                                                        "type": "integer",
+                                                        "description": "Number of days in past to backfill from. 0 is no backfill. e.g) if 10, then backfill last 10 days of data. Required if fullHistory is not set.",
+                                                        "minimum": 0,
+                                                        "example": 30,
+                                                        "x-oapi-codegen-extra-tags": {
+                                                          "validate": "required_without=FullHistory,omitempty,min=0"
+                                                        }
+                                                      },
+                                                      "fullHistory": {
+                                                        "type": "boolean",
+                                                        "description": "If true, backfill all history. Required if days is not set.",
+                                                        "example": false,
+                                                        "x-oapi-codegen-extra-tags": {
+                                                          "validate": "required_without=Days"
+                                                        }
+                                                      }
+                                                    }
+                                                  }
+                                                }
+                                              }
+                                            }
+                                          }
+                                        }
+                                      }
+                                    },
+                                    {
+                                      "type": "object",
+                                      "required": [
+                                        "objects"
+                                      ],
+                                      "properties": {
+                                        "objects": {
+                                          "additionalProperties": {
+                                            "title": "Read Config Object",
+                                            "allOf": [
+                                              {
+                                                "title": "Base Read Config Object",
+                                                "type": "object",
+                                                "properties": {
+                                                  "objectName": {
+                                                    "description": "The name of the object to read from.",
+                                                    "example": "account",
+                                                    "type": "string",
+                                                    "x-oapi-codegen-extra-tags": {
+                                                      "validate": "required"
+                                                    }
+                                                  },
+                                                  "schedule": {
+                                                    "type": "string",
+                                                    "description": "The schedule for reading the object, in cron syntax.",
+                                                    "example": "*/15 * * * *"
+                                                  },
+                                                  "destination": {
+                                                    "description": "The name of the destination that the result should be sent to.",
+                                                    "example": "accountWebhook",
+                                                    "type": "string"
+                                                  },
+                                                  "selectedFields": {
+                                                    "type": "object",
+                                                    "description": "This is a map of field names to booleans indicating whether they should be read. If a field is already included in `selectedFieldMappings`, it does not need to be included here.",
+                                                    "example": "{ phone: true, fax: true }",
+                                                    "additionalProperties": {
+                                                      "type": "boolean"
+                                                    }
+                                                  },
+                                                  "selectedValueMappings": {
+                                                    "type": "object",
+                                                    "description": "This is a map of field names to their value mappings.",
+                                                    "example": {
+                                                      "stage": {
+                                                        "open": "scheduled",
+                                                        "closedWon": "won",
+                                                        "closedLost": "lost"
+                                                      }
+                                                    },
+                                                    "x-go-type-skip-optional-pointer": true,
+                                                    "additionalProperties": {
+                                                      "title": "Selected Value Mappings",
+                                                      "type": "object",
+                                                      "description": "This is a map of values to their mappings. The key is the value delivered to the webhook, the value is the value coming from the provider API.",
+                                                      "example": {
+                                                        "open": "scheduled",
+                                                        "closedWon": "won",
+                                                        "closedLost": "lost"
+                                                      },
+                                                      "x-go-type-skip-optional-pointer": true,
+                                                      "additionalProperties": {
+                                                        "type": "string"
+                                                      }
+                                                    }
+                                                  },
+                                                  "selectedFieldMappings": {
+                                                    "type": "object",
+                                                    "description": "This is a map of mapToNames to field names. (A mapTo name is the name the builder wants to map a field to when it lands in their destination.)",
+                                                    "example": "{ phoneNumber: phone, faxNumber: fax }",
+                                                    "additionalProperties": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "selectedFieldsAuto": {
+                                                    "title": "Selected Fields Auto Config",
+                                                    "description": "If selectedFieldsAuto is set to all, all fields will be read.",
+                                                    "type": "string",
+                                                    "enum": [
+                                                      "all"
+                                                    ],
+                                                    "x-enum-varnames": [
+                                                      "SelectedFieldsAll"
+                                                    ]
+                                                  },
+                                                  "backfill": {
+                                                    "title": "Backfill Config",
+                                                    "type": "object",
+                                                    "required": [
+                                                      "defaultPeriod"
+                                                    ],
+                                                    "properties": {
+                                                      "defaultPeriod": {
+                                                        "title": "Default Period Config",
+                                                        "type": "object",
+                                                        "properties": {
+                                                          "days": {
+                                                            "type": "integer",
+                                                            "description": "Number of days in past to backfill from. 0 is no backfill. e.g) if 10, then backfill last 10 days of data. Required if fullHistory is not set.",
+                                                            "minimum": 0,
+                                                            "example": 30,
+                                                            "x-oapi-codegen-extra-tags": {
+                                                              "validate": "required_without=FullHistory,omitempty,min=0"
+                                                            }
+                                                          },
+                                                          "fullHistory": {
+                                                            "type": "boolean",
+                                                            "description": "If true, backfill all history. Required if days is not set.",
+                                                            "example": false,
+                                                            "x-oapi-codegen-extra-tags": {
+                                                              "validate": "required_without=Days"
+                                                            }
+                                                          }
+                                                        }
+                                                      }
+                                                    }
+                                                  }
+                                                }
+                                              },
+                                              {
+                                                "type": "object",
+                                                "required": [
+                                                  "objectName",
+                                                  "schedule",
+                                                  "destination",
+                                                  "selectedFields",
+                                                  "selectedFieldMappings"
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        }
+                                      }
+                                    }
+                                  ]
                                 },
                                 "write": {
-                                  "x-go-type": "WriteConfig"
+                                  "title": "Write Config",
+                                  "allOf": [
+                                    {
+                                      "title": "Base Write Config",
+                                      "type": "object",
+                                      "properties": {
+                                        "objects": {
+                                          "type": "object",
+                                          "description": "This is a map of object names to their configuration.",
+                                          "additionalProperties": {
+                                            "title": "Base Write Config Object",
+                                            "type": "object",
+                                            "required": [
+                                              "objectName"
+                                            ],
+                                            "properties": {
+                                              "objectName": {
+                                                "description": "The name of the object to write to.",
+                                                "example": "account",
+                                                "type": "string",
+                                                "x-oapi-codegen-extra-tags": {
+                                                  "validate": "required"
+                                                }
+                                              },
+                                              "selectedValueDefaults": {
+                                                "type": "object",
+                                                "deprecated": true,
+                                                "description": "This is a map of field names to default values. These values will be used when writing to the object.",
+                                                "x-go-type-skip-optional-pointer": true,
+                                                "additionalProperties": {
+                                                  "title": "Value Default (Legacy)",
+                                                  "deprecated": true,
+                                                  "x-go-type": "any",
+                                                  "oneOf": [
+                                                    {
+                                                      "title": "Value Default String",
+                                                      "type": "object",
+                                                      "required": [
+                                                        "value"
+                                                      ],
+                                                      "properties": {
+                                                        "value": {
+                                                          "type": "string",
+                                                          "description": "The value to be used as a default."
+                                                        },
+                                                        "applyOnUpdate": {
+                                                          "type": "string",
+                                                          "enum": [
+                                                            "always",
+                                                            "never"
+                                                          ],
+                                                          "description": "Whether the default value should be applied when updating a record.\nIf set to `always`, the default value will be applied when updating a record.\nIf set to `never`, the default value will not be applied when updating a record,\nonly when creating a record.\nIf unspecified, then `always` is assumed.\n"
+                                                        }
+                                                      }
+                                                    },
+                                                    {
+                                                      "title": "Value Default Integer",
+                                                      "type": "object",
+                                                      "required": [
+                                                        "value"
+                                                      ],
+                                                      "properties": {
+                                                        "value": {
+                                                          "type": "integer",
+                                                          "description": "The value to be used as a default."
+                                                        },
+                                                        "applyOnUpdate": {
+                                                          "type": "string",
+                                                          "enum": [
+                                                            "always",
+                                                            "never"
+                                                          ],
+                                                          "description": "Whether the default value should be applied when updating a record.\nIf set to `always`, the default value will be applied when updating a record.\nIf set to `never`, the default value will not be applied when updating a record,\nonly when creating a record.\nIf unspecified, then `always` is assumed.\n"
+                                                        }
+                                                      }
+                                                    },
+                                                    {
+                                                      "title": "Value Default Boolean",
+                                                      "type": "object",
+                                                      "required": [
+                                                        "value"
+                                                      ],
+                                                      "properties": {
+                                                        "value": {
+                                                          "type": "boolean",
+                                                          "description": "The value to be used as a default."
+                                                        },
+                                                        "applyOnUpdate": {
+                                                          "type": "string",
+                                                          "enum": [
+                                                            "always",
+                                                            "never"
+                                                          ],
+                                                          "description": "Whether the default value should be applied when updating a record.\nIf set to `always`, the default value will be applied when updating a record.\nIf set to `never`, the default value will not be applied when updating a record,\nonly when creating a record.\nIf unspecified, then `always` is assumed.\n"
+                                                        }
+                                                      }
+                                                    }
+                                                  ]
+                                                }
+                                              },
+                                              "selectedFieldSettings": {
+                                                "type": "object",
+                                                "description": "This is a map of field names to their settings.",
+                                                "x-go-type-skip-optional-pointer": true,
+                                                "additionalProperties": {
+                                                  "title": "Field setting",
+                                                  "type": "object",
+                                                  "properties": {
+                                                    "default": {
+                                                      "title": "Default value for a field",
+                                                      "description": "Only use one of stringValue, integerValue, booleanValue.",
+                                                      "type": "object",
+                                                      "properties": {
+                                                        "stringValue": {
+                                                          "type": "string",
+                                                          "description": "The default string value to apply to a field"
+                                                        },
+                                                        "integerValue": {
+                                                          "type": "integer",
+                                                          "description": "The default integer value to apply to a field"
+                                                        },
+                                                        "booleanValue": {
+                                                          "type": "boolean",
+                                                          "description": "The default boolean value to apply to a field"
+                                                        }
+                                                      }
+                                                    },
+                                                    "writeOnCreate": {
+                                                      "type": "string",
+                                                      "enum": [
+                                                        "always",
+                                                        "never"
+                                                      ],
+                                                      "default": "always",
+                                                      "x-go-type-skip-optional-pointer": true,
+                                                      "description": "Whether the default value should be applied when creating a record."
+                                                    },
+                                                    "writeOnUpdate": {
+                                                      "type": "string",
+                                                      "enum": [
+                                                        "always",
+                                                        "never"
+                                                      ],
+                                                      "default": "always",
+                                                      "x-go-type-skip-optional-pointer": true,
+                                                      "description": "Whether the default value should be applied when updating a record."
+                                                    }
+                                                  }
+                                                }
+                                              }
+                                            }
+                                          }
+                                        }
+                                      }
+                                    },
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "objects": {
+                                          "additionalProperties": {
+                                            "title": "Write Config Object",
+                                            "allOf": [
+                                              {
+                                                "title": "Base Write Config Object",
+                                                "type": "object",
+                                                "required": [
+                                                  "objectName"
+                                                ],
+                                                "properties": {
+                                                  "objectName": {
+                                                    "description": "The name of the object to write to.",
+                                                    "example": "account",
+                                                    "type": "string",
+                                                    "x-oapi-codegen-extra-tags": {
+                                                      "validate": "required"
+                                                    }
+                                                  },
+                                                  "selectedValueDefaults": {
+                                                    "type": "object",
+                                                    "deprecated": true,
+                                                    "description": "This is a map of field names to default values. These values will be used when writing to the object.",
+                                                    "x-go-type-skip-optional-pointer": true,
+                                                    "additionalProperties": {
+                                                      "title": "Value Default (Legacy)",
+                                                      "deprecated": true,
+                                                      "x-go-type": "any",
+                                                      "oneOf": [
+                                                        {
+                                                          "title": "Value Default String",
+                                                          "type": "object",
+                                                          "required": [
+                                                            "value"
+                                                          ],
+                                                          "properties": {
+                                                            "value": {
+                                                              "type": "string",
+                                                              "description": "The value to be used as a default."
+                                                            },
+                                                            "applyOnUpdate": {
+                                                              "type": "string",
+                                                              "enum": [
+                                                                "always",
+                                                                "never"
+                                                              ],
+                                                              "description": "Whether the default value should be applied when updating a record.\nIf set to `always`, the default value will be applied when updating a record.\nIf set to `never`, the default value will not be applied when updating a record,\nonly when creating a record.\nIf unspecified, then `always` is assumed.\n"
+                                                            }
+                                                          }
+                                                        },
+                                                        {
+                                                          "title": "Value Default Integer",
+                                                          "type": "object",
+                                                          "required": [
+                                                            "value"
+                                                          ],
+                                                          "properties": {
+                                                            "value": {
+                                                              "type": "integer",
+                                                              "description": "The value to be used as a default."
+                                                            },
+                                                            "applyOnUpdate": {
+                                                              "type": "string",
+                                                              "enum": [
+                                                                "always",
+                                                                "never"
+                                                              ],
+                                                              "description": "Whether the default value should be applied when updating a record.\nIf set to `always`, the default value will be applied when updating a record.\nIf set to `never`, the default value will not be applied when updating a record,\nonly when creating a record.\nIf unspecified, then `always` is assumed.\n"
+                                                            }
+                                                          }
+                                                        },
+                                                        {
+                                                          "title": "Value Default Boolean",
+                                                          "type": "object",
+                                                          "required": [
+                                                            "value"
+                                                          ],
+                                                          "properties": {
+                                                            "value": {
+                                                              "type": "boolean",
+                                                              "description": "The value to be used as a default."
+                                                            },
+                                                            "applyOnUpdate": {
+                                                              "type": "string",
+                                                              "enum": [
+                                                                "always",
+                                                                "never"
+                                                              ],
+                                                              "description": "Whether the default value should be applied when updating a record.\nIf set to `always`, the default value will be applied when updating a record.\nIf set to `never`, the default value will not be applied when updating a record,\nonly when creating a record.\nIf unspecified, then `always` is assumed.\n"
+                                                            }
+                                                          }
+                                                        }
+                                                      ]
+                                                    }
+                                                  },
+                                                  "selectedFieldSettings": {
+                                                    "type": "object",
+                                                    "description": "This is a map of field names to their settings.",
+                                                    "x-go-type-skip-optional-pointer": true,
+                                                    "additionalProperties": {
+                                                      "title": "Field setting",
+                                                      "type": "object",
+                                                      "properties": {
+                                                        "default": {
+                                                          "title": "Default value for a field",
+                                                          "description": "Only use one of stringValue, integerValue, booleanValue.",
+                                                          "type": "object",
+                                                          "properties": {
+                                                            "stringValue": {
+                                                              "type": "string",
+                                                              "description": "The default string value to apply to a field"
+                                                            },
+                                                            "integerValue": {
+                                                              "type": "integer",
+                                                              "description": "The default integer value to apply to a field"
+                                                            },
+                                                            "booleanValue": {
+                                                              "type": "boolean",
+                                                              "description": "The default boolean value to apply to a field"
+                                                            }
+                                                          }
+                                                        },
+                                                        "writeOnCreate": {
+                                                          "type": "string",
+                                                          "enum": [
+                                                            "always",
+                                                            "never"
+                                                          ],
+                                                          "default": "always",
+                                                          "x-go-type-skip-optional-pointer": true,
+                                                          "description": "Whether the default value should be applied when creating a record."
+                                                        },
+                                                        "writeOnUpdate": {
+                                                          "type": "string",
+                                                          "enum": [
+                                                            "always",
+                                                            "never"
+                                                          ],
+                                                          "default": "always",
+                                                          "x-go-type-skip-optional-pointer": true,
+                                                          "description": "Whether the default value should be applied when updating a record."
+                                                        }
+                                                      }
+                                                    }
+                                                  }
+                                                }
+                                              },
+                                              {
+                                                "type": "object",
+                                                "required": [
+                                                  "objectName"
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        }
+                                      }
+                                    }
+                                  ]
                                 }
                               }
                             }
@@ -18228,10 +20512,581 @@
                               ],
                               "properties": {
                                 "read": {
-                                  "x-go-type": "ReadConfig"
+                                  "title": "Read Config",
+                                  "allOf": [
+                                    {
+                                      "title": "Base Read Config",
+                                      "type": "object",
+                                      "properties": {
+                                        "objects": {
+                                          "type": "object",
+                                          "description": "This is a map of object names to their configuration.",
+                                          "additionalProperties": {
+                                            "title": "Base Read Config Object",
+                                            "type": "object",
+                                            "properties": {
+                                              "objectName": {
+                                                "description": "The name of the object to read from.",
+                                                "example": "account",
+                                                "type": "string",
+                                                "x-oapi-codegen-extra-tags": {
+                                                  "validate": "required"
+                                                }
+                                              },
+                                              "schedule": {
+                                                "type": "string",
+                                                "description": "The schedule for reading the object, in cron syntax.",
+                                                "example": "*/15 * * * *"
+                                              },
+                                              "destination": {
+                                                "description": "The name of the destination that the result should be sent to.",
+                                                "example": "accountWebhook",
+                                                "type": "string"
+                                              },
+                                              "selectedFields": {
+                                                "type": "object",
+                                                "description": "This is a map of field names to booleans indicating whether they should be read. If a field is already included in `selectedFieldMappings`, it does not need to be included here.",
+                                                "example": "{ phone: true, fax: true }",
+                                                "additionalProperties": {
+                                                  "type": "boolean"
+                                                }
+                                              },
+                                              "selectedValueMappings": {
+                                                "type": "object",
+                                                "description": "This is a map of field names to their value mappings.",
+                                                "example": {
+                                                  "stage": {
+                                                    "open": "scheduled",
+                                                    "closedWon": "won",
+                                                    "closedLost": "lost"
+                                                  }
+                                                },
+                                                "x-go-type-skip-optional-pointer": true,
+                                                "additionalProperties": {
+                                                  "title": "Selected Value Mappings",
+                                                  "type": "object",
+                                                  "description": "This is a map of values to their mappings. The key is the value delivered to the webhook, the value is the value coming from the provider API.",
+                                                  "example": {
+                                                    "open": "scheduled",
+                                                    "closedWon": "won",
+                                                    "closedLost": "lost"
+                                                  },
+                                                  "x-go-type-skip-optional-pointer": true,
+                                                  "additionalProperties": {
+                                                    "type": "string"
+                                                  }
+                                                }
+                                              },
+                                              "selectedFieldMappings": {
+                                                "type": "object",
+                                                "description": "This is a map of mapToNames to field names. (A mapTo name is the name the builder wants to map a field to when it lands in their destination.)",
+                                                "example": "{ phoneNumber: phone, faxNumber: fax }",
+                                                "additionalProperties": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "selectedFieldsAuto": {
+                                                "title": "Selected Fields Auto Config",
+                                                "description": "If selectedFieldsAuto is set to all, all fields will be read.",
+                                                "type": "string",
+                                                "enum": [
+                                                  "all"
+                                                ],
+                                                "x-enum-varnames": [
+                                                  "SelectedFieldsAll"
+                                                ]
+                                              },
+                                              "backfill": {
+                                                "title": "Backfill Config",
+                                                "type": "object",
+                                                "required": [
+                                                  "defaultPeriod"
+                                                ],
+                                                "properties": {
+                                                  "defaultPeriod": {
+                                                    "title": "Default Period Config",
+                                                    "type": "object",
+                                                    "properties": {
+                                                      "days": {
+                                                        "type": "integer",
+                                                        "description": "Number of days in past to backfill from. 0 is no backfill. e.g) if 10, then backfill last 10 days of data. Required if fullHistory is not set.",
+                                                        "minimum": 0,
+                                                        "example": 30,
+                                                        "x-oapi-codegen-extra-tags": {
+                                                          "validate": "required_without=FullHistory,omitempty,min=0"
+                                                        }
+                                                      },
+                                                      "fullHistory": {
+                                                        "type": "boolean",
+                                                        "description": "If true, backfill all history. Required if days is not set.",
+                                                        "example": false,
+                                                        "x-oapi-codegen-extra-tags": {
+                                                          "validate": "required_without=Days"
+                                                        }
+                                                      }
+                                                    }
+                                                  }
+                                                }
+                                              }
+                                            }
+                                          }
+                                        }
+                                      }
+                                    },
+                                    {
+                                      "type": "object",
+                                      "required": [
+                                        "objects"
+                                      ],
+                                      "properties": {
+                                        "objects": {
+                                          "additionalProperties": {
+                                            "title": "Read Config Object",
+                                            "allOf": [
+                                              {
+                                                "title": "Base Read Config Object",
+                                                "type": "object",
+                                                "properties": {
+                                                  "objectName": {
+                                                    "description": "The name of the object to read from.",
+                                                    "example": "account",
+                                                    "type": "string",
+                                                    "x-oapi-codegen-extra-tags": {
+                                                      "validate": "required"
+                                                    }
+                                                  },
+                                                  "schedule": {
+                                                    "type": "string",
+                                                    "description": "The schedule for reading the object, in cron syntax.",
+                                                    "example": "*/15 * * * *"
+                                                  },
+                                                  "destination": {
+                                                    "description": "The name of the destination that the result should be sent to.",
+                                                    "example": "accountWebhook",
+                                                    "type": "string"
+                                                  },
+                                                  "selectedFields": {
+                                                    "type": "object",
+                                                    "description": "This is a map of field names to booleans indicating whether they should be read. If a field is already included in `selectedFieldMappings`, it does not need to be included here.",
+                                                    "example": "{ phone: true, fax: true }",
+                                                    "additionalProperties": {
+                                                      "type": "boolean"
+                                                    }
+                                                  },
+                                                  "selectedValueMappings": {
+                                                    "type": "object",
+                                                    "description": "This is a map of field names to their value mappings.",
+                                                    "example": {
+                                                      "stage": {
+                                                        "open": "scheduled",
+                                                        "closedWon": "won",
+                                                        "closedLost": "lost"
+                                                      }
+                                                    },
+                                                    "x-go-type-skip-optional-pointer": true,
+                                                    "additionalProperties": {
+                                                      "title": "Selected Value Mappings",
+                                                      "type": "object",
+                                                      "description": "This is a map of values to their mappings. The key is the value delivered to the webhook, the value is the value coming from the provider API.",
+                                                      "example": {
+                                                        "open": "scheduled",
+                                                        "closedWon": "won",
+                                                        "closedLost": "lost"
+                                                      },
+                                                      "x-go-type-skip-optional-pointer": true,
+                                                      "additionalProperties": {
+                                                        "type": "string"
+                                                      }
+                                                    }
+                                                  },
+                                                  "selectedFieldMappings": {
+                                                    "type": "object",
+                                                    "description": "This is a map of mapToNames to field names. (A mapTo name is the name the builder wants to map a field to when it lands in their destination.)",
+                                                    "example": "{ phoneNumber: phone, faxNumber: fax }",
+                                                    "additionalProperties": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "selectedFieldsAuto": {
+                                                    "title": "Selected Fields Auto Config",
+                                                    "description": "If selectedFieldsAuto is set to all, all fields will be read.",
+                                                    "type": "string",
+                                                    "enum": [
+                                                      "all"
+                                                    ],
+                                                    "x-enum-varnames": [
+                                                      "SelectedFieldsAll"
+                                                    ]
+                                                  },
+                                                  "backfill": {
+                                                    "title": "Backfill Config",
+                                                    "type": "object",
+                                                    "required": [
+                                                      "defaultPeriod"
+                                                    ],
+                                                    "properties": {
+                                                      "defaultPeriod": {
+                                                        "title": "Default Period Config",
+                                                        "type": "object",
+                                                        "properties": {
+                                                          "days": {
+                                                            "type": "integer",
+                                                            "description": "Number of days in past to backfill from. 0 is no backfill. e.g) if 10, then backfill last 10 days of data. Required if fullHistory is not set.",
+                                                            "minimum": 0,
+                                                            "example": 30,
+                                                            "x-oapi-codegen-extra-tags": {
+                                                              "validate": "required_without=FullHistory,omitempty,min=0"
+                                                            }
+                                                          },
+                                                          "fullHistory": {
+                                                            "type": "boolean",
+                                                            "description": "If true, backfill all history. Required if days is not set.",
+                                                            "example": false,
+                                                            "x-oapi-codegen-extra-tags": {
+                                                              "validate": "required_without=Days"
+                                                            }
+                                                          }
+                                                        }
+                                                      }
+                                                    }
+                                                  }
+                                                }
+                                              },
+                                              {
+                                                "type": "object",
+                                                "required": [
+                                                  "objectName",
+                                                  "schedule",
+                                                  "destination",
+                                                  "selectedFields",
+                                                  "selectedFieldMappings"
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        }
+                                      }
+                                    }
+                                  ]
                                 },
                                 "write": {
-                                  "x-go-type": "WriteConfig"
+                                  "title": "Write Config",
+                                  "allOf": [
+                                    {
+                                      "title": "Base Write Config",
+                                      "type": "object",
+                                      "properties": {
+                                        "objects": {
+                                          "type": "object",
+                                          "description": "This is a map of object names to their configuration.",
+                                          "additionalProperties": {
+                                            "title": "Base Write Config Object",
+                                            "type": "object",
+                                            "required": [
+                                              "objectName"
+                                            ],
+                                            "properties": {
+                                              "objectName": {
+                                                "description": "The name of the object to write to.",
+                                                "example": "account",
+                                                "type": "string",
+                                                "x-oapi-codegen-extra-tags": {
+                                                  "validate": "required"
+                                                }
+                                              },
+                                              "selectedValueDefaults": {
+                                                "type": "object",
+                                                "deprecated": true,
+                                                "description": "This is a map of field names to default values. These values will be used when writing to the object.",
+                                                "x-go-type-skip-optional-pointer": true,
+                                                "additionalProperties": {
+                                                  "title": "Value Default (Legacy)",
+                                                  "deprecated": true,
+                                                  "x-go-type": "any",
+                                                  "oneOf": [
+                                                    {
+                                                      "title": "Value Default String",
+                                                      "type": "object",
+                                                      "required": [
+                                                        "value"
+                                                      ],
+                                                      "properties": {
+                                                        "value": {
+                                                          "type": "string",
+                                                          "description": "The value to be used as a default."
+                                                        },
+                                                        "applyOnUpdate": {
+                                                          "type": "string",
+                                                          "enum": [
+                                                            "always",
+                                                            "never"
+                                                          ],
+                                                          "description": "Whether the default value should be applied when updating a record.\nIf set to `always`, the default value will be applied when updating a record.\nIf set to `never`, the default value will not be applied when updating a record,\nonly when creating a record.\nIf unspecified, then `always` is assumed.\n"
+                                                        }
+                                                      }
+                                                    },
+                                                    {
+                                                      "title": "Value Default Integer",
+                                                      "type": "object",
+                                                      "required": [
+                                                        "value"
+                                                      ],
+                                                      "properties": {
+                                                        "value": {
+                                                          "type": "integer",
+                                                          "description": "The value to be used as a default."
+                                                        },
+                                                        "applyOnUpdate": {
+                                                          "type": "string",
+                                                          "enum": [
+                                                            "always",
+                                                            "never"
+                                                          ],
+                                                          "description": "Whether the default value should be applied when updating a record.\nIf set to `always`, the default value will be applied when updating a record.\nIf set to `never`, the default value will not be applied when updating a record,\nonly when creating a record.\nIf unspecified, then `always` is assumed.\n"
+                                                        }
+                                                      }
+                                                    },
+                                                    {
+                                                      "title": "Value Default Boolean",
+                                                      "type": "object",
+                                                      "required": [
+                                                        "value"
+                                                      ],
+                                                      "properties": {
+                                                        "value": {
+                                                          "type": "boolean",
+                                                          "description": "The value to be used as a default."
+                                                        },
+                                                        "applyOnUpdate": {
+                                                          "type": "string",
+                                                          "enum": [
+                                                            "always",
+                                                            "never"
+                                                          ],
+                                                          "description": "Whether the default value should be applied when updating a record.\nIf set to `always`, the default value will be applied when updating a record.\nIf set to `never`, the default value will not be applied when updating a record,\nonly when creating a record.\nIf unspecified, then `always` is assumed.\n"
+                                                        }
+                                                      }
+                                                    }
+                                                  ]
+                                                }
+                                              },
+                                              "selectedFieldSettings": {
+                                                "type": "object",
+                                                "description": "This is a map of field names to their settings.",
+                                                "x-go-type-skip-optional-pointer": true,
+                                                "additionalProperties": {
+                                                  "title": "Field setting",
+                                                  "type": "object",
+                                                  "properties": {
+                                                    "default": {
+                                                      "title": "Default value for a field",
+                                                      "description": "Only use one of stringValue, integerValue, booleanValue.",
+                                                      "type": "object",
+                                                      "properties": {
+                                                        "stringValue": {
+                                                          "type": "string",
+                                                          "description": "The default string value to apply to a field"
+                                                        },
+                                                        "integerValue": {
+                                                          "type": "integer",
+                                                          "description": "The default integer value to apply to a field"
+                                                        },
+                                                        "booleanValue": {
+                                                          "type": "boolean",
+                                                          "description": "The default boolean value to apply to a field"
+                                                        }
+                                                      }
+                                                    },
+                                                    "writeOnCreate": {
+                                                      "type": "string",
+                                                      "enum": [
+                                                        "always",
+                                                        "never"
+                                                      ],
+                                                      "default": "always",
+                                                      "x-go-type-skip-optional-pointer": true,
+                                                      "description": "Whether the default value should be applied when creating a record."
+                                                    },
+                                                    "writeOnUpdate": {
+                                                      "type": "string",
+                                                      "enum": [
+                                                        "always",
+                                                        "never"
+                                                      ],
+                                                      "default": "always",
+                                                      "x-go-type-skip-optional-pointer": true,
+                                                      "description": "Whether the default value should be applied when updating a record."
+                                                    }
+                                                  }
+                                                }
+                                              }
+                                            }
+                                          }
+                                        }
+                                      }
+                                    },
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "objects": {
+                                          "additionalProperties": {
+                                            "title": "Write Config Object",
+                                            "allOf": [
+                                              {
+                                                "title": "Base Write Config Object",
+                                                "type": "object",
+                                                "required": [
+                                                  "objectName"
+                                                ],
+                                                "properties": {
+                                                  "objectName": {
+                                                    "description": "The name of the object to write to.",
+                                                    "example": "account",
+                                                    "type": "string",
+                                                    "x-oapi-codegen-extra-tags": {
+                                                      "validate": "required"
+                                                    }
+                                                  },
+                                                  "selectedValueDefaults": {
+                                                    "type": "object",
+                                                    "deprecated": true,
+                                                    "description": "This is a map of field names to default values. These values will be used when writing to the object.",
+                                                    "x-go-type-skip-optional-pointer": true,
+                                                    "additionalProperties": {
+                                                      "title": "Value Default (Legacy)",
+                                                      "deprecated": true,
+                                                      "x-go-type": "any",
+                                                      "oneOf": [
+                                                        {
+                                                          "title": "Value Default String",
+                                                          "type": "object",
+                                                          "required": [
+                                                            "value"
+                                                          ],
+                                                          "properties": {
+                                                            "value": {
+                                                              "type": "string",
+                                                              "description": "The value to be used as a default."
+                                                            },
+                                                            "applyOnUpdate": {
+                                                              "type": "string",
+                                                              "enum": [
+                                                                "always",
+                                                                "never"
+                                                              ],
+                                                              "description": "Whether the default value should be applied when updating a record.\nIf set to `always`, the default value will be applied when updating a record.\nIf set to `never`, the default value will not be applied when updating a record,\nonly when creating a record.\nIf unspecified, then `always` is assumed.\n"
+                                                            }
+                                                          }
+                                                        },
+                                                        {
+                                                          "title": "Value Default Integer",
+                                                          "type": "object",
+                                                          "required": [
+                                                            "value"
+                                                          ],
+                                                          "properties": {
+                                                            "value": {
+                                                              "type": "integer",
+                                                              "description": "The value to be used as a default."
+                                                            },
+                                                            "applyOnUpdate": {
+                                                              "type": "string",
+                                                              "enum": [
+                                                                "always",
+                                                                "never"
+                                                              ],
+                                                              "description": "Whether the default value should be applied when updating a record.\nIf set to `always`, the default value will be applied when updating a record.\nIf set to `never`, the default value will not be applied when updating a record,\nonly when creating a record.\nIf unspecified, then `always` is assumed.\n"
+                                                            }
+                                                          }
+                                                        },
+                                                        {
+                                                          "title": "Value Default Boolean",
+                                                          "type": "object",
+                                                          "required": [
+                                                            "value"
+                                                          ],
+                                                          "properties": {
+                                                            "value": {
+                                                              "type": "boolean",
+                                                              "description": "The value to be used as a default."
+                                                            },
+                                                            "applyOnUpdate": {
+                                                              "type": "string",
+                                                              "enum": [
+                                                                "always",
+                                                                "never"
+                                                              ],
+                                                              "description": "Whether the default value should be applied when updating a record.\nIf set to `always`, the default value will be applied when updating a record.\nIf set to `never`, the default value will not be applied when updating a record,\nonly when creating a record.\nIf unspecified, then `always` is assumed.\n"
+                                                            }
+                                                          }
+                                                        }
+                                                      ]
+                                                    }
+                                                  },
+                                                  "selectedFieldSettings": {
+                                                    "type": "object",
+                                                    "description": "This is a map of field names to their settings.",
+                                                    "x-go-type-skip-optional-pointer": true,
+                                                    "additionalProperties": {
+                                                      "title": "Field setting",
+                                                      "type": "object",
+                                                      "properties": {
+                                                        "default": {
+                                                          "title": "Default value for a field",
+                                                          "description": "Only use one of stringValue, integerValue, booleanValue.",
+                                                          "type": "object",
+                                                          "properties": {
+                                                            "stringValue": {
+                                                              "type": "string",
+                                                              "description": "The default string value to apply to a field"
+                                                            },
+                                                            "integerValue": {
+                                                              "type": "integer",
+                                                              "description": "The default integer value to apply to a field"
+                                                            },
+                                                            "booleanValue": {
+                                                              "type": "boolean",
+                                                              "description": "The default boolean value to apply to a field"
+                                                            }
+                                                          }
+                                                        },
+                                                        "writeOnCreate": {
+                                                          "type": "string",
+                                                          "enum": [
+                                                            "always",
+                                                            "never"
+                                                          ],
+                                                          "default": "always",
+                                                          "x-go-type-skip-optional-pointer": true,
+                                                          "description": "Whether the default value should be applied when creating a record."
+                                                        },
+                                                        "writeOnUpdate": {
+                                                          "type": "string",
+                                                          "enum": [
+                                                            "always",
+                                                            "never"
+                                                          ],
+                                                          "default": "always",
+                                                          "x-go-type-skip-optional-pointer": true,
+                                                          "description": "Whether the default value should be applied when updating a record."
+                                                        }
+                                                      }
+                                                    }
+                                                  }
+                                                }
+                                              },
+                                              {
+                                                "type": "object",
+                                                "required": [
+                                                  "objectName"
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        }
+                                      }
+                                    }
+                                  ]
                                 }
                               }
                             }
@@ -42819,10 +45674,581 @@
                     ],
                     "properties": {
                       "read": {
-                        "x-go-type": "ReadConfig"
+                        "title": "Read Config",
+                        "allOf": [
+                          {
+                            "title": "Base Read Config",
+                            "type": "object",
+                            "properties": {
+                              "objects": {
+                                "type": "object",
+                                "description": "This is a map of object names to their configuration.",
+                                "additionalProperties": {
+                                  "title": "Base Read Config Object",
+                                  "type": "object",
+                                  "properties": {
+                                    "objectName": {
+                                      "description": "The name of the object to read from.",
+                                      "example": "account",
+                                      "type": "string",
+                                      "x-oapi-codegen-extra-tags": {
+                                        "validate": "required"
+                                      }
+                                    },
+                                    "schedule": {
+                                      "type": "string",
+                                      "description": "The schedule for reading the object, in cron syntax.",
+                                      "example": "*/15 * * * *"
+                                    },
+                                    "destination": {
+                                      "description": "The name of the destination that the result should be sent to.",
+                                      "example": "accountWebhook",
+                                      "type": "string"
+                                    },
+                                    "selectedFields": {
+                                      "type": "object",
+                                      "description": "This is a map of field names to booleans indicating whether they should be read. If a field is already included in `selectedFieldMappings`, it does not need to be included here.",
+                                      "example": "{ phone: true, fax: true }",
+                                      "additionalProperties": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "selectedValueMappings": {
+                                      "type": "object",
+                                      "description": "This is a map of field names to their value mappings.",
+                                      "example": {
+                                        "stage": {
+                                          "open": "scheduled",
+                                          "closedWon": "won",
+                                          "closedLost": "lost"
+                                        }
+                                      },
+                                      "x-go-type-skip-optional-pointer": true,
+                                      "additionalProperties": {
+                                        "title": "Selected Value Mappings",
+                                        "type": "object",
+                                        "description": "This is a map of values to their mappings. The key is the value delivered to the webhook, the value is the value coming from the provider API.",
+                                        "example": {
+                                          "open": "scheduled",
+                                          "closedWon": "won",
+                                          "closedLost": "lost"
+                                        },
+                                        "x-go-type-skip-optional-pointer": true,
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        }
+                                      }
+                                    },
+                                    "selectedFieldMappings": {
+                                      "type": "object",
+                                      "description": "This is a map of mapToNames to field names. (A mapTo name is the name the builder wants to map a field to when it lands in their destination.)",
+                                      "example": "{ phoneNumber: phone, faxNumber: fax }",
+                                      "additionalProperties": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "selectedFieldsAuto": {
+                                      "title": "Selected Fields Auto Config",
+                                      "description": "If selectedFieldsAuto is set to all, all fields will be read.",
+                                      "type": "string",
+                                      "enum": [
+                                        "all"
+                                      ],
+                                      "x-enum-varnames": [
+                                        "SelectedFieldsAll"
+                                      ]
+                                    },
+                                    "backfill": {
+                                      "title": "Backfill Config",
+                                      "type": "object",
+                                      "required": [
+                                        "defaultPeriod"
+                                      ],
+                                      "properties": {
+                                        "defaultPeriod": {
+                                          "title": "Default Period Config",
+                                          "type": "object",
+                                          "properties": {
+                                            "days": {
+                                              "type": "integer",
+                                              "description": "Number of days in past to backfill from. 0 is no backfill. e.g) if 10, then backfill last 10 days of data. Required if fullHistory is not set.",
+                                              "minimum": 0,
+                                              "example": 30,
+                                              "x-oapi-codegen-extra-tags": {
+                                                "validate": "required_without=FullHistory,omitempty,min=0"
+                                              }
+                                            },
+                                            "fullHistory": {
+                                              "type": "boolean",
+                                              "description": "If true, backfill all history. Required if days is not set.",
+                                              "example": false,
+                                              "x-oapi-codegen-extra-tags": {
+                                                "validate": "required_without=Days"
+                                              }
+                                            }
+                                          }
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          {
+                            "type": "object",
+                            "required": [
+                              "objects"
+                            ],
+                            "properties": {
+                              "objects": {
+                                "additionalProperties": {
+                                  "title": "Read Config Object",
+                                  "allOf": [
+                                    {
+                                      "title": "Base Read Config Object",
+                                      "type": "object",
+                                      "properties": {
+                                        "objectName": {
+                                          "description": "The name of the object to read from.",
+                                          "example": "account",
+                                          "type": "string",
+                                          "x-oapi-codegen-extra-tags": {
+                                            "validate": "required"
+                                          }
+                                        },
+                                        "schedule": {
+                                          "type": "string",
+                                          "description": "The schedule for reading the object, in cron syntax.",
+                                          "example": "*/15 * * * *"
+                                        },
+                                        "destination": {
+                                          "description": "The name of the destination that the result should be sent to.",
+                                          "example": "accountWebhook",
+                                          "type": "string"
+                                        },
+                                        "selectedFields": {
+                                          "type": "object",
+                                          "description": "This is a map of field names to booleans indicating whether they should be read. If a field is already included in `selectedFieldMappings`, it does not need to be included here.",
+                                          "example": "{ phone: true, fax: true }",
+                                          "additionalProperties": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "selectedValueMappings": {
+                                          "type": "object",
+                                          "description": "This is a map of field names to their value mappings.",
+                                          "example": {
+                                            "stage": {
+                                              "open": "scheduled",
+                                              "closedWon": "won",
+                                              "closedLost": "lost"
+                                            }
+                                          },
+                                          "x-go-type-skip-optional-pointer": true,
+                                          "additionalProperties": {
+                                            "title": "Selected Value Mappings",
+                                            "type": "object",
+                                            "description": "This is a map of values to their mappings. The key is the value delivered to the webhook, the value is the value coming from the provider API.",
+                                            "example": {
+                                              "open": "scheduled",
+                                              "closedWon": "won",
+                                              "closedLost": "lost"
+                                            },
+                                            "x-go-type-skip-optional-pointer": true,
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            }
+                                          }
+                                        },
+                                        "selectedFieldMappings": {
+                                          "type": "object",
+                                          "description": "This is a map of mapToNames to field names. (A mapTo name is the name the builder wants to map a field to when it lands in their destination.)",
+                                          "example": "{ phoneNumber: phone, faxNumber: fax }",
+                                          "additionalProperties": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "selectedFieldsAuto": {
+                                          "title": "Selected Fields Auto Config",
+                                          "description": "If selectedFieldsAuto is set to all, all fields will be read.",
+                                          "type": "string",
+                                          "enum": [
+                                            "all"
+                                          ],
+                                          "x-enum-varnames": [
+                                            "SelectedFieldsAll"
+                                          ]
+                                        },
+                                        "backfill": {
+                                          "title": "Backfill Config",
+                                          "type": "object",
+                                          "required": [
+                                            "defaultPeriod"
+                                          ],
+                                          "properties": {
+                                            "defaultPeriod": {
+                                              "title": "Default Period Config",
+                                              "type": "object",
+                                              "properties": {
+                                                "days": {
+                                                  "type": "integer",
+                                                  "description": "Number of days in past to backfill from. 0 is no backfill. e.g) if 10, then backfill last 10 days of data. Required if fullHistory is not set.",
+                                                  "minimum": 0,
+                                                  "example": 30,
+                                                  "x-oapi-codegen-extra-tags": {
+                                                    "validate": "required_without=FullHistory,omitempty,min=0"
+                                                  }
+                                                },
+                                                "fullHistory": {
+                                                  "type": "boolean",
+                                                  "description": "If true, backfill all history. Required if days is not set.",
+                                                  "example": false,
+                                                  "x-oapi-codegen-extra-tags": {
+                                                    "validate": "required_without=Days"
+                                                  }
+                                                }
+                                              }
+                                            }
+                                          }
+                                        }
+                                      }
+                                    },
+                                    {
+                                      "type": "object",
+                                      "required": [
+                                        "objectName",
+                                        "schedule",
+                                        "destination",
+                                        "selectedFields",
+                                        "selectedFieldMappings"
+                                      ]
+                                    }
+                                  ]
+                                }
+                              }
+                            }
+                          }
+                        ]
                       },
                       "write": {
-                        "x-go-type": "WriteConfig"
+                        "title": "Write Config",
+                        "allOf": [
+                          {
+                            "title": "Base Write Config",
+                            "type": "object",
+                            "properties": {
+                              "objects": {
+                                "type": "object",
+                                "description": "This is a map of object names to their configuration.",
+                                "additionalProperties": {
+                                  "title": "Base Write Config Object",
+                                  "type": "object",
+                                  "required": [
+                                    "objectName"
+                                  ],
+                                  "properties": {
+                                    "objectName": {
+                                      "description": "The name of the object to write to.",
+                                      "example": "account",
+                                      "type": "string",
+                                      "x-oapi-codegen-extra-tags": {
+                                        "validate": "required"
+                                      }
+                                    },
+                                    "selectedValueDefaults": {
+                                      "type": "object",
+                                      "deprecated": true,
+                                      "description": "This is a map of field names to default values. These values will be used when writing to the object.",
+                                      "x-go-type-skip-optional-pointer": true,
+                                      "additionalProperties": {
+                                        "title": "Value Default (Legacy)",
+                                        "deprecated": true,
+                                        "x-go-type": "any",
+                                        "oneOf": [
+                                          {
+                                            "title": "Value Default String",
+                                            "type": "object",
+                                            "required": [
+                                              "value"
+                                            ],
+                                            "properties": {
+                                              "value": {
+                                                "type": "string",
+                                                "description": "The value to be used as a default."
+                                              },
+                                              "applyOnUpdate": {
+                                                "type": "string",
+                                                "enum": [
+                                                  "always",
+                                                  "never"
+                                                ],
+                                                "description": "Whether the default value should be applied when updating a record.\nIf set to `always`, the default value will be applied when updating a record.\nIf set to `never`, the default value will not be applied when updating a record,\nonly when creating a record.\nIf unspecified, then `always` is assumed.\n"
+                                              }
+                                            }
+                                          },
+                                          {
+                                            "title": "Value Default Integer",
+                                            "type": "object",
+                                            "required": [
+                                              "value"
+                                            ],
+                                            "properties": {
+                                              "value": {
+                                                "type": "integer",
+                                                "description": "The value to be used as a default."
+                                              },
+                                              "applyOnUpdate": {
+                                                "type": "string",
+                                                "enum": [
+                                                  "always",
+                                                  "never"
+                                                ],
+                                                "description": "Whether the default value should be applied when updating a record.\nIf set to `always`, the default value will be applied when updating a record.\nIf set to `never`, the default value will not be applied when updating a record,\nonly when creating a record.\nIf unspecified, then `always` is assumed.\n"
+                                              }
+                                            }
+                                          },
+                                          {
+                                            "title": "Value Default Boolean",
+                                            "type": "object",
+                                            "required": [
+                                              "value"
+                                            ],
+                                            "properties": {
+                                              "value": {
+                                                "type": "boolean",
+                                                "description": "The value to be used as a default."
+                                              },
+                                              "applyOnUpdate": {
+                                                "type": "string",
+                                                "enum": [
+                                                  "always",
+                                                  "never"
+                                                ],
+                                                "description": "Whether the default value should be applied when updating a record.\nIf set to `always`, the default value will be applied when updating a record.\nIf set to `never`, the default value will not be applied when updating a record,\nonly when creating a record.\nIf unspecified, then `always` is assumed.\n"
+                                              }
+                                            }
+                                          }
+                                        ]
+                                      }
+                                    },
+                                    "selectedFieldSettings": {
+                                      "type": "object",
+                                      "description": "This is a map of field names to their settings.",
+                                      "x-go-type-skip-optional-pointer": true,
+                                      "additionalProperties": {
+                                        "title": "Field setting",
+                                        "type": "object",
+                                        "properties": {
+                                          "default": {
+                                            "title": "Default value for a field",
+                                            "description": "Only use one of stringValue, integerValue, booleanValue.",
+                                            "type": "object",
+                                            "properties": {
+                                              "stringValue": {
+                                                "type": "string",
+                                                "description": "The default string value to apply to a field"
+                                              },
+                                              "integerValue": {
+                                                "type": "integer",
+                                                "description": "The default integer value to apply to a field"
+                                              },
+                                              "booleanValue": {
+                                                "type": "boolean",
+                                                "description": "The default boolean value to apply to a field"
+                                              }
+                                            }
+                                          },
+                                          "writeOnCreate": {
+                                            "type": "string",
+                                            "enum": [
+                                              "always",
+                                              "never"
+                                            ],
+                                            "default": "always",
+                                            "x-go-type-skip-optional-pointer": true,
+                                            "description": "Whether the default value should be applied when creating a record."
+                                          },
+                                          "writeOnUpdate": {
+                                            "type": "string",
+                                            "enum": [
+                                              "always",
+                                              "never"
+                                            ],
+                                            "default": "always",
+                                            "x-go-type-skip-optional-pointer": true,
+                                            "description": "Whether the default value should be applied when updating a record."
+                                          }
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          {
+                            "type": "object",
+                            "properties": {
+                              "objects": {
+                                "additionalProperties": {
+                                  "title": "Write Config Object",
+                                  "allOf": [
+                                    {
+                                      "title": "Base Write Config Object",
+                                      "type": "object",
+                                      "required": [
+                                        "objectName"
+                                      ],
+                                      "properties": {
+                                        "objectName": {
+                                          "description": "The name of the object to write to.",
+                                          "example": "account",
+                                          "type": "string",
+                                          "x-oapi-codegen-extra-tags": {
+                                            "validate": "required"
+                                          }
+                                        },
+                                        "selectedValueDefaults": {
+                                          "type": "object",
+                                          "deprecated": true,
+                                          "description": "This is a map of field names to default values. These values will be used when writing to the object.",
+                                          "x-go-type-skip-optional-pointer": true,
+                                          "additionalProperties": {
+                                            "title": "Value Default (Legacy)",
+                                            "deprecated": true,
+                                            "x-go-type": "any",
+                                            "oneOf": [
+                                              {
+                                                "title": "Value Default String",
+                                                "type": "object",
+                                                "required": [
+                                                  "value"
+                                                ],
+                                                "properties": {
+                                                  "value": {
+                                                    "type": "string",
+                                                    "description": "The value to be used as a default."
+                                                  },
+                                                  "applyOnUpdate": {
+                                                    "type": "string",
+                                                    "enum": [
+                                                      "always",
+                                                      "never"
+                                                    ],
+                                                    "description": "Whether the default value should be applied when updating a record.\nIf set to `always`, the default value will be applied when updating a record.\nIf set to `never`, the default value will not be applied when updating a record,\nonly when creating a record.\nIf unspecified, then `always` is assumed.\n"
+                                                  }
+                                                }
+                                              },
+                                              {
+                                                "title": "Value Default Integer",
+                                                "type": "object",
+                                                "required": [
+                                                  "value"
+                                                ],
+                                                "properties": {
+                                                  "value": {
+                                                    "type": "integer",
+                                                    "description": "The value to be used as a default."
+                                                  },
+                                                  "applyOnUpdate": {
+                                                    "type": "string",
+                                                    "enum": [
+                                                      "always",
+                                                      "never"
+                                                    ],
+                                                    "description": "Whether the default value should be applied when updating a record.\nIf set to `always`, the default value will be applied when updating a record.\nIf set to `never`, the default value will not be applied when updating a record,\nonly when creating a record.\nIf unspecified, then `always` is assumed.\n"
+                                                  }
+                                                }
+                                              },
+                                              {
+                                                "title": "Value Default Boolean",
+                                                "type": "object",
+                                                "required": [
+                                                  "value"
+                                                ],
+                                                "properties": {
+                                                  "value": {
+                                                    "type": "boolean",
+                                                    "description": "The value to be used as a default."
+                                                  },
+                                                  "applyOnUpdate": {
+                                                    "type": "string",
+                                                    "enum": [
+                                                      "always",
+                                                      "never"
+                                                    ],
+                                                    "description": "Whether the default value should be applied when updating a record.\nIf set to `always`, the default value will be applied when updating a record.\nIf set to `never`, the default value will not be applied when updating a record,\nonly when creating a record.\nIf unspecified, then `always` is assumed.\n"
+                                                  }
+                                                }
+                                              }
+                                            ]
+                                          }
+                                        },
+                                        "selectedFieldSettings": {
+                                          "type": "object",
+                                          "description": "This is a map of field names to their settings.",
+                                          "x-go-type-skip-optional-pointer": true,
+                                          "additionalProperties": {
+                                            "title": "Field setting",
+                                            "type": "object",
+                                            "properties": {
+                                              "default": {
+                                                "title": "Default value for a field",
+                                                "description": "Only use one of stringValue, integerValue, booleanValue.",
+                                                "type": "object",
+                                                "properties": {
+                                                  "stringValue": {
+                                                    "type": "string",
+                                                    "description": "The default string value to apply to a field"
+                                                  },
+                                                  "integerValue": {
+                                                    "type": "integer",
+                                                    "description": "The default integer value to apply to a field"
+                                                  },
+                                                  "booleanValue": {
+                                                    "type": "boolean",
+                                                    "description": "The default boolean value to apply to a field"
+                                                  }
+                                                }
+                                              },
+                                              "writeOnCreate": {
+                                                "type": "string",
+                                                "enum": [
+                                                  "always",
+                                                  "never"
+                                                ],
+                                                "default": "always",
+                                                "x-go-type-skip-optional-pointer": true,
+                                                "description": "Whether the default value should be applied when creating a record."
+                                              },
+                                              "writeOnUpdate": {
+                                                "type": "string",
+                                                "enum": [
+                                                  "always",
+                                                  "never"
+                                                ],
+                                                "default": "always",
+                                                "x-go-type-skip-optional-pointer": true,
+                                                "description": "Whether the default value should be applied when updating a record."
+                                              }
+                                            }
+                                          }
+                                        }
+                                      }
+                                    },
+                                    {
+                                      "type": "object",
+                                      "required": [
+                                        "objectName"
+                                      ]
+                                    }
+                                  ]
+                                }
+                              }
+                            }
+                          }
+                        ]
                       }
                     }
                   }
@@ -43165,10 +46591,581 @@
                 ],
                 "properties": {
                   "read": {
-                    "x-go-type": "ReadConfig"
+                    "title": "Read Config",
+                    "allOf": [
+                      {
+                        "title": "Base Read Config",
+                        "type": "object",
+                        "properties": {
+                          "objects": {
+                            "type": "object",
+                            "description": "This is a map of object names to their configuration.",
+                            "additionalProperties": {
+                              "title": "Base Read Config Object",
+                              "type": "object",
+                              "properties": {
+                                "objectName": {
+                                  "description": "The name of the object to read from.",
+                                  "example": "account",
+                                  "type": "string",
+                                  "x-oapi-codegen-extra-tags": {
+                                    "validate": "required"
+                                  }
+                                },
+                                "schedule": {
+                                  "type": "string",
+                                  "description": "The schedule for reading the object, in cron syntax.",
+                                  "example": "*/15 * * * *"
+                                },
+                                "destination": {
+                                  "description": "The name of the destination that the result should be sent to.",
+                                  "example": "accountWebhook",
+                                  "type": "string"
+                                },
+                                "selectedFields": {
+                                  "type": "object",
+                                  "description": "This is a map of field names to booleans indicating whether they should be read. If a field is already included in `selectedFieldMappings`, it does not need to be included here.",
+                                  "example": "{ phone: true, fax: true }",
+                                  "additionalProperties": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "selectedValueMappings": {
+                                  "type": "object",
+                                  "description": "This is a map of field names to their value mappings.",
+                                  "example": {
+                                    "stage": {
+                                      "open": "scheduled",
+                                      "closedWon": "won",
+                                      "closedLost": "lost"
+                                    }
+                                  },
+                                  "x-go-type-skip-optional-pointer": true,
+                                  "additionalProperties": {
+                                    "title": "Selected Value Mappings",
+                                    "type": "object",
+                                    "description": "This is a map of values to their mappings. The key is the value delivered to the webhook, the value is the value coming from the provider API.",
+                                    "example": {
+                                      "open": "scheduled",
+                                      "closedWon": "won",
+                                      "closedLost": "lost"
+                                    },
+                                    "x-go-type-skip-optional-pointer": true,
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    }
+                                  }
+                                },
+                                "selectedFieldMappings": {
+                                  "type": "object",
+                                  "description": "This is a map of mapToNames to field names. (A mapTo name is the name the builder wants to map a field to when it lands in their destination.)",
+                                  "example": "{ phoneNumber: phone, faxNumber: fax }",
+                                  "additionalProperties": {
+                                    "type": "string"
+                                  }
+                                },
+                                "selectedFieldsAuto": {
+                                  "title": "Selected Fields Auto Config",
+                                  "description": "If selectedFieldsAuto is set to all, all fields will be read.",
+                                  "type": "string",
+                                  "enum": [
+                                    "all"
+                                  ],
+                                  "x-enum-varnames": [
+                                    "SelectedFieldsAll"
+                                  ]
+                                },
+                                "backfill": {
+                                  "title": "Backfill Config",
+                                  "type": "object",
+                                  "required": [
+                                    "defaultPeriod"
+                                  ],
+                                  "properties": {
+                                    "defaultPeriod": {
+                                      "title": "Default Period Config",
+                                      "type": "object",
+                                      "properties": {
+                                        "days": {
+                                          "type": "integer",
+                                          "description": "Number of days in past to backfill from. 0 is no backfill. e.g) if 10, then backfill last 10 days of data. Required if fullHistory is not set.",
+                                          "minimum": 0,
+                                          "example": 30,
+                                          "x-oapi-codegen-extra-tags": {
+                                            "validate": "required_without=FullHistory,omitempty,min=0"
+                                          }
+                                        },
+                                        "fullHistory": {
+                                          "type": "boolean",
+                                          "description": "If true, backfill all history. Required if days is not set.",
+                                          "example": false,
+                                          "x-oapi-codegen-extra-tags": {
+                                            "validate": "required_without=Days"
+                                          }
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      },
+                      {
+                        "type": "object",
+                        "required": [
+                          "objects"
+                        ],
+                        "properties": {
+                          "objects": {
+                            "additionalProperties": {
+                              "title": "Read Config Object",
+                              "allOf": [
+                                {
+                                  "title": "Base Read Config Object",
+                                  "type": "object",
+                                  "properties": {
+                                    "objectName": {
+                                      "description": "The name of the object to read from.",
+                                      "example": "account",
+                                      "type": "string",
+                                      "x-oapi-codegen-extra-tags": {
+                                        "validate": "required"
+                                      }
+                                    },
+                                    "schedule": {
+                                      "type": "string",
+                                      "description": "The schedule for reading the object, in cron syntax.",
+                                      "example": "*/15 * * * *"
+                                    },
+                                    "destination": {
+                                      "description": "The name of the destination that the result should be sent to.",
+                                      "example": "accountWebhook",
+                                      "type": "string"
+                                    },
+                                    "selectedFields": {
+                                      "type": "object",
+                                      "description": "This is a map of field names to booleans indicating whether they should be read. If a field is already included in `selectedFieldMappings`, it does not need to be included here.",
+                                      "example": "{ phone: true, fax: true }",
+                                      "additionalProperties": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "selectedValueMappings": {
+                                      "type": "object",
+                                      "description": "This is a map of field names to their value mappings.",
+                                      "example": {
+                                        "stage": {
+                                          "open": "scheduled",
+                                          "closedWon": "won",
+                                          "closedLost": "lost"
+                                        }
+                                      },
+                                      "x-go-type-skip-optional-pointer": true,
+                                      "additionalProperties": {
+                                        "title": "Selected Value Mappings",
+                                        "type": "object",
+                                        "description": "This is a map of values to their mappings. The key is the value delivered to the webhook, the value is the value coming from the provider API.",
+                                        "example": {
+                                          "open": "scheduled",
+                                          "closedWon": "won",
+                                          "closedLost": "lost"
+                                        },
+                                        "x-go-type-skip-optional-pointer": true,
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        }
+                                      }
+                                    },
+                                    "selectedFieldMappings": {
+                                      "type": "object",
+                                      "description": "This is a map of mapToNames to field names. (A mapTo name is the name the builder wants to map a field to when it lands in their destination.)",
+                                      "example": "{ phoneNumber: phone, faxNumber: fax }",
+                                      "additionalProperties": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "selectedFieldsAuto": {
+                                      "title": "Selected Fields Auto Config",
+                                      "description": "If selectedFieldsAuto is set to all, all fields will be read.",
+                                      "type": "string",
+                                      "enum": [
+                                        "all"
+                                      ],
+                                      "x-enum-varnames": [
+                                        "SelectedFieldsAll"
+                                      ]
+                                    },
+                                    "backfill": {
+                                      "title": "Backfill Config",
+                                      "type": "object",
+                                      "required": [
+                                        "defaultPeriod"
+                                      ],
+                                      "properties": {
+                                        "defaultPeriod": {
+                                          "title": "Default Period Config",
+                                          "type": "object",
+                                          "properties": {
+                                            "days": {
+                                              "type": "integer",
+                                              "description": "Number of days in past to backfill from. 0 is no backfill. e.g) if 10, then backfill last 10 days of data. Required if fullHistory is not set.",
+                                              "minimum": 0,
+                                              "example": 30,
+                                              "x-oapi-codegen-extra-tags": {
+                                                "validate": "required_without=FullHistory,omitempty,min=0"
+                                              }
+                                            },
+                                            "fullHistory": {
+                                              "type": "boolean",
+                                              "description": "If true, backfill all history. Required if days is not set.",
+                                              "example": false,
+                                              "x-oapi-codegen-extra-tags": {
+                                                "validate": "required_without=Days"
+                                              }
+                                            }
+                                          }
+                                        }
+                                      }
+                                    }
+                                  }
+                                },
+                                {
+                                  "type": "object",
+                                  "required": [
+                                    "objectName",
+                                    "schedule",
+                                    "destination",
+                                    "selectedFields",
+                                    "selectedFieldMappings"
+                                  ]
+                                }
+                              ]
+                            }
+                          }
+                        }
+                      }
+                    ]
                   },
                   "write": {
-                    "x-go-type": "WriteConfig"
+                    "title": "Write Config",
+                    "allOf": [
+                      {
+                        "title": "Base Write Config",
+                        "type": "object",
+                        "properties": {
+                          "objects": {
+                            "type": "object",
+                            "description": "This is a map of object names to their configuration.",
+                            "additionalProperties": {
+                              "title": "Base Write Config Object",
+                              "type": "object",
+                              "required": [
+                                "objectName"
+                              ],
+                              "properties": {
+                                "objectName": {
+                                  "description": "The name of the object to write to.",
+                                  "example": "account",
+                                  "type": "string",
+                                  "x-oapi-codegen-extra-tags": {
+                                    "validate": "required"
+                                  }
+                                },
+                                "selectedValueDefaults": {
+                                  "type": "object",
+                                  "deprecated": true,
+                                  "description": "This is a map of field names to default values. These values will be used when writing to the object.",
+                                  "x-go-type-skip-optional-pointer": true,
+                                  "additionalProperties": {
+                                    "title": "Value Default (Legacy)",
+                                    "deprecated": true,
+                                    "x-go-type": "any",
+                                    "oneOf": [
+                                      {
+                                        "title": "Value Default String",
+                                        "type": "object",
+                                        "required": [
+                                          "value"
+                                        ],
+                                        "properties": {
+                                          "value": {
+                                            "type": "string",
+                                            "description": "The value to be used as a default."
+                                          },
+                                          "applyOnUpdate": {
+                                            "type": "string",
+                                            "enum": [
+                                              "always",
+                                              "never"
+                                            ],
+                                            "description": "Whether the default value should be applied when updating a record.\nIf set to `always`, the default value will be applied when updating a record.\nIf set to `never`, the default value will not be applied when updating a record,\nonly when creating a record.\nIf unspecified, then `always` is assumed.\n"
+                                          }
+                                        }
+                                      },
+                                      {
+                                        "title": "Value Default Integer",
+                                        "type": "object",
+                                        "required": [
+                                          "value"
+                                        ],
+                                        "properties": {
+                                          "value": {
+                                            "type": "integer",
+                                            "description": "The value to be used as a default."
+                                          },
+                                          "applyOnUpdate": {
+                                            "type": "string",
+                                            "enum": [
+                                              "always",
+                                              "never"
+                                            ],
+                                            "description": "Whether the default value should be applied when updating a record.\nIf set to `always`, the default value will be applied when updating a record.\nIf set to `never`, the default value will not be applied when updating a record,\nonly when creating a record.\nIf unspecified, then `always` is assumed.\n"
+                                          }
+                                        }
+                                      },
+                                      {
+                                        "title": "Value Default Boolean",
+                                        "type": "object",
+                                        "required": [
+                                          "value"
+                                        ],
+                                        "properties": {
+                                          "value": {
+                                            "type": "boolean",
+                                            "description": "The value to be used as a default."
+                                          },
+                                          "applyOnUpdate": {
+                                            "type": "string",
+                                            "enum": [
+                                              "always",
+                                              "never"
+                                            ],
+                                            "description": "Whether the default value should be applied when updating a record.\nIf set to `always`, the default value will be applied when updating a record.\nIf set to `never`, the default value will not be applied when updating a record,\nonly when creating a record.\nIf unspecified, then `always` is assumed.\n"
+                                          }
+                                        }
+                                      }
+                                    ]
+                                  }
+                                },
+                                "selectedFieldSettings": {
+                                  "type": "object",
+                                  "description": "This is a map of field names to their settings.",
+                                  "x-go-type-skip-optional-pointer": true,
+                                  "additionalProperties": {
+                                    "title": "Field setting",
+                                    "type": "object",
+                                    "properties": {
+                                      "default": {
+                                        "title": "Default value for a field",
+                                        "description": "Only use one of stringValue, integerValue, booleanValue.",
+                                        "type": "object",
+                                        "properties": {
+                                          "stringValue": {
+                                            "type": "string",
+                                            "description": "The default string value to apply to a field"
+                                          },
+                                          "integerValue": {
+                                            "type": "integer",
+                                            "description": "The default integer value to apply to a field"
+                                          },
+                                          "booleanValue": {
+                                            "type": "boolean",
+                                            "description": "The default boolean value to apply to a field"
+                                          }
+                                        }
+                                      },
+                                      "writeOnCreate": {
+                                        "type": "string",
+                                        "enum": [
+                                          "always",
+                                          "never"
+                                        ],
+                                        "default": "always",
+                                        "x-go-type-skip-optional-pointer": true,
+                                        "description": "Whether the default value should be applied when creating a record."
+                                      },
+                                      "writeOnUpdate": {
+                                        "type": "string",
+                                        "enum": [
+                                          "always",
+                                          "never"
+                                        ],
+                                        "default": "always",
+                                        "x-go-type-skip-optional-pointer": true,
+                                        "description": "Whether the default value should be applied when updating a record."
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "objects": {
+                            "additionalProperties": {
+                              "title": "Write Config Object",
+                              "allOf": [
+                                {
+                                  "title": "Base Write Config Object",
+                                  "type": "object",
+                                  "required": [
+                                    "objectName"
+                                  ],
+                                  "properties": {
+                                    "objectName": {
+                                      "description": "The name of the object to write to.",
+                                      "example": "account",
+                                      "type": "string",
+                                      "x-oapi-codegen-extra-tags": {
+                                        "validate": "required"
+                                      }
+                                    },
+                                    "selectedValueDefaults": {
+                                      "type": "object",
+                                      "deprecated": true,
+                                      "description": "This is a map of field names to default values. These values will be used when writing to the object.",
+                                      "x-go-type-skip-optional-pointer": true,
+                                      "additionalProperties": {
+                                        "title": "Value Default (Legacy)",
+                                        "deprecated": true,
+                                        "x-go-type": "any",
+                                        "oneOf": [
+                                          {
+                                            "title": "Value Default String",
+                                            "type": "object",
+                                            "required": [
+                                              "value"
+                                            ],
+                                            "properties": {
+                                              "value": {
+                                                "type": "string",
+                                                "description": "The value to be used as a default."
+                                              },
+                                              "applyOnUpdate": {
+                                                "type": "string",
+                                                "enum": [
+                                                  "always",
+                                                  "never"
+                                                ],
+                                                "description": "Whether the default value should be applied when updating a record.\nIf set to `always`, the default value will be applied when updating a record.\nIf set to `never`, the default value will not be applied when updating a record,\nonly when creating a record.\nIf unspecified, then `always` is assumed.\n"
+                                              }
+                                            }
+                                          },
+                                          {
+                                            "title": "Value Default Integer",
+                                            "type": "object",
+                                            "required": [
+                                              "value"
+                                            ],
+                                            "properties": {
+                                              "value": {
+                                                "type": "integer",
+                                                "description": "The value to be used as a default."
+                                              },
+                                              "applyOnUpdate": {
+                                                "type": "string",
+                                                "enum": [
+                                                  "always",
+                                                  "never"
+                                                ],
+                                                "description": "Whether the default value should be applied when updating a record.\nIf set to `always`, the default value will be applied when updating a record.\nIf set to `never`, the default value will not be applied when updating a record,\nonly when creating a record.\nIf unspecified, then `always` is assumed.\n"
+                                              }
+                                            }
+                                          },
+                                          {
+                                            "title": "Value Default Boolean",
+                                            "type": "object",
+                                            "required": [
+                                              "value"
+                                            ],
+                                            "properties": {
+                                              "value": {
+                                                "type": "boolean",
+                                                "description": "The value to be used as a default."
+                                              },
+                                              "applyOnUpdate": {
+                                                "type": "string",
+                                                "enum": [
+                                                  "always",
+                                                  "never"
+                                                ],
+                                                "description": "Whether the default value should be applied when updating a record.\nIf set to `always`, the default value will be applied when updating a record.\nIf set to `never`, the default value will not be applied when updating a record,\nonly when creating a record.\nIf unspecified, then `always` is assumed.\n"
+                                              }
+                                            }
+                                          }
+                                        ]
+                                      }
+                                    },
+                                    "selectedFieldSettings": {
+                                      "type": "object",
+                                      "description": "This is a map of field names to their settings.",
+                                      "x-go-type-skip-optional-pointer": true,
+                                      "additionalProperties": {
+                                        "title": "Field setting",
+                                        "type": "object",
+                                        "properties": {
+                                          "default": {
+                                            "title": "Default value for a field",
+                                            "description": "Only use one of stringValue, integerValue, booleanValue.",
+                                            "type": "object",
+                                            "properties": {
+                                              "stringValue": {
+                                                "type": "string",
+                                                "description": "The default string value to apply to a field"
+                                              },
+                                              "integerValue": {
+                                                "type": "integer",
+                                                "description": "The default integer value to apply to a field"
+                                              },
+                                              "booleanValue": {
+                                                "type": "boolean",
+                                                "description": "The default boolean value to apply to a field"
+                                              }
+                                            }
+                                          },
+                                          "writeOnCreate": {
+                                            "type": "string",
+                                            "enum": [
+                                              "always",
+                                              "never"
+                                            ],
+                                            "default": "always",
+                                            "x-go-type-skip-optional-pointer": true,
+                                            "description": "Whether the default value should be applied when creating a record."
+                                          },
+                                          "writeOnUpdate": {
+                                            "type": "string",
+                                            "enum": [
+                                              "always",
+                                              "never"
+                                            ],
+                                            "default": "always",
+                                            "x-go-type-skip-optional-pointer": true,
+                                            "description": "Whether the default value should be applied when updating a record."
+                                          }
+                                        }
+                                      }
+                                    }
+                                  }
+                                },
+                                {
+                                  "type": "object",
+                                  "required": [
+                                    "objectName"
+                                  ]
+                                }
+                              ]
+                            }
+                          }
+                        }
+                      }
+                    ]
                   }
                 }
               }

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -149,9 +149,9 @@ components:
             - provider
           properties:
             read:
-              x-go-type: ReadConfig
+              $ref: '#/components/schemas/ReadConfig'
             write:
-              x-go-type: WriteConfig
+              $ref: '#/components/schemas/WriteConfig'
 
     ReadConfig:
       title: Read Config
@@ -163,8 +163,7 @@ components:
           properties:
             objects:
               additionalProperties:
-                x-go-type: ReadConfigObject
-
+                $ref: '#/components/schemas/ReadConfigObject'
     ReadConfigObject:
       title: Read Config Object
       allOf:
@@ -185,7 +184,7 @@ components:
           properties:
             objects:
               additionalProperties:
-                x-go-type: WriteConfigObject
+                $ref: '#/components/schemas/WriteConfigObject'
 
     WriteConfigObject:
       title: Write Config Object

--- a/config/generated/config.json
+++ b/config/generated/config.json
@@ -1153,10 +1153,581 @@
             ],
             "properties": {
               "read": {
-                "x-go-type": "ReadConfig"
+                "title": "Read Config",
+                "allOf": [
+                  {
+                    "title": "Base Read Config",
+                    "type": "object",
+                    "properties": {
+                      "objects": {
+                        "type": "object",
+                        "description": "This is a map of object names to their configuration.",
+                        "additionalProperties": {
+                          "title": "Base Read Config Object",
+                          "type": "object",
+                          "properties": {
+                            "objectName": {
+                              "description": "The name of the object to read from.",
+                              "example": "account",
+                              "type": "string",
+                              "x-oapi-codegen-extra-tags": {
+                                "validate": "required"
+                              }
+                            },
+                            "schedule": {
+                              "type": "string",
+                              "description": "The schedule for reading the object, in cron syntax.",
+                              "example": "*/15 * * * *"
+                            },
+                            "destination": {
+                              "description": "The name of the destination that the result should be sent to.",
+                              "example": "accountWebhook",
+                              "type": "string"
+                            },
+                            "selectedFields": {
+                              "type": "object",
+                              "description": "This is a map of field names to booleans indicating whether they should be read. If a field is already included in `selectedFieldMappings`, it does not need to be included here.",
+                              "example": "{ phone: true, fax: true }",
+                              "additionalProperties": {
+                                "type": "boolean"
+                              }
+                            },
+                            "selectedValueMappings": {
+                              "type": "object",
+                              "description": "This is a map of field names to their value mappings.",
+                              "example": {
+                                "stage": {
+                                  "open": "scheduled",
+                                  "closedWon": "won",
+                                  "closedLost": "lost"
+                                }
+                              },
+                              "x-go-type-skip-optional-pointer": true,
+                              "additionalProperties": {
+                                "title": "Selected Value Mappings",
+                                "type": "object",
+                                "description": "This is a map of values to their mappings. The key is the value delivered to the webhook, the value is the value coming from the provider API.",
+                                "example": {
+                                  "open": "scheduled",
+                                  "closedWon": "won",
+                                  "closedLost": "lost"
+                                },
+                                "x-go-type-skip-optional-pointer": true,
+                                "additionalProperties": {
+                                  "type": "string"
+                                }
+                              }
+                            },
+                            "selectedFieldMappings": {
+                              "type": "object",
+                              "description": "This is a map of mapToNames to field names. (A mapTo name is the name the builder wants to map a field to when it lands in their destination.)",
+                              "example": "{ phoneNumber: phone, faxNumber: fax }",
+                              "additionalProperties": {
+                                "type": "string"
+                              }
+                            },
+                            "selectedFieldsAuto": {
+                              "title": "Selected Fields Auto Config",
+                              "description": "If selectedFieldsAuto is set to all, all fields will be read.",
+                              "type": "string",
+                              "enum": [
+                                "all"
+                              ],
+                              "x-enum-varnames": [
+                                "SelectedFieldsAll"
+                              ]
+                            },
+                            "backfill": {
+                              "title": "Backfill Config",
+                              "type": "object",
+                              "required": [
+                                "defaultPeriod"
+                              ],
+                              "properties": {
+                                "defaultPeriod": {
+                                  "title": "Default Period Config",
+                                  "type": "object",
+                                  "properties": {
+                                    "days": {
+                                      "type": "integer",
+                                      "description": "Number of days in past to backfill from. 0 is no backfill. e.g) if 10, then backfill last 10 days of data. Required if fullHistory is not set.",
+                                      "minimum": 0,
+                                      "example": 30,
+                                      "x-oapi-codegen-extra-tags": {
+                                        "validate": "required_without=FullHistory,omitempty,min=0"
+                                      }
+                                    },
+                                    "fullHistory": {
+                                      "type": "boolean",
+                                      "description": "If true, backfill all history. Required if days is not set.",
+                                      "example": false,
+                                      "x-oapi-codegen-extra-tags": {
+                                        "validate": "required_without=Days"
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "type": "object",
+                    "required": [
+                      "objects"
+                    ],
+                    "properties": {
+                      "objects": {
+                        "additionalProperties": {
+                          "title": "Read Config Object",
+                          "allOf": [
+                            {
+                              "title": "Base Read Config Object",
+                              "type": "object",
+                              "properties": {
+                                "objectName": {
+                                  "description": "The name of the object to read from.",
+                                  "example": "account",
+                                  "type": "string",
+                                  "x-oapi-codegen-extra-tags": {
+                                    "validate": "required"
+                                  }
+                                },
+                                "schedule": {
+                                  "type": "string",
+                                  "description": "The schedule for reading the object, in cron syntax.",
+                                  "example": "*/15 * * * *"
+                                },
+                                "destination": {
+                                  "description": "The name of the destination that the result should be sent to.",
+                                  "example": "accountWebhook",
+                                  "type": "string"
+                                },
+                                "selectedFields": {
+                                  "type": "object",
+                                  "description": "This is a map of field names to booleans indicating whether they should be read. If a field is already included in `selectedFieldMappings`, it does not need to be included here.",
+                                  "example": "{ phone: true, fax: true }",
+                                  "additionalProperties": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "selectedValueMappings": {
+                                  "type": "object",
+                                  "description": "This is a map of field names to their value mappings.",
+                                  "example": {
+                                    "stage": {
+                                      "open": "scheduled",
+                                      "closedWon": "won",
+                                      "closedLost": "lost"
+                                    }
+                                  },
+                                  "x-go-type-skip-optional-pointer": true,
+                                  "additionalProperties": {
+                                    "title": "Selected Value Mappings",
+                                    "type": "object",
+                                    "description": "This is a map of values to their mappings. The key is the value delivered to the webhook, the value is the value coming from the provider API.",
+                                    "example": {
+                                      "open": "scheduled",
+                                      "closedWon": "won",
+                                      "closedLost": "lost"
+                                    },
+                                    "x-go-type-skip-optional-pointer": true,
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    }
+                                  }
+                                },
+                                "selectedFieldMappings": {
+                                  "type": "object",
+                                  "description": "This is a map of mapToNames to field names. (A mapTo name is the name the builder wants to map a field to when it lands in their destination.)",
+                                  "example": "{ phoneNumber: phone, faxNumber: fax }",
+                                  "additionalProperties": {
+                                    "type": "string"
+                                  }
+                                },
+                                "selectedFieldsAuto": {
+                                  "title": "Selected Fields Auto Config",
+                                  "description": "If selectedFieldsAuto is set to all, all fields will be read.",
+                                  "type": "string",
+                                  "enum": [
+                                    "all"
+                                  ],
+                                  "x-enum-varnames": [
+                                    "SelectedFieldsAll"
+                                  ]
+                                },
+                                "backfill": {
+                                  "title": "Backfill Config",
+                                  "type": "object",
+                                  "required": [
+                                    "defaultPeriod"
+                                  ],
+                                  "properties": {
+                                    "defaultPeriod": {
+                                      "title": "Default Period Config",
+                                      "type": "object",
+                                      "properties": {
+                                        "days": {
+                                          "type": "integer",
+                                          "description": "Number of days in past to backfill from. 0 is no backfill. e.g) if 10, then backfill last 10 days of data. Required if fullHistory is not set.",
+                                          "minimum": 0,
+                                          "example": 30,
+                                          "x-oapi-codegen-extra-tags": {
+                                            "validate": "required_without=FullHistory,omitempty,min=0"
+                                          }
+                                        },
+                                        "fullHistory": {
+                                          "type": "boolean",
+                                          "description": "If true, backfill all history. Required if days is not set.",
+                                          "example": false,
+                                          "x-oapi-codegen-extra-tags": {
+                                            "validate": "required_without=Days"
+                                          }
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            {
+                              "type": "object",
+                              "required": [
+                                "objectName",
+                                "schedule",
+                                "destination",
+                                "selectedFields",
+                                "selectedFieldMappings"
+                              ]
+                            }
+                          ]
+                        }
+                      }
+                    }
+                  }
+                ]
               },
               "write": {
-                "x-go-type": "WriteConfig"
+                "title": "Write Config",
+                "allOf": [
+                  {
+                    "title": "Base Write Config",
+                    "type": "object",
+                    "properties": {
+                      "objects": {
+                        "type": "object",
+                        "description": "This is a map of object names to their configuration.",
+                        "additionalProperties": {
+                          "title": "Base Write Config Object",
+                          "type": "object",
+                          "required": [
+                            "objectName"
+                          ],
+                          "properties": {
+                            "objectName": {
+                              "description": "The name of the object to write to.",
+                              "example": "account",
+                              "type": "string",
+                              "x-oapi-codegen-extra-tags": {
+                                "validate": "required"
+                              }
+                            },
+                            "selectedValueDefaults": {
+                              "type": "object",
+                              "deprecated": true,
+                              "description": "This is a map of field names to default values. These values will be used when writing to the object.",
+                              "x-go-type-skip-optional-pointer": true,
+                              "additionalProperties": {
+                                "title": "Value Default (Legacy)",
+                                "deprecated": true,
+                                "x-go-type": "any",
+                                "oneOf": [
+                                  {
+                                    "title": "Value Default String",
+                                    "type": "object",
+                                    "required": [
+                                      "value"
+                                    ],
+                                    "properties": {
+                                      "value": {
+                                        "type": "string",
+                                        "description": "The value to be used as a default."
+                                      },
+                                      "applyOnUpdate": {
+                                        "type": "string",
+                                        "enum": [
+                                          "always",
+                                          "never"
+                                        ],
+                                        "description": "Whether the default value should be applied when updating a record.\nIf set to `always`, the default value will be applied when updating a record.\nIf set to `never`, the default value will not be applied when updating a record,\nonly when creating a record.\nIf unspecified, then `always` is assumed.\n"
+                                      }
+                                    }
+                                  },
+                                  {
+                                    "title": "Value Default Integer",
+                                    "type": "object",
+                                    "required": [
+                                      "value"
+                                    ],
+                                    "properties": {
+                                      "value": {
+                                        "type": "integer",
+                                        "description": "The value to be used as a default."
+                                      },
+                                      "applyOnUpdate": {
+                                        "type": "string",
+                                        "enum": [
+                                          "always",
+                                          "never"
+                                        ],
+                                        "description": "Whether the default value should be applied when updating a record.\nIf set to `always`, the default value will be applied when updating a record.\nIf set to `never`, the default value will not be applied when updating a record,\nonly when creating a record.\nIf unspecified, then `always` is assumed.\n"
+                                      }
+                                    }
+                                  },
+                                  {
+                                    "title": "Value Default Boolean",
+                                    "type": "object",
+                                    "required": [
+                                      "value"
+                                    ],
+                                    "properties": {
+                                      "value": {
+                                        "type": "boolean",
+                                        "description": "The value to be used as a default."
+                                      },
+                                      "applyOnUpdate": {
+                                        "type": "string",
+                                        "enum": [
+                                          "always",
+                                          "never"
+                                        ],
+                                        "description": "Whether the default value should be applied when updating a record.\nIf set to `always`, the default value will be applied when updating a record.\nIf set to `never`, the default value will not be applied when updating a record,\nonly when creating a record.\nIf unspecified, then `always` is assumed.\n"
+                                      }
+                                    }
+                                  }
+                                ]
+                              }
+                            },
+                            "selectedFieldSettings": {
+                              "type": "object",
+                              "description": "This is a map of field names to their settings.",
+                              "x-go-type-skip-optional-pointer": true,
+                              "additionalProperties": {
+                                "title": "Field setting",
+                                "type": "object",
+                                "properties": {
+                                  "default": {
+                                    "title": "Default value for a field",
+                                    "description": "Only use one of stringValue, integerValue, booleanValue.",
+                                    "type": "object",
+                                    "properties": {
+                                      "stringValue": {
+                                        "type": "string",
+                                        "description": "The default string value to apply to a field"
+                                      },
+                                      "integerValue": {
+                                        "type": "integer",
+                                        "description": "The default integer value to apply to a field"
+                                      },
+                                      "booleanValue": {
+                                        "type": "boolean",
+                                        "description": "The default boolean value to apply to a field"
+                                      }
+                                    }
+                                  },
+                                  "writeOnCreate": {
+                                    "type": "string",
+                                    "enum": [
+                                      "always",
+                                      "never"
+                                    ],
+                                    "default": "always",
+                                    "x-go-type-skip-optional-pointer": true,
+                                    "description": "Whether the default value should be applied when creating a record."
+                                  },
+                                  "writeOnUpdate": {
+                                    "type": "string",
+                                    "enum": [
+                                      "always",
+                                      "never"
+                                    ],
+                                    "default": "always",
+                                    "x-go-type-skip-optional-pointer": true,
+                                    "description": "Whether the default value should be applied when updating a record."
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "objects": {
+                        "additionalProperties": {
+                          "title": "Write Config Object",
+                          "allOf": [
+                            {
+                              "title": "Base Write Config Object",
+                              "type": "object",
+                              "required": [
+                                "objectName"
+                              ],
+                              "properties": {
+                                "objectName": {
+                                  "description": "The name of the object to write to.",
+                                  "example": "account",
+                                  "type": "string",
+                                  "x-oapi-codegen-extra-tags": {
+                                    "validate": "required"
+                                  }
+                                },
+                                "selectedValueDefaults": {
+                                  "type": "object",
+                                  "deprecated": true,
+                                  "description": "This is a map of field names to default values. These values will be used when writing to the object.",
+                                  "x-go-type-skip-optional-pointer": true,
+                                  "additionalProperties": {
+                                    "title": "Value Default (Legacy)",
+                                    "deprecated": true,
+                                    "x-go-type": "any",
+                                    "oneOf": [
+                                      {
+                                        "title": "Value Default String",
+                                        "type": "object",
+                                        "required": [
+                                          "value"
+                                        ],
+                                        "properties": {
+                                          "value": {
+                                            "type": "string",
+                                            "description": "The value to be used as a default."
+                                          },
+                                          "applyOnUpdate": {
+                                            "type": "string",
+                                            "enum": [
+                                              "always",
+                                              "never"
+                                            ],
+                                            "description": "Whether the default value should be applied when updating a record.\nIf set to `always`, the default value will be applied when updating a record.\nIf set to `never`, the default value will not be applied when updating a record,\nonly when creating a record.\nIf unspecified, then `always` is assumed.\n"
+                                          }
+                                        }
+                                      },
+                                      {
+                                        "title": "Value Default Integer",
+                                        "type": "object",
+                                        "required": [
+                                          "value"
+                                        ],
+                                        "properties": {
+                                          "value": {
+                                            "type": "integer",
+                                            "description": "The value to be used as a default."
+                                          },
+                                          "applyOnUpdate": {
+                                            "type": "string",
+                                            "enum": [
+                                              "always",
+                                              "never"
+                                            ],
+                                            "description": "Whether the default value should be applied when updating a record.\nIf set to `always`, the default value will be applied when updating a record.\nIf set to `never`, the default value will not be applied when updating a record,\nonly when creating a record.\nIf unspecified, then `always` is assumed.\n"
+                                          }
+                                        }
+                                      },
+                                      {
+                                        "title": "Value Default Boolean",
+                                        "type": "object",
+                                        "required": [
+                                          "value"
+                                        ],
+                                        "properties": {
+                                          "value": {
+                                            "type": "boolean",
+                                            "description": "The value to be used as a default."
+                                          },
+                                          "applyOnUpdate": {
+                                            "type": "string",
+                                            "enum": [
+                                              "always",
+                                              "never"
+                                            ],
+                                            "description": "Whether the default value should be applied when updating a record.\nIf set to `always`, the default value will be applied when updating a record.\nIf set to `never`, the default value will not be applied when updating a record,\nonly when creating a record.\nIf unspecified, then `always` is assumed.\n"
+                                          }
+                                        }
+                                      }
+                                    ]
+                                  }
+                                },
+                                "selectedFieldSettings": {
+                                  "type": "object",
+                                  "description": "This is a map of field names to their settings.",
+                                  "x-go-type-skip-optional-pointer": true,
+                                  "additionalProperties": {
+                                    "title": "Field setting",
+                                    "type": "object",
+                                    "properties": {
+                                      "default": {
+                                        "title": "Default value for a field",
+                                        "description": "Only use one of stringValue, integerValue, booleanValue.",
+                                        "type": "object",
+                                        "properties": {
+                                          "stringValue": {
+                                            "type": "string",
+                                            "description": "The default string value to apply to a field"
+                                          },
+                                          "integerValue": {
+                                            "type": "integer",
+                                            "description": "The default integer value to apply to a field"
+                                          },
+                                          "booleanValue": {
+                                            "type": "boolean",
+                                            "description": "The default boolean value to apply to a field"
+                                          }
+                                        }
+                                      },
+                                      "writeOnCreate": {
+                                        "type": "string",
+                                        "enum": [
+                                          "always",
+                                          "never"
+                                        ],
+                                        "default": "always",
+                                        "x-go-type-skip-optional-pointer": true,
+                                        "description": "Whether the default value should be applied when creating a record."
+                                      },
+                                      "writeOnUpdate": {
+                                        "type": "string",
+                                        "enum": [
+                                          "always",
+                                          "never"
+                                        ],
+                                        "default": "always",
+                                        "x-go-type-skip-optional-pointer": true,
+                                        "description": "Whether the default value should be applied when updating a record."
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            {
+                              "type": "object",
+                              "required": [
+                                "objectName"
+                              ]
+                            }
+                          ]
+                        }
+                      }
+                    }
+                  }
+                ]
               }
             }
           }
@@ -1292,7 +1863,128 @@
             "properties": {
               "objects": {
                 "additionalProperties": {
-                  "x-go-type": "ReadConfigObject"
+                  "title": "Read Config Object",
+                  "allOf": [
+                    {
+                      "title": "Base Read Config Object",
+                      "type": "object",
+                      "properties": {
+                        "objectName": {
+                          "description": "The name of the object to read from.",
+                          "example": "account",
+                          "type": "string",
+                          "x-oapi-codegen-extra-tags": {
+                            "validate": "required"
+                          }
+                        },
+                        "schedule": {
+                          "type": "string",
+                          "description": "The schedule for reading the object, in cron syntax.",
+                          "example": "*/15 * * * *"
+                        },
+                        "destination": {
+                          "description": "The name of the destination that the result should be sent to.",
+                          "example": "accountWebhook",
+                          "type": "string"
+                        },
+                        "selectedFields": {
+                          "type": "object",
+                          "description": "This is a map of field names to booleans indicating whether they should be read. If a field is already included in `selectedFieldMappings`, it does not need to be included here.",
+                          "example": "{ phone: true, fax: true }",
+                          "additionalProperties": {
+                            "type": "boolean"
+                          }
+                        },
+                        "selectedValueMappings": {
+                          "type": "object",
+                          "description": "This is a map of field names to their value mappings.",
+                          "example": {
+                            "stage": {
+                              "open": "scheduled",
+                              "closedWon": "won",
+                              "closedLost": "lost"
+                            }
+                          },
+                          "x-go-type-skip-optional-pointer": true,
+                          "additionalProperties": {
+                            "title": "Selected Value Mappings",
+                            "type": "object",
+                            "description": "This is a map of values to their mappings. The key is the value delivered to the webhook, the value is the value coming from the provider API.",
+                            "example": {
+                              "open": "scheduled",
+                              "closedWon": "won",
+                              "closedLost": "lost"
+                            },
+                            "x-go-type-skip-optional-pointer": true,
+                            "additionalProperties": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "selectedFieldMappings": {
+                          "type": "object",
+                          "description": "This is a map of mapToNames to field names. (A mapTo name is the name the builder wants to map a field to when it lands in their destination.)",
+                          "example": "{ phoneNumber: phone, faxNumber: fax }",
+                          "additionalProperties": {
+                            "type": "string"
+                          }
+                        },
+                        "selectedFieldsAuto": {
+                          "title": "Selected Fields Auto Config",
+                          "description": "If selectedFieldsAuto is set to all, all fields will be read.",
+                          "type": "string",
+                          "enum": [
+                            "all"
+                          ],
+                          "x-enum-varnames": [
+                            "SelectedFieldsAll"
+                          ]
+                        },
+                        "backfill": {
+                          "title": "Backfill Config",
+                          "type": "object",
+                          "required": [
+                            "defaultPeriod"
+                          ],
+                          "properties": {
+                            "defaultPeriod": {
+                              "title": "Default Period Config",
+                              "type": "object",
+                              "properties": {
+                                "days": {
+                                  "type": "integer",
+                                  "description": "Number of days in past to backfill from. 0 is no backfill. e.g) if 10, then backfill last 10 days of data. Required if fullHistory is not set.",
+                                  "minimum": 0,
+                                  "example": 30,
+                                  "x-oapi-codegen-extra-tags": {
+                                    "validate": "required_without=FullHistory,omitempty,min=0"
+                                  }
+                                },
+                                "fullHistory": {
+                                  "type": "boolean",
+                                  "description": "If true, backfill all history. Required if days is not set.",
+                                  "example": false,
+                                  "x-oapi-codegen-extra-tags": {
+                                    "validate": "required_without=Days"
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    {
+                      "type": "object",
+                      "required": [
+                        "objectName",
+                        "schedule",
+                        "destination",
+                        "selectedFields",
+                        "selectedFieldMappings"
+                      ]
+                    }
+                  ]
                 }
               }
             }
@@ -1584,7 +2276,158 @@
             "properties": {
               "objects": {
                 "additionalProperties": {
-                  "x-go-type": "WriteConfigObject"
+                  "title": "Write Config Object",
+                  "allOf": [
+                    {
+                      "title": "Base Write Config Object",
+                      "type": "object",
+                      "required": [
+                        "objectName"
+                      ],
+                      "properties": {
+                        "objectName": {
+                          "description": "The name of the object to write to.",
+                          "example": "account",
+                          "type": "string",
+                          "x-oapi-codegen-extra-tags": {
+                            "validate": "required"
+                          }
+                        },
+                        "selectedValueDefaults": {
+                          "type": "object",
+                          "deprecated": true,
+                          "description": "This is a map of field names to default values. These values will be used when writing to the object.",
+                          "x-go-type-skip-optional-pointer": true,
+                          "additionalProperties": {
+                            "title": "Value Default (Legacy)",
+                            "deprecated": true,
+                            "x-go-type": "any",
+                            "oneOf": [
+                              {
+                                "title": "Value Default String",
+                                "type": "object",
+                                "required": [
+                                  "value"
+                                ],
+                                "properties": {
+                                  "value": {
+                                    "type": "string",
+                                    "description": "The value to be used as a default."
+                                  },
+                                  "applyOnUpdate": {
+                                    "type": "string",
+                                    "enum": [
+                                      "always",
+                                      "never"
+                                    ],
+                                    "description": "Whether the default value should be applied when updating a record.\nIf set to `always`, the default value will be applied when updating a record.\nIf set to `never`, the default value will not be applied when updating a record,\nonly when creating a record.\nIf unspecified, then `always` is assumed.\n"
+                                  }
+                                }
+                              },
+                              {
+                                "title": "Value Default Integer",
+                                "type": "object",
+                                "required": [
+                                  "value"
+                                ],
+                                "properties": {
+                                  "value": {
+                                    "type": "integer",
+                                    "description": "The value to be used as a default."
+                                  },
+                                  "applyOnUpdate": {
+                                    "type": "string",
+                                    "enum": [
+                                      "always",
+                                      "never"
+                                    ],
+                                    "description": "Whether the default value should be applied when updating a record.\nIf set to `always`, the default value will be applied when updating a record.\nIf set to `never`, the default value will not be applied when updating a record,\nonly when creating a record.\nIf unspecified, then `always` is assumed.\n"
+                                  }
+                                }
+                              },
+                              {
+                                "title": "Value Default Boolean",
+                                "type": "object",
+                                "required": [
+                                  "value"
+                                ],
+                                "properties": {
+                                  "value": {
+                                    "type": "boolean",
+                                    "description": "The value to be used as a default."
+                                  },
+                                  "applyOnUpdate": {
+                                    "type": "string",
+                                    "enum": [
+                                      "always",
+                                      "never"
+                                    ],
+                                    "description": "Whether the default value should be applied when updating a record.\nIf set to `always`, the default value will be applied when updating a record.\nIf set to `never`, the default value will not be applied when updating a record,\nonly when creating a record.\nIf unspecified, then `always` is assumed.\n"
+                                  }
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        "selectedFieldSettings": {
+                          "type": "object",
+                          "description": "This is a map of field names to their settings.",
+                          "x-go-type-skip-optional-pointer": true,
+                          "additionalProperties": {
+                            "title": "Field setting",
+                            "type": "object",
+                            "properties": {
+                              "default": {
+                                "title": "Default value for a field",
+                                "description": "Only use one of stringValue, integerValue, booleanValue.",
+                                "type": "object",
+                                "properties": {
+                                  "stringValue": {
+                                    "type": "string",
+                                    "description": "The default string value to apply to a field"
+                                  },
+                                  "integerValue": {
+                                    "type": "integer",
+                                    "description": "The default integer value to apply to a field"
+                                  },
+                                  "booleanValue": {
+                                    "type": "boolean",
+                                    "description": "The default boolean value to apply to a field"
+                                  }
+                                }
+                              },
+                              "writeOnCreate": {
+                                "type": "string",
+                                "enum": [
+                                  "always",
+                                  "never"
+                                ],
+                                "default": "always",
+                                "x-go-type-skip-optional-pointer": true,
+                                "description": "Whether the default value should be applied when creating a record."
+                              },
+                              "writeOnUpdate": {
+                                "type": "string",
+                                "enum": [
+                                  "always",
+                                  "never"
+                                ],
+                                "default": "always",
+                                "x-go-type-skip-optional-pointer": true,
+                                "description": "Whether the default value should be applied when updating a record."
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    {
+                      "type": "object",
+                      "required": [
+                        "objectName"
+                      ]
+                    }
+                  ]
                 }
               }
             }


### PR DESCRIPTION
Reverts amp-labs/openapi#157

Reintroducing this PR, since reverting it did not fix the Mintlify deployment: https://github.com/amp-labs/docs/runs/41770704902
