### PR TITLE
Remove validation for config requiredWatchFields 

### DIFF
--- a/api/generated/api.json
+++ b/api/generated/api.json
@@ -13452,9 +13452,6 @@
                                                       }
                                                     },
                                                     "watchFieldsAuto": {
-                                                      "x-oapi-codegen-extra-tags": {
-                                                        "validate": "required_without=RequiredWatchFields"
-                                                      },
                                                       "type": "string",
                                                       "description": "Whether to watch fields all fields automatically.",
                                                       "example": "all",
@@ -13463,9 +13460,6 @@
                                                       ]
                                                     },
                                                     "requiredWatchFields": {
-                                                      "x-oapi-codegen-extra-tags": {
-                                                        "validate": "required_without=WatchFieldsAuto,min=1"
-                                                      },
                                                       "type": "array",
                                                       "items": {
                                                         "type": "string"
@@ -13581,9 +13575,6 @@
                                                           }
                                                         },
                                                         "watchFieldsAuto": {
-                                                          "x-oapi-codegen-extra-tags": {
-                                                            "validate": "required_without=RequiredWatchFields"
-                                                          },
                                                           "type": "string",
                                                           "description": "Whether to watch fields all fields automatically.",
                                                           "example": "all",
@@ -13592,9 +13583,6 @@
                                                           ]
                                                         },
                                                         "requiredWatchFields": {
-                                                          "x-oapi-codegen-extra-tags": {
-                                                            "validate": "required_without=WatchFieldsAuto,min=1"
-                                                          },
                                                           "type": "array",
                                                           "items": {
                                                             "type": "string"
@@ -15133,9 +15121,6 @@
                                                   }
                                                 },
                                                 "watchFieldsAuto": {
-                                                  "x-oapi-codegen-extra-tags": {
-                                                    "validate": "required_without=RequiredWatchFields"
-                                                  },
                                                   "type": "string",
                                                   "description": "Whether to watch fields all fields automatically.",
                                                   "example": "all",
@@ -15144,9 +15129,6 @@
                                                   ]
                                                 },
                                                 "requiredWatchFields": {
-                                                  "x-oapi-codegen-extra-tags": {
-                                                    "validate": "required_without=WatchFieldsAuto,min=1"
-                                                  },
                                                   "type": "array",
                                                   "items": {
                                                     "type": "string"
@@ -15262,9 +15244,6 @@
                                                       }
                                                     },
                                                     "watchFieldsAuto": {
-                                                      "x-oapi-codegen-extra-tags": {
-                                                        "validate": "required_without=RequiredWatchFields"
-                                                      },
                                                       "type": "string",
                                                       "description": "Whether to watch fields all fields automatically.",
                                                       "example": "all",
@@ -15273,9 +15252,6 @@
                                                       ]
                                                     },
                                                     "requiredWatchFields": {
-                                                      "x-oapi-codegen-extra-tags": {
-                                                        "validate": "required_without=WatchFieldsAuto,min=1"
-                                                      },
                                                       "type": "array",
                                                       "items": {
                                                         "type": "string"
@@ -16726,9 +16702,6 @@
                                                     }
                                                   },
                                                   "watchFieldsAuto": {
-                                                    "x-oapi-codegen-extra-tags": {
-                                                      "validate": "required_without=RequiredWatchFields"
-                                                    },
                                                     "type": "string",
                                                     "description": "Whether to watch fields all fields automatically.",
                                                     "example": "all",
@@ -16737,9 +16710,6 @@
                                                     ]
                                                   },
                                                   "requiredWatchFields": {
-                                                    "x-oapi-codegen-extra-tags": {
-                                                      "validate": "required_without=WatchFieldsAuto,min=1"
-                                                    },
                                                     "type": "array",
                                                     "items": {
                                                       "type": "string"
@@ -16855,9 +16825,6 @@
                                                         }
                                                       },
                                                       "watchFieldsAuto": {
-                                                        "x-oapi-codegen-extra-tags": {
-                                                          "validate": "required_without=RequiredWatchFields"
-                                                        },
                                                         "type": "string",
                                                         "description": "Whether to watch fields all fields automatically.",
                                                         "example": "all",
@@ -16866,9 +16833,6 @@
                                                         ]
                                                       },
                                                       "requiredWatchFields": {
-                                                        "x-oapi-codegen-extra-tags": {
-                                                          "validate": "required_without=WatchFieldsAuto,min=1"
-                                                        },
                                                         "type": "array",
                                                         "items": {
                                                           "type": "string"
@@ -19141,9 +19105,6 @@
                                                     }
                                                   },
                                                   "watchFieldsAuto": {
-                                                    "x-oapi-codegen-extra-tags": {
-                                                      "validate": "required_without=RequiredWatchFields"
-                                                    },
                                                     "type": "string",
                                                     "description": "Whether to watch fields all fields automatically.",
                                                     "example": "all",
@@ -19152,9 +19113,6 @@
                                                     ]
                                                   },
                                                   "requiredWatchFields": {
-                                                    "x-oapi-codegen-extra-tags": {
-                                                      "validate": "required_without=WatchFieldsAuto,min=1"
-                                                    },
                                                     "type": "array",
                                                     "items": {
                                                       "type": "string"
@@ -19270,9 +19228,6 @@
                                                         }
                                                       },
                                                       "watchFieldsAuto": {
-                                                        "x-oapi-codegen-extra-tags": {
-                                                          "validate": "required_without=RequiredWatchFields"
-                                                        },
                                                         "type": "string",
                                                         "description": "Whether to watch fields all fields automatically.",
                                                         "example": "all",
@@ -19281,9 +19236,6 @@
                                                         ]
                                                       },
                                                       "requiredWatchFields": {
-                                                        "x-oapi-codegen-extra-tags": {
-                                                          "validate": "required_without=WatchFieldsAuto,min=1"
-                                                        },
                                                         "type": "array",
                                                         "items": {
                                                           "type": "string"
@@ -21757,9 +21709,6 @@
                                                     }
                                                   },
                                                   "watchFieldsAuto": {
-                                                    "x-oapi-codegen-extra-tags": {
-                                                      "validate": "required_without=RequiredWatchFields"
-                                                    },
                                                     "type": "string",
                                                     "description": "Whether to watch fields all fields automatically.",
                                                     "example": "all",
@@ -21768,9 +21717,6 @@
                                                     ]
                                                   },
                                                   "requiredWatchFields": {
-                                                    "x-oapi-codegen-extra-tags": {
-                                                      "validate": "required_without=WatchFieldsAuto,min=1"
-                                                    },
                                                     "type": "array",
                                                     "items": {
                                                       "type": "string"
@@ -21886,9 +21832,6 @@
                                                         }
                                                       },
                                                       "watchFieldsAuto": {
-                                                        "x-oapi-codegen-extra-tags": {
-                                                          "validate": "required_without=RequiredWatchFields"
-                                                        },
                                                         "type": "string",
                                                         "description": "Whether to watch fields all fields automatically.",
                                                         "example": "all",
@@ -21897,9 +21840,6 @@
                                                         ]
                                                       },
                                                       "requiredWatchFields": {
-                                                        "x-oapi-codegen-extra-tags": {
-                                                          "validate": "required_without=WatchFieldsAuto,min=1"
-                                                        },
                                                         "type": "array",
                                                         "items": {
                                                           "type": "string"
@@ -47262,9 +47202,6 @@
                                           }
                                         },
                                         "watchFieldsAuto": {
-                                          "x-oapi-codegen-extra-tags": {
-                                            "validate": "required_without=RequiredWatchFields"
-                                          },
                                           "type": "string",
                                           "description": "Whether to watch fields all fields automatically.",
                                           "example": "all",
@@ -47273,9 +47210,6 @@
                                           ]
                                         },
                                         "requiredWatchFields": {
-                                          "x-oapi-codegen-extra-tags": {
-                                            "validate": "required_without=WatchFieldsAuto,min=1"
-                                          },
                                           "type": "array",
                                           "items": {
                                             "type": "string"
@@ -47391,9 +47325,6 @@
                                               }
                                             },
                                             "watchFieldsAuto": {
-                                              "x-oapi-codegen-extra-tags": {
-                                                "validate": "required_without=RequiredWatchFields"
-                                              },
                                               "type": "string",
                                               "description": "Whether to watch fields all fields automatically.",
                                               "example": "all",
@@ -47402,9 +47333,6 @@
                                               ]
                                             },
                                             "requiredWatchFields": {
-                                              "x-oapi-codegen-extra-tags": {
-                                                "validate": "required_without=WatchFieldsAuto,min=1"
-                                              },
                                               "type": "array",
                                               "items": {
                                                 "type": "string"
@@ -48448,9 +48376,6 @@
                                       }
                                     },
                                     "watchFieldsAuto": {
-                                      "x-oapi-codegen-extra-tags": {
-                                        "validate": "required_without=RequiredWatchFields"
-                                      },
                                       "type": "string",
                                       "description": "Whether to watch fields all fields automatically.",
                                       "example": "all",
@@ -48459,9 +48384,6 @@
                                       ]
                                     },
                                     "requiredWatchFields": {
-                                      "x-oapi-codegen-extra-tags": {
-                                        "validate": "required_without=WatchFieldsAuto,min=1"
-                                      },
                                       "type": "array",
                                       "items": {
                                         "type": "string"
@@ -48577,9 +48499,6 @@
                                           }
                                         },
                                         "watchFieldsAuto": {
-                                          "x-oapi-codegen-extra-tags": {
-                                            "validate": "required_without=RequiredWatchFields"
-                                          },
                                           "type": "string",
                                           "description": "Whether to watch fields all fields automatically.",
                                           "example": "all",
@@ -48588,9 +48507,6 @@
                                           ]
                                         },
                                         "requiredWatchFields": {
-                                          "x-oapi-codegen-extra-tags": {
-                                            "validate": "required_without=WatchFieldsAuto,min=1"
-                                          },
                                           "type": "array",
                                           "items": {
                                             "type": "string"

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -205,15 +205,11 @@ components:
           x-oapi-codegen-extra-tags:
             validate: oneof=always never
         watchFieldsAuto:
-          x-oapi-codegen-extra-tags:
-            validate: required_without=RequiredWatchFields
           type: string
           description: Whether to watch fields all fields automatically.
           example: all
           enum: [ all ]
         requiredWatchFields:
-          x-oapi-codegen-extra-tags:
-            validate: required_without=WatchFieldsAuto,min=1
           type: array
           items:
             type: string

--- a/config/generated/config.json
+++ b/config/generated/config.json
@@ -924,9 +924,6 @@
                       }
                     },
                     "watchFieldsAuto": {
-                      "x-oapi-codegen-extra-tags": {
-                        "validate": "required_without=RequiredWatchFields"
-                      },
                       "type": "string",
                       "description": "Whether to watch fields all fields automatically.",
                       "example": "all",
@@ -935,9 +932,6 @@
                       ]
                     },
                     "requiredWatchFields": {
-                      "x-oapi-codegen-extra-tags": {
-                        "validate": "required_without=WatchFieldsAuto,min=1"
-                      },
                       "type": "array",
                       "items": {
                         "type": "string"
@@ -1043,9 +1037,6 @@
                 }
               },
               "watchFieldsAuto": {
-                "x-oapi-codegen-extra-tags": {
-                  "validate": "required_without=RequiredWatchFields"
-                },
                 "type": "string",
                 "description": "Whether to watch fields all fields automatically.",
                 "example": "all",
@@ -1054,9 +1045,6 @@
                 ]
               },
               "requiredWatchFields": {
-                "x-oapi-codegen-extra-tags": {
-                  "validate": "required_without=WatchFieldsAuto,min=1"
-                },
                 "type": "array",
                 "items": {
                   "type": "string"
@@ -1132,9 +1120,6 @@
             }
           },
           "watchFieldsAuto": {
-            "x-oapi-codegen-extra-tags": {
-              "validate": "required_without=RequiredWatchFields"
-            },
             "type": "string",
             "description": "Whether to watch fields all fields automatically.",
             "example": "all",
@@ -1143,9 +1128,6 @@
             ]
           },
           "requiredWatchFields": {
-            "x-oapi-codegen-extra-tags": {
-              "validate": "required_without=WatchFieldsAuto,min=1"
-            },
             "type": "array",
             "items": {
               "type": "string"
@@ -2133,9 +2115,6 @@
                                   }
                                 },
                                 "watchFieldsAuto": {
-                                  "x-oapi-codegen-extra-tags": {
-                                    "validate": "required_without=RequiredWatchFields"
-                                  },
                                   "type": "string",
                                   "description": "Whether to watch fields all fields automatically.",
                                   "example": "all",
@@ -2144,9 +2123,6 @@
                                   ]
                                 },
                                 "requiredWatchFields": {
-                                  "x-oapi-codegen-extra-tags": {
-                                    "validate": "required_without=WatchFieldsAuto,min=1"
-                                  },
                                   "type": "array",
                                   "items": {
                                     "type": "string"
@@ -2262,9 +2238,6 @@
                                       }
                                     },
                                     "watchFieldsAuto": {
-                                      "x-oapi-codegen-extra-tags": {
-                                        "validate": "required_without=RequiredWatchFields"
-                                      },
                                       "type": "string",
                                       "description": "Whether to watch fields all fields automatically.",
                                       "example": "all",
@@ -2273,9 +2246,6 @@
                                       ]
                                     },
                                     "requiredWatchFields": {
-                                      "x-oapi-codegen-extra-tags": {
-                                        "validate": "required_without=WatchFieldsAuto,min=1"
-                                      },
                                       "type": "array",
                                       "items": {
                                         "type": "string"
@@ -3261,9 +3231,6 @@
                           }
                         },
                         "watchFieldsAuto": {
-                          "x-oapi-codegen-extra-tags": {
-                            "validate": "required_without=RequiredWatchFields"
-                          },
                           "type": "string",
                           "description": "Whether to watch fields all fields automatically.",
                           "example": "all",
@@ -3272,9 +3239,6 @@
                           ]
                         },
                         "requiredWatchFields": {
-                          "x-oapi-codegen-extra-tags": {
-                            "validate": "required_without=WatchFieldsAuto,min=1"
-                          },
                           "type": "array",
                           "items": {
                             "type": "string"
@@ -3390,9 +3354,6 @@
                               }
                             },
                             "watchFieldsAuto": {
-                              "x-oapi-codegen-extra-tags": {
-                                "validate": "required_without=RequiredWatchFields"
-                              },
                               "type": "string",
                               "description": "Whether to watch fields all fields automatically.",
                               "example": "all",
@@ -3401,9 +3362,6 @@
                               ]
                             },
                             "requiredWatchFields": {
-                              "x-oapi-codegen-extra-tags": {
-                                "validate": "required_without=WatchFieldsAuto,min=1"
-                              },
                               "type": "array",
                               "items": {
                                 "type": "string"
@@ -3524,9 +3482,6 @@
                     }
                   },
                   "watchFieldsAuto": {
-                    "x-oapi-codegen-extra-tags": {
-                      "validate": "required_without=RequiredWatchFields"
-                    },
                     "type": "string",
                     "description": "Whether to watch fields all fields automatically.",
                     "example": "all",
@@ -3535,9 +3490,6 @@
                     ]
                   },
                   "requiredWatchFields": {
-                    "x-oapi-codegen-extra-tags": {
-                      "validate": "required_without=WatchFieldsAuto,min=1"
-                    },
                     "type": "array",
                     "items": {
                       "type": "string"


### PR DESCRIPTION
This make the go type to become *[]string

We run validation on the struct and validation library panics for that type. So we will remove tag here and do manual validation in server