### PR TITLE
add go tags for valueTemplate so that substitutions will be skipped

### DIFF
--- a/api/generated/api.json
+++ b/api/generated/api.json
@@ -26306,7 +26306,10 @@
                                 "valueTemplate": {
                                   "type": "string",
                                   "example": "Bearer {{ .token }}",
-                                  "description": "The value of the header, represented as a Golang text/template expression. Only the backend will interpret this."
+                                  "description": "The value of the header, represented as a Golang text/template expression. Only the backend will interpret this.",
+                                  "x-oapi-codegen-extra-tags": {
+                                    "skipSubstitutions": "true"
+                                  }
                                 }
                               }
                             },
@@ -26332,7 +26335,10 @@
                                 "valueTemplate": {
                                   "type": "string",
                                   "example": "{{ .token }}",
-                                  "description": "The value of the query parameter, represented as a Golang text/template expression. Only the backend will interpret this."
+                                  "description": "The value of the query parameter, represented as a Golang text/template expression. Only the backend will interpret this.",
+                                  "x-oapi-codegen-extra-tags": {
+                                    "skipSubstitutions": "true"
+                                  }
                                 }
                               }
                             },
@@ -27258,7 +27264,10 @@
                               "valueTemplate": {
                                 "type": "string",
                                 "example": "Bearer {{ .token }}",
-                                "description": "The value of the header, represented as a Golang text/template expression. Only the backend will interpret this."
+                                "description": "The value of the header, represented as a Golang text/template expression. Only the backend will interpret this.",
+                                "x-oapi-codegen-extra-tags": {
+                                  "skipSubstitutions": "true"
+                                }
                               }
                             }
                           },
@@ -27284,7 +27293,10 @@
                               "valueTemplate": {
                                 "type": "string",
                                 "example": "{{ .token }}",
-                                "description": "The value of the query parameter, represented as a Golang text/template expression. Only the backend will interpret this."
+                                "description": "The value of the query parameter, represented as a Golang text/template expression. Only the backend will interpret this.",
+                                "x-oapi-codegen-extra-tags": {
+                                  "skipSubstitutions": "true"
+                                }
                               }
                             }
                           },

--- a/catalog/catalog.yaml
+++ b/catalog/catalog.yaml
@@ -312,6 +312,8 @@ components:
           type: string
           example: "Bearer {{ .token }}"
           description: The value of the header, represented as a Golang text/template expression. Only the backend will interpret this.
+          x-oapi-codegen-extra-tags:
+            skipSubstitutions: "true"
 
     CustomAuthQueryParam:
       title: Custom Auth Query Parameter
@@ -329,6 +331,8 @@ components:
           type: string
           example: "{{ .token }}"
           description: "The value of the query parameter, represented as a Golang text/template expression. Only the backend will interpret this."
+          x-oapi-codegen-extra-tags:
+            skipSubstitutions: "true"
 
     CustomAuthInput:
       title: Custom Auth Input

--- a/catalog/generated/catalog.json
+++ b/catalog/generated/catalog.json
@@ -594,7 +594,10 @@
           "valueTemplate": {
             "type": "string",
             "example": "Bearer {{ .token }}",
-            "description": "The value of the header, represented as a Golang text/template expression. Only the backend will interpret this."
+            "description": "The value of the header, represented as a Golang text/template expression. Only the backend will interpret this.",
+            "x-oapi-codegen-extra-tags": {
+              "skipSubstitutions": "true"
+            }
           }
         }
       },
@@ -615,7 +618,10 @@
           "valueTemplate": {
             "type": "string",
             "example": "{{ .token }}",
-            "description": "The value of the query parameter, represented as a Golang text/template expression. Only the backend will interpret this."
+            "description": "The value of the query parameter, represented as a Golang text/template expression. Only the backend will interpret this.",
+            "x-oapi-codegen-extra-tags": {
+              "skipSubstitutions": "true"
+            }
           }
         }
       },
@@ -676,7 +682,10 @@
                 "valueTemplate": {
                   "type": "string",
                   "example": "Bearer {{ .token }}",
-                  "description": "The value of the header, represented as a Golang text/template expression. Only the backend will interpret this."
+                  "description": "The value of the header, represented as a Golang text/template expression. Only the backend will interpret this.",
+                  "x-oapi-codegen-extra-tags": {
+                    "skipSubstitutions": "true"
+                  }
                 }
               }
             },
@@ -702,7 +711,10 @@
                 "valueTemplate": {
                   "type": "string",
                   "example": "{{ .token }}",
-                  "description": "The value of the query parameter, represented as a Golang text/template expression. Only the backend will interpret this."
+                  "description": "The value of the query parameter, represented as a Golang text/template expression. Only the backend will interpret this.",
+                  "x-oapi-codegen-extra-tags": {
+                    "skipSubstitutions": "true"
+                  }
                 }
               }
             },
@@ -1345,7 +1357,10 @@
                     "valueTemplate": {
                       "type": "string",
                       "example": "Bearer {{ .token }}",
-                      "description": "The value of the header, represented as a Golang text/template expression. Only the backend will interpret this."
+                      "description": "The value of the header, represented as a Golang text/template expression. Only the backend will interpret this.",
+                      "x-oapi-codegen-extra-tags": {
+                        "skipSubstitutions": "true"
+                      }
                     }
                   }
                 },
@@ -1371,7 +1386,10 @@
                     "valueTemplate": {
                       "type": "string",
                       "example": "{{ .token }}",
-                      "description": "The value of the query parameter, represented as a Golang text/template expression. Only the backend will interpret this."
+                      "description": "The value of the query parameter, represented as a Golang text/template expression. Only the backend will interpret this.",
+                      "x-oapi-codegen-extra-tags": {
+                        "skipSubstitutions": "true"
+                      }
                     }
                   }
                 },
@@ -2150,7 +2168,10 @@
                           "valueTemplate": {
                             "type": "string",
                             "example": "Bearer {{ .token }}",
-                            "description": "The value of the header, represented as a Golang text/template expression. Only the backend will interpret this."
+                            "description": "The value of the header, represented as a Golang text/template expression. Only the backend will interpret this.",
+                            "x-oapi-codegen-extra-tags": {
+                              "skipSubstitutions": "true"
+                            }
                           }
                         }
                       },
@@ -2176,7 +2197,10 @@
                           "valueTemplate": {
                             "type": "string",
                             "example": "{{ .token }}",
-                            "description": "The value of the query parameter, represented as a Golang text/template expression. Only the backend will interpret this."
+                            "description": "The value of the query parameter, represented as a Golang text/template expression. Only the backend will interpret this.",
+                            "x-oapi-codegen-extra-tags": {
+                              "skipSubstitutions": "true"
+                            }
                           }
                         }
                       },
@@ -2942,7 +2966,10 @@
                       "valueTemplate": {
                         "type": "string",
                         "example": "Bearer {{ .token }}",
-                        "description": "The value of the header, represented as a Golang text/template expression. Only the backend will interpret this."
+                        "description": "The value of the header, represented as a Golang text/template expression. Only the backend will interpret this.",
+                        "x-oapi-codegen-extra-tags": {
+                          "skipSubstitutions": "true"
+                        }
                       }
                     }
                   },
@@ -2968,7 +2995,10 @@
                       "valueTemplate": {
                         "type": "string",
                         "example": "{{ .token }}",
-                        "description": "The value of the query parameter, represented as a Golang text/template expression. Only the backend will interpret this."
+                        "description": "The value of the query parameter, represented as a Golang text/template expression. Only the backend will interpret this.",
+                        "x-oapi-codegen-extra-tags": {
+                          "skipSubstitutions": "true"
+                        }
                       }
                     }
                   },


### PR DESCRIPTION
This adds a few tags to the go structures for a specific field (valueTemplate) which we can use to key off of in order to decide whether or not to do substitutions.