### PR TITLE
build: change enums to examples

### DIFF
--- a/api/api.yaml
+++ b/api/api.yaml
@@ -282,7 +282,7 @@ paths:
                   type: array
                   items:
                     type: string
-                  description: "Array of field paths specifying which fields to update. Common values: appName, name"
+                  description: "Array of field paths specifying which fields to update. Allowed values: appName, name"
                   example: ["appName", "name"]
                 project:
                   type: object
@@ -498,7 +498,7 @@ paths:
                   type: array
                   items:
                     type: string
-                  description: "Array of field paths specifying which fields to update. Common values: externalRef, clientId, clientSecret, provider, scopes"
+                  description: "Array of field paths specifying which fields to update. Allowed values: externalRef, clientId, clientSecret, provider, scopes"
                   example: ["externalRef", "clientId"]
                 providerApp:
                   type: object
@@ -1140,8 +1140,8 @@ paths:
                   type: array
                   items:
                     type: string
-                  description: "Array of field paths specifying which fields to update. Examples: config, connectionId, config.revisionId, config.content.read.objects.contacts, config.content.write.objects.leads"
-                  example: ["config", "config.content.read.objects.contacts"]
+                  description: "Array of field paths specifying which fields to update. Allowed values: config, connectionId, config.revisionId, config.createdBy, config.content.read.objects.*, config.content.write.objects.*, config.content.subscribe.objects.*. The * operator allows you to specify any object name (e.g., 'config.content.read.objects.contacts' or 'config.content.write.objects.leads')"
+                  example: ["config", "config.content.read.objects.contacts", "config.content.write.objects.leads"]
                 installation:
                   type: object
                   properties:
@@ -2163,7 +2163,7 @@ paths:
                   type: array
                   items:
                     type: string
-                  description: "Array of field paths specifying which fields to update. Common values: name, metadata.url, metadata.headers"
+                  description: "Array of field paths specifying which fields to update. Allowed values: name, metadata.url, metadata.headers"
                   example: ["name", "metadata.url"]
                 destination:
                   type: object
@@ -2357,7 +2357,7 @@ paths:
                   type: array
                   items:
                     type: string
-                  description: "Array of field paths specifying which fields to update. Common values: label"
+                  description: "Array of field paths specifying which fields to update. Allowed values: label"
                   example: ["label"]
                 org:
                   type: object
@@ -3557,7 +3557,7 @@ components:
           type: array
           items:
             type: string
-          description: "Array of field paths specifying which fields to update. Common values: providerWorkspaceRef, providerMetadata, apiKey, basicAuth, oauth2ClientCredentials, oauth2PasswordCredentials"
+          description: "Array of field paths specifying which fields to update. Allowed values: providerWorkspaceRef, providerMetadata, apiKey, basicAuth, oauth2ClientCredentials, oauth2PasswordCredentials"
           example: ["providerWorkspaceRef", "providerMetadata"]
         connection:
           $ref: "#/components/schemas/ConnectionRequest"
@@ -3884,7 +3884,7 @@ components:
           type: array
           items:
             type: string
-          description: "Array of field paths specifying which fields to update. Common values: active, label, scopes"
+          description: "Array of field paths specifying which fields to update. Allowed values: active, label, scopes"
           example: ["active", "label"]
         apiKey:
           type: object
@@ -4146,8 +4146,10 @@ components:
         - Escape special characters: `field\.with\.dots`, `field\:with\:colons`
         - Array elements not directly addressable
         - Object names can be specified directly (e.g., "config.content.read.objects.contacts")
+        - The * operator in paths like "config.content.read.objects.*" allows you to specify any object name
+          - Example: "config.content.read.objects.*" pattern allows "config.content.read.objects.contacts", "config.content.read.objects.leads", etc.
 
-      example: ["name", "config.content.read.objects.contacts"]
+      example: ["name", "config.content.read.objects.contacts", "config.content.write.objects.leads"]
     CreateJWTKeyRequest:
       type: object
       required:

--- a/api/api.yaml
+++ b/api/api.yaml
@@ -282,8 +282,8 @@ paths:
                   type: array
                   items:
                     type: string
-                    enum: ["appName", "name"]
-                  description: "Array of field paths specifying which fields to update."
+                  description: "Array of field paths specifying which fields to update. Common values: appName, name"
+                  example: ["appName", "name"]
                 project:
                   type: object
                   properties:
@@ -498,8 +498,8 @@ paths:
                   type: array
                   items:
                     type: string
-                    enum: ["externalRef", "clientId", "clientSecret", "provider", "scopes"]
-                  description: "Array of field paths specifying which fields to update."
+                  description: "Array of field paths specifying which fields to update. Common values: externalRef, clientId, clientSecret, provider, scopes"
+                  example: ["externalRef", "clientId"]
                 providerApp:
                   type: object
                   properties:
@@ -1140,8 +1140,8 @@ paths:
                   type: array
                   items:
                     type: string
-                    enum: ["config", "connectionId", "config.revisionId", "config.createdBy", "config.content.read.objects.*", "config.content.write.objects.*", "config.content.write.objects", "config.content.subscribe.objects.*"]
-                  description: "Array of field paths specifying which fields to update. `*` indicates an object name, for example `config.content.read.objects.*` means that you can use the update mask `config.content.read.objects.contact`."
+                  description: "Array of field paths specifying which fields to update. Examples: config, connectionId, config.revisionId, config.content.read.objects.contacts, config.content.write.objects.leads"
+                  example: ["config", "config.content.read.objects.contacts"]
                 installation:
                   type: object
                   properties:
@@ -2163,8 +2163,8 @@ paths:
                   type: array
                   items:
                     type: string
-                    enum: ["name", "metadata.url", "metadata.headers"]
-                  description: "Array of field paths specifying which fields to update."
+                  description: "Array of field paths specifying which fields to update. Common values: name, metadata.url, metadata.headers"
+                  example: ["name", "metadata.url"]
                 destination:
                   type: object
                   properties:
@@ -2357,8 +2357,8 @@ paths:
                   type: array
                   items:
                     type: string
-                    enum: ["label"]
-                  description: "Array of field paths specifying which fields to update."
+                  description: "Array of field paths specifying which fields to update. Common values: label"
+                  example: ["label"]
                 org:
                   type: object
                   properties:
@@ -3557,8 +3557,8 @@ components:
           type: array
           items:
             type: string
-            enum: ["providerWorkspaceRef", "providerMetadata", "apiKey", "basicAuth", "oauth2ClientCredentials", "oauth2PasswordCredentials"]
-          description: "Array of field paths specifying which fields to update."
+          description: "Array of field paths specifying which fields to update. Common values: providerWorkspaceRef, providerMetadata, apiKey, basicAuth, oauth2ClientCredentials, oauth2PasswordCredentials"
+          example: ["providerWorkspaceRef", "providerMetadata"]
         connection:
           $ref: "#/components/schemas/ConnectionRequest"
     ConnectionRequest:
@@ -3884,8 +3884,8 @@ components:
           type: array
           items:
             type: string
-            enum: ["active", "label", "scopes"]
-          description: "Array of field paths specifying which fields to update."
+          description: "Array of field paths specifying which fields to update. Common values: active, label, scopes"
+          example: ["active", "label"]
         apiKey:
           type: object
           properties:
@@ -4145,9 +4145,9 @@ components:
         - Use dot notation for nested objects: `parent.child.field`
         - Escape special characters: `field\.with\.dots`, `field\:with\:colons`
         - Array elements not directly addressable
-        - Only explicitly allowed fields can be updated
+        - Object names can be specified directly (e.g., "config.content.read.objects.contacts")
 
-      example: ["name", "config.revision", "metadata.tags"]
+      example: ["name", "config.content.read.objects.contacts"]
     CreateJWTKeyRequest:
       type: object
       required:

--- a/api/generated/api.json
+++ b/api/generated/api.json
@@ -2472,7 +2472,7 @@
                     "items": {
                       "type": "string"
                     },
-                    "description": "Array of field paths specifying which fields to update. Common values: appName, name",
+                    "description": "Array of field paths specifying which fields to update. Allowed values: appName, name",
                     "example": [
                       "appName",
                       "name"
@@ -5366,7 +5366,7 @@
                     "items": {
                       "type": "string"
                     },
-                    "description": "Array of field paths specifying which fields to update. Common values: externalRef, clientId, clientSecret, provider, scopes",
+                    "description": "Array of field paths specifying which fields to update. Allowed values: externalRef, clientId, clientSecret, provider, scopes",
                     "example": [
                       "externalRef",
                       "clientId"
@@ -21028,10 +21028,11 @@
                     "items": {
                       "type": "string"
                     },
-                    "description": "Array of field paths specifying which fields to update. Examples: config, connectionId, config.revisionId, config.content.read.objects.contacts, config.content.write.objects.leads",
+                    "description": "Array of field paths specifying which fields to update. Allowed values: config, connectionId, config.revisionId, config.createdBy, config.content.read.objects.*, config.content.write.objects.*, config.content.subscribe.objects.*. The * operator allows you to specify any object name (e.g., 'config.content.read.objects.contacts' or 'config.content.write.objects.leads')",
                     "example": [
                       "config",
-                      "config.content.read.objects.contacts"
+                      "config.content.read.objects.contacts",
+                      "config.content.write.objects.leads"
                     ]
                   },
                   "installation": {
@@ -32768,7 +32769,7 @@
                     "items": {
                       "type": "string"
                     },
-                    "description": "Array of field paths specifying which fields to update. Common values: active, label, scopes",
+                    "description": "Array of field paths specifying which fields to update. Allowed values: active, label, scopes",
                     "example": [
                       "active",
                       "label"
@@ -37030,7 +37031,7 @@
                     "items": {
                       "type": "string"
                     },
-                    "description": "Array of field paths specifying which fields to update. Common values: providerWorkspaceRef, providerMetadata, apiKey, basicAuth, oauth2ClientCredentials, oauth2PasswordCredentials",
+                    "description": "Array of field paths specifying which fields to update. Allowed values: providerWorkspaceRef, providerMetadata, apiKey, basicAuth, oauth2ClientCredentials, oauth2PasswordCredentials",
                     "example": [
                       "providerWorkspaceRef",
                       "providerMetadata"
@@ -40001,7 +40002,7 @@
                     "items": {
                       "type": "string"
                     },
-                    "description": "Array of field paths specifying which fields to update. Common values: name, metadata.url, metadata.headers",
+                    "description": "Array of field paths specifying which fields to update. Allowed values: name, metadata.url, metadata.headers",
                     "example": [
                       "name",
                       "metadata.url"
@@ -42663,7 +42664,7 @@
                     "items": {
                       "type": "string"
                     },
-                    "description": "Array of field paths specifying which fields to update. Common values: label",
+                    "description": "Array of field paths specifying which fields to update. Allowed values: label",
                     "example": [
                       "label"
                     ]
@@ -53586,7 +53587,7 @@
             "items": {
               "type": "string"
             },
-            "description": "Array of field paths specifying which fields to update. Common values: providerWorkspaceRef, providerMetadata, apiKey, basicAuth, oauth2ClientCredentials, oauth2PasswordCredentials",
+            "description": "Array of field paths specifying which fields to update. Allowed values: providerWorkspaceRef, providerMetadata, apiKey, basicAuth, oauth2ClientCredentials, oauth2PasswordCredentials",
             "example": [
               "providerWorkspaceRef",
               "providerMetadata"
@@ -54536,7 +54537,7 @@
             "items": {
               "type": "string"
             },
-            "description": "Array of field paths specifying which fields to update. Common values: active, label, scopes",
+            "description": "Array of field paths specifying which fields to update. Allowed values: active, label, scopes",
             "example": [
               "active",
               "label"
@@ -55125,10 +55126,11 @@
         "items": {
           "type": "string"
         },
-        "description": "Array of field paths specifying which fields to update.\nUses dot notation for nested fields (e.g., \"config.revision\", \"metadata.tags\").\n\n**Field Path Rules:**\n- Use dot notation for nested objects: `parent.child.field`\n- Escape special characters: `field\\.with\\.dots`, `field\\:with\\:colons`\n- Array elements not directly addressable\n- Object names can be specified directly (e.g., \"config.content.read.objects.contacts\")\n",
+        "description": "Array of field paths specifying which fields to update.\nUses dot notation for nested fields (e.g., \"config.revision\", \"metadata.tags\").\n\n**Field Path Rules:**\n- Use dot notation for nested objects: `parent.child.field`\n- Escape special characters: `field\\.with\\.dots`, `field\\:with\\:colons`\n- Array elements not directly addressable\n- Object names can be specified directly (e.g., \"config.content.read.objects.contacts\")\n- The * operator in paths like \"config.content.read.objects.*\" allows you to specify any object name\n  - Example: \"config.content.read.objects.*\" pattern allows \"config.content.read.objects.contacts\", \"config.content.read.objects.leads\", etc.\n",
         "example": [
           "name",
-          "config.content.read.objects.contacts"
+          "config.content.read.objects.contacts",
+          "config.content.write.objects.leads"
         ]
       },
       "CreateJWTKeyRequest": {

--- a/api/generated/api.json
+++ b/api/generated/api.json
@@ -2470,13 +2470,13 @@
                   "updateMask": {
                     "type": "array",
                     "items": {
-                      "type": "string",
-                      "enum": [
-                        "appName",
-                        "name"
-                      ]
+                      "type": "string"
                     },
-                    "description": "Array of field paths specifying which fields to update."
+                    "description": "Array of field paths specifying which fields to update. Common values: appName, name",
+                    "example": [
+                      "appName",
+                      "name"
+                    ]
                   },
                   "project": {
                     "type": "object",
@@ -5364,16 +5364,13 @@
                   "updateMask": {
                     "type": "array",
                     "items": {
-                      "type": "string",
-                      "enum": [
-                        "externalRef",
-                        "clientId",
-                        "clientSecret",
-                        "provider",
-                        "scopes"
-                      ]
+                      "type": "string"
                     },
-                    "description": "Array of field paths specifying which fields to update."
+                    "description": "Array of field paths specifying which fields to update. Common values: externalRef, clientId, clientSecret, provider, scopes",
+                    "example": [
+                      "externalRef",
+                      "clientId"
+                    ]
                   },
                   "providerApp": {
                     "type": "object",
@@ -21029,19 +21026,13 @@
                   "updateMask": {
                     "type": "array",
                     "items": {
-                      "type": "string",
-                      "enum": [
-                        "config",
-                        "connectionId",
-                        "config.revisionId",
-                        "config.createdBy",
-                        "config.content.read.objects.*",
-                        "config.content.write.objects.*",
-                        "config.content.write.objects",
-                        "config.content.subscribe.objects.*"
-                      ]
+                      "type": "string"
                     },
-                    "description": "Array of field paths specifying which fields to update. `*` indicates an object name, for example `config.content.read.objects.*` means that you can use the update mask `config.content.read.objects.contact`."
+                    "description": "Array of field paths specifying which fields to update. Examples: config, connectionId, config.revisionId, config.content.read.objects.contacts, config.content.write.objects.leads",
+                    "example": [
+                      "config",
+                      "config.content.read.objects.contacts"
+                    ]
                   },
                   "installation": {
                     "type": "object",
@@ -32775,14 +32766,13 @@
                   "updateMask": {
                     "type": "array",
                     "items": {
-                      "type": "string",
-                      "enum": [
-                        "active",
-                        "label",
-                        "scopes"
-                      ]
+                      "type": "string"
                     },
-                    "description": "Array of field paths specifying which fields to update."
+                    "description": "Array of field paths specifying which fields to update. Common values: active, label, scopes",
+                    "example": [
+                      "active",
+                      "label"
+                    ]
                   },
                   "apiKey": {
                     "type": "object",
@@ -37038,17 +37028,13 @@
                   "updateMask": {
                     "type": "array",
                     "items": {
-                      "type": "string",
-                      "enum": [
-                        "providerWorkspaceRef",
-                        "providerMetadata",
-                        "apiKey",
-                        "basicAuth",
-                        "oauth2ClientCredentials",
-                        "oauth2PasswordCredentials"
-                      ]
+                      "type": "string"
                     },
-                    "description": "Array of field paths specifying which fields to update."
+                    "description": "Array of field paths specifying which fields to update. Common values: providerWorkspaceRef, providerMetadata, apiKey, basicAuth, oauth2ClientCredentials, oauth2PasswordCredentials",
+                    "example": [
+                      "providerWorkspaceRef",
+                      "providerMetadata"
+                    ]
                   },
                   "connection": {
                     "title": "Connection Request Body",
@@ -40013,14 +39999,13 @@
                   "updateMask": {
                     "type": "array",
                     "items": {
-                      "type": "string",
-                      "enum": [
-                        "name",
-                        "metadata.url",
-                        "metadata.headers"
-                      ]
+                      "type": "string"
                     },
-                    "description": "Array of field paths specifying which fields to update."
+                    "description": "Array of field paths specifying which fields to update. Common values: name, metadata.url, metadata.headers",
+                    "example": [
+                      "name",
+                      "metadata.url"
+                    ]
                   },
                   "destination": {
                     "type": "object",
@@ -42676,12 +42661,12 @@
                   "updateMask": {
                     "type": "array",
                     "items": {
-                      "type": "string",
-                      "enum": [
-                        "label"
-                      ]
+                      "type": "string"
                     },
-                    "description": "Array of field paths specifying which fields to update."
+                    "description": "Array of field paths specifying which fields to update. Common values: label",
+                    "example": [
+                      "label"
+                    ]
                   },
                   "org": {
                     "type": "object",
@@ -53599,17 +53584,13 @@
           "updateMask": {
             "type": "array",
             "items": {
-              "type": "string",
-              "enum": [
-                "providerWorkspaceRef",
-                "providerMetadata",
-                "apiKey",
-                "basicAuth",
-                "oauth2ClientCredentials",
-                "oauth2PasswordCredentials"
-              ]
+              "type": "string"
             },
-            "description": "Array of field paths specifying which fields to update."
+            "description": "Array of field paths specifying which fields to update. Common values: providerWorkspaceRef, providerMetadata, apiKey, basicAuth, oauth2ClientCredentials, oauth2PasswordCredentials",
+            "example": [
+              "providerWorkspaceRef",
+              "providerMetadata"
+            ]
           },
           "connection": {
             "title": "Connection Request Body",
@@ -54553,14 +54534,13 @@
           "updateMask": {
             "type": "array",
             "items": {
-              "type": "string",
-              "enum": [
-                "active",
-                "label",
-                "scopes"
-              ]
+              "type": "string"
             },
-            "description": "Array of field paths specifying which fields to update."
+            "description": "Array of field paths specifying which fields to update. Common values: active, label, scopes",
+            "example": [
+              "active",
+              "label"
+            ]
           },
           "apiKey": {
             "type": "object",
@@ -55145,11 +55125,10 @@
         "items": {
           "type": "string"
         },
-        "description": "Array of field paths specifying which fields to update.\nUses dot notation for nested fields (e.g., \"config.revision\", \"metadata.tags\").\n\n**Field Path Rules:**\n- Use dot notation for nested objects: `parent.child.field`\n- Escape special characters: `field\\.with\\.dots`, `field\\:with\\:colons`\n- Array elements not directly addressable\n- Only explicitly allowed fields can be updated\n",
+        "description": "Array of field paths specifying which fields to update.\nUses dot notation for nested fields (e.g., \"config.revision\", \"metadata.tags\").\n\n**Field Path Rules:**\n- Use dot notation for nested objects: `parent.child.field`\n- Escape special characters: `field\\.with\\.dots`, `field\\:with\\:colons`\n- Array elements not directly addressable\n- Object names can be specified directly (e.g., \"config.content.read.objects.contacts\")\n",
         "example": [
           "name",
-          "config.revision",
-          "metadata.tags"
+          "config.content.read.objects.contacts"
         ]
       },
       "CreateJWTKeyRequest": {


### PR DESCRIPTION
- enums are too restrictive for update masks
- examples are more flexible and give recommended values


