### PR TITLE
[ENG-2525] fix: add missing orgUpdate and invite object definitions to OpenAPI schema

### DIFF
--- a/api/api.yaml
+++ b/api/api.yaml
@@ -4339,6 +4339,38 @@ components:
           example:
             active: false
             name: "updated-key-name"
+    orgUpdate:
+      title: Organization Update Request
+      type: object
+      required:
+        - updateMask
+        - org
+      properties:
+        updateMask:
+          type: array
+          items:
+            type: string
+          description: |
+            Array of field paths specifying which fields to update. Allowed values include:
+            - label
+          example: ["label"]
+        org:
+          type: object
+          properties:
+            label:
+              type: string
+              description: The organization label.
+              example: "org-123"
+    invite:
+      title: Invite Request
+      type: object
+      required:
+        - invitedEmail
+      properties:
+        invitedEmail:
+          type: string
+          description: The email address of the user to invite.
+          example: "user@example.com"
   securitySchemes:
     APIKeyHeader:
       type: apiKey


### PR DESCRIPTION
Currently missing endpoints in Ampersand docs:
- [Invite a user to an organization](https://docs.withampersand.com/reference/org/invite-a-user-to-an-organization?utm_source=chatgpt.com):
- [Update an organization](https://docs.withampersand.com/reference/org/update-an-organization?utm_source=chatgpt.com)

Added missing schemas so that reference webpages in Ampersand docs are displayed:
<img width="2144" height="1187" alt="Screenshot 2025-08-28 at 5 36 10 PM" src="https://github.com/user-attachments/assets/ea41c888-9aaf-43ee-82ee-90e7871b8bc4" />
<img width="2161" height="1162" alt="Screenshot 2025-08-28 at 5 36 18 PM" src="https://github.com/user-attachments/assets/249ba4d7-6f0d-46cf-b41b-2785b0cd84a1" />
