### PR TITLE
feat(api-types): Default metadata value

### DIFF
--- a/api/generated/api.json
+++ b/api/generated/api.json
@@ -26716,6 +26716,11 @@
                                   "description": "The human-readable name for the field",
                                   "x-go-type-skip-optional-pointer": true
                                 },
+                                "defaultValue": {
+                                  "type": "string",
+                                  "description": "Default value for this metadata item",
+                                  "x-go-type-skip-optional-pointer": true
+                                },
                                 "docsURL": {
                                   "type": "string",
                                   "description": "URL with more information about how to locate this value",
@@ -27666,6 +27671,11 @@
                               "displayName": {
                                 "type": "string",
                                 "description": "The human-readable name for the field",
+                                "x-go-type-skip-optional-pointer": true
+                              },
+                              "defaultValue": {
+                                "type": "string",
+                                "description": "Default value for this metadata item",
                                 "x-go-type-skip-optional-pointer": true
                               },
                               "docsURL": {

--- a/catalog/catalog.yaml
+++ b/catalog/catalog.yaml
@@ -608,6 +608,10 @@ components:
           type: string
           description: The human-readable name for the field
           x-go-type-skip-optional-pointer: true
+        defaultValue:
+          type: string
+          description: Default value for this metadata item
+          x-go-type-skip-optional-pointer: true
         docsURL:
           type: string
           description: URL with more information about how to locate this value

--- a/catalog/generated/catalog.json
+++ b/catalog/generated/catalog.json
@@ -1755,6 +1755,11 @@
                       "description": "The human-readable name for the field",
                       "x-go-type-skip-optional-pointer": true
                     },
+                    "defaultValue": {
+                      "type": "string",
+                      "description": "Default value for this metadata item",
+                      "x-go-type-skip-optional-pointer": true
+                    },
                     "docsURL": {
                       "type": "string",
                       "description": "URL with more information about how to locate this value",
@@ -2560,6 +2565,11 @@
                             "description": "The human-readable name for the field",
                             "x-go-type-skip-optional-pointer": true
                           },
+                          "defaultValue": {
+                            "type": "string",
+                            "description": "Default value for this metadata item",
+                            "x-go-type-skip-optional-pointer": true
+                          },
                           "docsURL": {
                             "type": "string",
                             "description": "URL with more information about how to locate this value",
@@ -3352,6 +3362,11 @@
                         "description": "The human-readable name for the field",
                         "x-go-type-skip-optional-pointer": true
                       },
+                      "defaultValue": {
+                        "type": "string",
+                        "description": "Default value for this metadata item",
+                        "x-go-type-skip-optional-pointer": true
+                      },
                       "docsURL": {
                         "type": "string",
                         "description": "URL with more information about how to locate this value",
@@ -3494,6 +3509,11 @@
                   "description": "The human-readable name for the field",
                   "x-go-type-skip-optional-pointer": true
                 },
+                "defaultValue": {
+                  "type": "string",
+                  "description": "Default value for this metadata item",
+                  "x-go-type-skip-optional-pointer": true
+                },
                 "docsURL": {
                   "type": "string",
                   "description": "URL with more information about how to locate this value",
@@ -3570,6 +3590,11 @@
           "displayName": {
             "type": "string",
             "description": "The human-readable name for the field",
+            "x-go-type-skip-optional-pointer": true
+          },
+          "defaultValue": {
+            "type": "string",
+            "description": "Default value for this metadata item",
             "x-go-type-skip-optional-pointer": true
           },
           "docsURL": {


### PR DESCRIPTION
# Changes

This PR introduces the default values for metadata.

# Background

Modified ProviderInfo of Microsoft such that single tenant as well as multitenant can be selected.
![image](https://github.com/user-attachments/assets/3fc7c226-419c-4367-984a-e13c04052ef6)
![image](https://github.com/user-attachments/assets/30cbf8c9-295f-4437-bd2a-a3ae473f3fca)
For backwards compatability AuthURL and TokenURL must default to `common` "workspace".

# Usage/Debug
I tried specifying and omitting workspace metadata and got expected values:
![image](https://github.com/user-attachments/assets/5e807fcb-98db-4f0e-b272-ac4e2182aecd)
![image](https://github.com/user-attachments/assets/d3d4ae6c-be49-4b1f-a2c2-e5a2bead5792)
