### PR TITLE
rollback never

### DIFF
--- a/api/generated/api.json
+++ b/api/generated/api.json
@@ -6341,8 +6341,7 @@
                                               "type": "string",
                                               "description": "If always, the integration will subscribe to create events by default.",
                                               "enum": [
-                                                "always",
-                                                "never"
+                                                "always"
                                               ]
                                             }
                                           }
@@ -6354,8 +6353,7 @@
                                               "type": "string",
                                               "description": "If always, the integration will subscribe to update events by default.",
                                               "enum": [
-                                                "always",
-                                                "never"
+                                                "always"
                                               ]
                                             },
                                             "watchFieldsAuto": {
@@ -6386,8 +6384,7 @@
                                               "type": "string",
                                               "description": "If always, the integration will subscribe to delete events by default.",
                                               "enum": [
-                                                "always",
-                                                "never"
+                                                "always"
                                               ]
                                             }
                                           }
@@ -7249,8 +7246,7 @@
                                           "type": "string",
                                           "description": "If always, the integration will subscribe to create events by default.",
                                           "enum": [
-                                            "always",
-                                            "never"
+                                            "always"
                                           ]
                                         }
                                       }
@@ -7262,8 +7258,7 @@
                                           "type": "string",
                                           "description": "If always, the integration will subscribe to update events by default.",
                                           "enum": [
-                                            "always",
-                                            "never"
+                                            "always"
                                           ]
                                         },
                                         "watchFieldsAuto": {
@@ -7294,8 +7289,7 @@
                                           "type": "string",
                                           "description": "If always, the integration will subscribe to delete events by default.",
                                           "enum": [
-                                            "always",
-                                            "never"
+                                            "always"
                                           ]
                                         }
                                       }
@@ -9371,8 +9365,7 @@
                                               "type": "string",
                                               "description": "If always, the integration will subscribe to create events by default.",
                                               "enum": [
-                                                "always",
-                                                "never"
+                                                "always"
                                               ]
                                             }
                                           }
@@ -9384,8 +9377,7 @@
                                               "type": "string",
                                               "description": "If always, the integration will subscribe to update events by default.",
                                               "enum": [
-                                                "always",
-                                                "never"
+                                                "always"
                                               ]
                                             },
                                             "watchFieldsAuto": {
@@ -9416,8 +9408,7 @@
                                               "type": "string",
                                               "description": "If always, the integration will subscribe to delete events by default.",
                                               "enum": [
-                                                "always",
-                                                "never"
+                                                "always"
                                               ]
                                             }
                                           }
@@ -44993,8 +44984,7 @@
                                   "type": "string",
                                   "description": "If always, the integration will subscribe to create events by default.",
                                   "enum": [
-                                    "always",
-                                    "never"
+                                    "always"
                                   ]
                                 }
                               }
@@ -45006,8 +44996,7 @@
                                   "type": "string",
                                   "description": "If always, the integration will subscribe to update events by default.",
                                   "enum": [
-                                    "always",
-                                    "never"
+                                    "always"
                                   ]
                                 },
                                 "watchFieldsAuto": {
@@ -45038,8 +45027,7 @@
                                   "type": "string",
                                   "description": "If always, the integration will subscribe to delete events by default.",
                                   "enum": [
-                                    "always",
-                                    "never"
+                                    "always"
                                   ]
                                 }
                               }
@@ -45411,8 +45399,7 @@
                               "type": "string",
                               "description": "If always, the integration will subscribe to create events by default.",
                               "enum": [
-                                "always",
-                                "never"
+                                "always"
                               ]
                             }
                           }
@@ -45424,8 +45411,7 @@
                               "type": "string",
                               "description": "If always, the integration will subscribe to update events by default.",
                               "enum": [
-                                "always",
-                                "never"
+                                "always"
                               ]
                             },
                             "watchFieldsAuto": {
@@ -45456,8 +45442,7 @@
                               "type": "string",
                               "description": "If always, the integration will subscribe to delete events by default.",
                               "enum": [
-                                "always",
-                                "never"
+                                "always"
                               ]
                             }
                           }

--- a/manifest/generated/manifest.json
+++ b/manifest/generated/manifest.json
@@ -331,8 +331,7 @@
                                 "type": "string",
                                 "description": "If always, the integration will subscribe to create events by default.",
                                 "enum": [
-                                  "always",
-                                  "never"
+                                  "always"
                                 ]
                               }
                             }
@@ -344,8 +343,7 @@
                                 "type": "string",
                                 "description": "If always, the integration will subscribe to update events by default.",
                                 "enum": [
-                                  "always",
-                                  "never"
+                                  "always"
                                 ]
                               },
                               "watchFieldsAuto": {
@@ -376,8 +374,7 @@
                                 "type": "string",
                                 "description": "If always, the integration will subscribe to delete events by default.",
                                 "enum": [
-                                  "always",
-                                  "never"
+                                  "always"
                                 ]
                               }
                             }
@@ -723,8 +720,7 @@
                           "type": "string",
                           "description": "If always, the integration will subscribe to create events by default.",
                           "enum": [
-                            "always",
-                            "never"
+                            "always"
                           ]
                         }
                       }
@@ -736,8 +732,7 @@
                           "type": "string",
                           "description": "If always, the integration will subscribe to update events by default.",
                           "enum": [
-                            "always",
-                            "never"
+                            "always"
                           ]
                         },
                         "watchFieldsAuto": {
@@ -768,8 +763,7 @@
                           "type": "string",
                           "description": "If always, the integration will subscribe to delete events by default.",
                           "enum": [
-                            "always",
-                            "never"
+                            "always"
                           ]
                         }
                       }
@@ -1095,8 +1089,7 @@
                       "type": "string",
                       "description": "If always, the integration will subscribe to create events by default.",
                       "enum": [
-                        "always",
-                        "never"
+                        "always"
                       ]
                     }
                   }
@@ -1108,8 +1101,7 @@
                       "type": "string",
                       "description": "If always, the integration will subscribe to update events by default.",
                       "enum": [
-                        "always",
-                        "never"
+                        "always"
                       ]
                     },
                     "watchFieldsAuto": {
@@ -1140,8 +1132,7 @@
                       "type": "string",
                       "description": "If always, the integration will subscribe to delete events by default.",
                       "enum": [
-                        "always",
-                        "never"
+                        "always"
                       ]
                     }
                   }
@@ -1432,8 +1423,7 @@
                 "type": "string",
                 "description": "If always, the integration will subscribe to create events by default.",
                 "enum": [
-                  "always",
-                  "never"
+                  "always"
                 ]
               }
             }
@@ -1445,8 +1435,7 @@
                 "type": "string",
                 "description": "If always, the integration will subscribe to update events by default.",
                 "enum": [
-                  "always",
-                  "never"
+                  "always"
                 ]
               },
               "watchFieldsAuto": {
@@ -1477,8 +1466,7 @@
                 "type": "string",
                 "description": "If always, the integration will subscribe to delete events by default.",
                 "enum": [
-                  "always",
-                  "never"
+                  "always"
                 ]
               }
             }
@@ -1519,8 +1507,7 @@
             "type": "string",
             "description": "If always, the integration will subscribe to create events by default.",
             "enum": [
-              "always",
-              "never"
+              "always"
             ]
           }
         }
@@ -1532,8 +1519,7 @@
             "type": "string",
             "description": "If always, the integration will subscribe to update events by default.",
             "enum": [
-              "always",
-              "never"
+              "always"
             ]
           },
           "watchFieldsAuto": {
@@ -1564,8 +1550,7 @@
             "type": "string",
             "description": "If always, the integration will subscribe to delete events by default.",
             "enum": [
-              "always",
-              "never"
+              "always"
             ]
           }
         }

--- a/manifest/manifest.yaml
+++ b/manifest/manifest.yaml
@@ -177,7 +177,7 @@ components:
         enabled:
           type: string
           description: If always, the integration will subscribe to create events by default.
-          enum: [always, never]
+          enum: [always]
 
     UpdateEvent:
       type: object
@@ -185,7 +185,7 @@ components:
         enabled:
           type: string
           description: If always, the integration will subscribe to update events by default.
-          enum: [always, never]
+          enum: [always]
         watchFieldsAuto:
           type: string
           description: If all, the integration will watch all fields for updates.
@@ -206,7 +206,7 @@ components:
         enabled:
           type: string
           description: If always, the integration will subscribe to delete events by default.
-          enum: [always, never]
+          enum: [always]
 
     AssociationChangeEvent:
       type: object


### PR DESCRIPTION
Reverting never for manifest. we only need one for config, but manifest can leave enabled empty which will be equivalent to never

reverting changes from: https://github.com/amp-labs/openapi/pull/169
but keeping never from config. 