### PR TITLE
[ENG-2284] feat: Include original error message in return payload

### DIFF
--- a/api/generated/write.json
+++ b/api/generated/write.json
@@ -186,6 +186,12 @@
                   ],
                   "additionalProperties": false,
                   "properties": {
+                    "rawResponse": {
+                      "type": "string",
+                      "description": "The raw response from the provider, if available",
+                      "example": "{\"error\": \"Record not found\"}",
+                      "x-go-type-skip-optional-pointer": true
+                    },
                     "errors": {
                       "type": "array",
                       "description": "Error messages resulted in failures",
@@ -504,6 +510,12 @@
         ],
         "additionalProperties": false,
         "properties": {
+          "rawResponse": {
+            "type": "string",
+            "description": "The raw response from the provider, if available",
+            "example": "{\"error\": \"Record not found\"}",
+            "x-go-type-skip-optional-pointer": true
+          },
           "errors": {
             "type": "array",
             "description": "Error messages resulted in failures",

--- a/api/write.yaml
+++ b/api/write.yaml
@@ -136,6 +136,11 @@ components:
         - operationId
       additionalProperties: false
       properties:
+        rawResponse:
+          type: string
+          description: The raw response from the provider, if available
+          example: "{\"error\": \"Record not found\"}"
+          x-go-type-skip-optional-pointer: true
         errors:
           type: array
           description: Error messages resulted in failures


### PR DESCRIPTION
This adds an optional field for write errors which lets us return the original response body that we get from the provider.