### PR TITLE
Remove required validation tag to accept `never` override

### DIFF
--- a/api/generated/api.json
+++ b/api/generated/api.json
@@ -13410,10 +13410,7 @@
                                                 "destination": {
                                                   "description": "The name of the destination that the result should be sent to.",
                                                   "example": "accountWebhook",
-                                                  "type": "string",
-                                                  "x-oapi-codegen-extra-tags": {
-                                                    "validate": "required"
-                                                  }
+                                                  "type": "string"
                                                 },
                                                 "createEvent": {
                                                   "title": "Create Event",
@@ -13542,10 +13539,7 @@
                                                     "destination": {
                                                       "description": "The name of the destination that the result should be sent to.",
                                                       "example": "accountWebhook",
-                                                      "type": "string",
-                                                      "x-oapi-codegen-extra-tags": {
-                                                        "validate": "required"
-                                                      }
+                                                      "type": "string"
                                                     },
                                                     "createEvent": {
                                                       "title": "Create Event",
@@ -15097,10 +15091,7 @@
                                             "destination": {
                                               "description": "The name of the destination that the result should be sent to.",
                                               "example": "accountWebhook",
-                                              "type": "string",
-                                              "x-oapi-codegen-extra-tags": {
-                                                "validate": "required"
-                                              }
+                                              "type": "string"
                                             },
                                             "createEvent": {
                                               "title": "Create Event",
@@ -15229,10 +15220,7 @@
                                                 "destination": {
                                                   "description": "The name of the destination that the result should be sent to.",
                                                   "example": "accountWebhook",
-                                                  "type": "string",
-                                                  "x-oapi-codegen-extra-tags": {
-                                                    "validate": "required"
-                                                  }
+                                                  "type": "string"
                                                 },
                                                 "createEvent": {
                                                   "title": "Create Event",
@@ -16696,10 +16684,7 @@
                                               "destination": {
                                                 "description": "The name of the destination that the result should be sent to.",
                                                 "example": "accountWebhook",
-                                                "type": "string",
-                                                "x-oapi-codegen-extra-tags": {
-                                                  "validate": "required"
-                                                }
+                                                "type": "string"
                                               },
                                               "createEvent": {
                                                 "title": "Create Event",
@@ -16828,10 +16813,7 @@
                                                   "destination": {
                                                     "description": "The name of the destination that the result should be sent to.",
                                                     "example": "accountWebhook",
-                                                    "type": "string",
-                                                    "x-oapi-codegen-extra-tags": {
-                                                      "validate": "required"
-                                                    }
+                                                    "type": "string"
                                                   },
                                                   "createEvent": {
                                                     "title": "Create Event",
@@ -19117,10 +19099,7 @@
                                               "destination": {
                                                 "description": "The name of the destination that the result should be sent to.",
                                                 "example": "accountWebhook",
-                                                "type": "string",
-                                                "x-oapi-codegen-extra-tags": {
-                                                  "validate": "required"
-                                                }
+                                                "type": "string"
                                               },
                                               "createEvent": {
                                                 "title": "Create Event",
@@ -19249,10 +19228,7 @@
                                                   "destination": {
                                                     "description": "The name of the destination that the result should be sent to.",
                                                     "example": "accountWebhook",
-                                                    "type": "string",
-                                                    "x-oapi-codegen-extra-tags": {
-                                                      "validate": "required"
-                                                    }
+                                                    "type": "string"
                                                   },
                                                   "createEvent": {
                                                     "title": "Create Event",
@@ -21739,10 +21715,7 @@
                                               "destination": {
                                                 "description": "The name of the destination that the result should be sent to.",
                                                 "example": "accountWebhook",
-                                                "type": "string",
-                                                "x-oapi-codegen-extra-tags": {
-                                                  "validate": "required"
-                                                }
+                                                "type": "string"
                                               },
                                               "createEvent": {
                                                 "title": "Create Event",
@@ -21871,10 +21844,7 @@
                                                   "destination": {
                                                     "description": "The name of the destination that the result should be sent to.",
                                                     "example": "accountWebhook",
-                                                    "type": "string",
-                                                    "x-oapi-codegen-extra-tags": {
-                                                      "validate": "required"
-                                                    }
+                                                    "type": "string"
                                                   },
                                                   "createEvent": {
                                                     "title": "Create Event",
@@ -47250,10 +47220,7 @@
                                     "destination": {
                                       "description": "The name of the destination that the result should be sent to.",
                                       "example": "accountWebhook",
-                                      "type": "string",
-                                      "x-oapi-codegen-extra-tags": {
-                                        "validate": "required"
-                                      }
+                                      "type": "string"
                                     },
                                     "createEvent": {
                                       "title": "Create Event",
@@ -47382,10 +47349,7 @@
                                         "destination": {
                                           "description": "The name of the destination that the result should be sent to.",
                                           "example": "accountWebhook",
-                                          "type": "string",
-                                          "x-oapi-codegen-extra-tags": {
-                                            "validate": "required"
-                                          }
+                                          "type": "string"
                                         },
                                         "createEvent": {
                                           "title": "Create Event",
@@ -48442,10 +48406,7 @@
                                 "destination": {
                                   "description": "The name of the destination that the result should be sent to.",
                                   "example": "accountWebhook",
-                                  "type": "string",
-                                  "x-oapi-codegen-extra-tags": {
-                                    "validate": "required"
-                                  }
+                                  "type": "string"
                                 },
                                 "createEvent": {
                                   "title": "Create Event",
@@ -48574,10 +48535,7 @@
                                     "destination": {
                                       "description": "The name of the destination that the result should be sent to.",
                                       "example": "accountWebhook",
-                                      "type": "string",
-                                      "x-oapi-codegen-extra-tags": {
-                                        "validate": "required"
-                                      }
+                                      "type": "string"
                                     },
                                     "createEvent": {
                                       "title": "Create Event",

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -171,8 +171,6 @@ components:
           description: The name of the destination that the result should be sent to.
           example: accountWebhook
           type: string
-          x-oapi-codegen-extra-tags:
-            validate: required
         createEvent:
           $ref: '#/components/schemas/ConfigCreateEvent'
         updateEvent:

--- a/config/generated/config.json
+++ b/config/generated/config.json
@@ -882,10 +882,7 @@
                 "destination": {
                   "description": "The name of the destination that the result should be sent to.",
                   "example": "accountWebhook",
-                  "type": "string",
-                  "x-oapi-codegen-extra-tags": {
-                    "validate": "required"
-                  }
+                  "type": "string"
                 },
                 "createEvent": {
                   "title": "Create Event",
@@ -1004,10 +1001,7 @@
           "destination": {
             "description": "The name of the destination that the result should be sent to.",
             "example": "accountWebhook",
-            "type": "string",
-            "x-oapi-codegen-extra-tags": {
-              "validate": "required"
-            }
+            "type": "string"
           },
           "createEvent": {
             "title": "Create Event",
@@ -2097,10 +2091,7 @@
                             "destination": {
                               "description": "The name of the destination that the result should be sent to.",
                               "example": "accountWebhook",
-                              "type": "string",
-                              "x-oapi-codegen-extra-tags": {
-                                "validate": "required"
-                              }
+                              "type": "string"
                             },
                             "createEvent": {
                               "title": "Create Event",
@@ -2229,10 +2220,7 @@
                                 "destination": {
                                   "description": "The name of the destination that the result should be sent to.",
                                   "example": "accountWebhook",
-                                  "type": "string",
-                                  "x-oapi-codegen-extra-tags": {
-                                    "validate": "required"
-                                  }
+                                  "type": "string"
                                 },
                                 "createEvent": {
                                   "title": "Create Event",
@@ -3231,10 +3219,7 @@
                     "destination": {
                       "description": "The name of the destination that the result should be sent to.",
                       "example": "accountWebhook",
-                      "type": "string",
-                      "x-oapi-codegen-extra-tags": {
-                        "validate": "required"
-                      }
+                      "type": "string"
                     },
                     "createEvent": {
                       "title": "Create Event",
@@ -3363,10 +3348,7 @@
                         "destination": {
                           "description": "The name of the destination that the result should be sent to.",
                           "example": "accountWebhook",
-                          "type": "string",
-                          "x-oapi-codegen-extra-tags": {
-                            "validate": "required"
-                          }
+                          "type": "string"
                         },
                         "createEvent": {
                           "title": "Create Event",
@@ -3500,10 +3482,7 @@
               "destination": {
                 "description": "The name of the destination that the result should be sent to.",
                 "example": "accountWebhook",
-                "type": "string",
-                "x-oapi-codegen-extra-tags": {
-                  "validate": "required"
-                }
+                "type": "string"
               },
               "createEvent": {
                 "title": "Create Event",


### PR DESCRIPTION
We are now supporting config overriding revision to never. So if all events are overridden to never, destination is not required. 