### PR TITLE
Schedule and Destination optional pointer true

### DIFF
--- a/api/generated/api.json
+++ b/api/generated/api.json
@@ -6079,10 +6079,12 @@
                                           "type": "string"
                                         },
                                         "destination": {
-                                          "type": "string"
+                                          "type": "string",
+                                          "x-go-type-skip-optional-pointer": true
                                         },
                                         "schedule": {
-                                          "type": "string"
+                                          "type": "string",
+                                          "x-go-type-skip-optional-pointer": true
                                         },
                                         "mapToName": {
                                           "type": "string",
@@ -7002,10 +7004,12 @@
                                       "type": "string"
                                     },
                                     "destination": {
-                                      "type": "string"
+                                      "type": "string",
+                                      "x-go-type-skip-optional-pointer": true
                                     },
                                     "schedule": {
-                                      "type": "string"
+                                      "type": "string",
+                                      "x-go-type-skip-optional-pointer": true
                                     },
                                     "mapToName": {
                                       "type": "string",
@@ -8306,10 +8310,12 @@
                                         "type": "string"
                                       },
                                       "destination": {
-                                        "type": "string"
+                                        "type": "string",
+                                        "x-go-type-skip-optional-pointer": true
                                       },
                                       "schedule": {
-                                        "type": "string"
+                                        "type": "string",
+                                        "x-go-type-skip-optional-pointer": true
                                       },
                                       "mapToName": {
                                         "type": "string",
@@ -10112,10 +10118,12 @@
                                           "type": "string"
                                         },
                                         "destination": {
-                                          "type": "string"
+                                          "type": "string",
+                                          "x-go-type-skip-optional-pointer": true
                                         },
                                         "schedule": {
-                                          "type": "string"
+                                          "type": "string",
+                                          "x-go-type-skip-optional-pointer": true
                                         },
                                         "mapToName": {
                                           "type": "string",
@@ -13576,12 +13584,14 @@
                                             "schedule": {
                                               "type": "string",
                                               "description": "The schedule for reading the object, in cron syntax.",
-                                              "example": "*/15 * * * *"
+                                              "example": "*/15 * * * *",
+                                              "x-go-type-skip-optional-pointer": true
                                             },
                                             "destination": {
                                               "description": "The name of the destination that the result should be sent to.",
                                               "example": "accountWebhook",
-                                              "type": "string"
+                                              "type": "string",
+                                              "x-go-type-skip-optional-pointer": true
                                             },
                                             "selectedFields": {
                                               "type": "object",
@@ -13872,12 +13882,14 @@
                                                 "schedule": {
                                                   "type": "string",
                                                   "description": "The schedule for reading the object, in cron syntax.",
-                                                  "example": "*/15 * * * *"
+                                                  "example": "*/15 * * * *",
+                                                  "x-go-type-skip-optional-pointer": true
                                                 },
                                                 "destination": {
                                                   "description": "The name of the destination that the result should be sent to.",
                                                   "example": "accountWebhook",
-                                                  "type": "string"
+                                                  "type": "string",
+                                                  "x-go-type-skip-optional-pointer": true
                                                 },
                                                 "selectedFields": {
                                                   "type": "object",
@@ -13994,12 +14006,14 @@
                                                     "schedule": {
                                                       "type": "string",
                                                       "description": "The schedule for reading the object, in cron syntax.",
-                                                      "example": "*/15 * * * *"
+                                                      "example": "*/15 * * * *",
+                                                      "x-go-type-skip-optional-pointer": true
                                                     },
                                                     "destination": {
                                                       "description": "The name of the destination that the result should be sent to.",
                                                       "example": "accountWebhook",
-                                                      "type": "string"
+                                                      "type": "string",
+                                                      "x-go-type-skip-optional-pointer": true
                                                     },
                                                     "selectedFields": {
                                                       "type": "object",
@@ -15253,12 +15267,14 @@
                                         "schedule": {
                                           "type": "string",
                                           "description": "The schedule for reading the object, in cron syntax.",
-                                          "example": "*/15 * * * *"
+                                          "example": "*/15 * * * *",
+                                          "x-go-type-skip-optional-pointer": true
                                         },
                                         "destination": {
                                           "description": "The name of the destination that the result should be sent to.",
                                           "example": "accountWebhook",
-                                          "type": "string"
+                                          "type": "string",
+                                          "x-go-type-skip-optional-pointer": true
                                         },
                                         "selectedFields": {
                                           "type": "object",
@@ -15549,12 +15565,14 @@
                                             "schedule": {
                                               "type": "string",
                                               "description": "The schedule for reading the object, in cron syntax.",
-                                              "example": "*/15 * * * *"
+                                              "example": "*/15 * * * *",
+                                              "x-go-type-skip-optional-pointer": true
                                             },
                                             "destination": {
                                               "description": "The name of the destination that the result should be sent to.",
                                               "example": "accountWebhook",
-                                              "type": "string"
+                                              "type": "string",
+                                              "x-go-type-skip-optional-pointer": true
                                             },
                                             "selectedFields": {
                                               "type": "object",
@@ -15671,12 +15689,14 @@
                                                 "schedule": {
                                                   "type": "string",
                                                   "description": "The schedule for reading the object, in cron syntax.",
-                                                  "example": "*/15 * * * *"
+                                                  "example": "*/15 * * * *",
+                                                  "x-go-type-skip-optional-pointer": true
                                                 },
                                                 "destination": {
                                                   "description": "The name of the destination that the result should be sent to.",
                                                   "example": "accountWebhook",
-                                                  "type": "string"
+                                                  "type": "string",
+                                                  "x-go-type-skip-optional-pointer": true
                                                 },
                                                 "selectedFields": {
                                                   "type": "object",
@@ -16842,12 +16862,14 @@
                                           "schedule": {
                                             "type": "string",
                                             "description": "The schedule for reading the object, in cron syntax.",
-                                            "example": "*/15 * * * *"
+                                            "example": "*/15 * * * *",
+                                            "x-go-type-skip-optional-pointer": true
                                           },
                                           "destination": {
                                             "description": "The name of the destination that the result should be sent to.",
                                             "example": "accountWebhook",
-                                            "type": "string"
+                                            "type": "string",
+                                            "x-go-type-skip-optional-pointer": true
                                           },
                                           "selectedFields": {
                                             "type": "object",
@@ -17138,12 +17160,14 @@
                                               "schedule": {
                                                 "type": "string",
                                                 "description": "The schedule for reading the object, in cron syntax.",
-                                                "example": "*/15 * * * *"
+                                                "example": "*/15 * * * *",
+                                                "x-go-type-skip-optional-pointer": true
                                               },
                                               "destination": {
                                                 "description": "The name of the destination that the result should be sent to.",
                                                 "example": "accountWebhook",
-                                                "type": "string"
+                                                "type": "string",
+                                                "x-go-type-skip-optional-pointer": true
                                               },
                                               "selectedFields": {
                                                 "type": "object",
@@ -17260,12 +17284,14 @@
                                                   "schedule": {
                                                     "type": "string",
                                                     "description": "The schedule for reading the object, in cron syntax.",
-                                                    "example": "*/15 * * * *"
+                                                    "example": "*/15 * * * *",
+                                                    "x-go-type-skip-optional-pointer": true
                                                   },
                                                   "destination": {
                                                     "description": "The name of the destination that the result should be sent to.",
                                                     "example": "accountWebhook",
-                                                    "type": "string"
+                                                    "type": "string",
+                                                    "x-go-type-skip-optional-pointer": true
                                                   },
                                                   "selectedFields": {
                                                     "type": "object",
@@ -19253,12 +19279,14 @@
                                           "schedule": {
                                             "type": "string",
                                             "description": "The schedule for reading the object, in cron syntax.",
-                                            "example": "*/15 * * * *"
+                                            "example": "*/15 * * * *",
+                                            "x-go-type-skip-optional-pointer": true
                                           },
                                           "destination": {
                                             "description": "The name of the destination that the result should be sent to.",
                                             "example": "accountWebhook",
-                                            "type": "string"
+                                            "type": "string",
+                                            "x-go-type-skip-optional-pointer": true
                                           },
                                           "selectedFields": {
                                             "type": "object",
@@ -19549,12 +19577,14 @@
                                               "schedule": {
                                                 "type": "string",
                                                 "description": "The schedule for reading the object, in cron syntax.",
-                                                "example": "*/15 * * * *"
+                                                "example": "*/15 * * * *",
+                                                "x-go-type-skip-optional-pointer": true
                                               },
                                               "destination": {
                                                 "description": "The name of the destination that the result should be sent to.",
                                                 "example": "accountWebhook",
-                                                "type": "string"
+                                                "type": "string",
+                                                "x-go-type-skip-optional-pointer": true
                                               },
                                               "selectedFields": {
                                                 "type": "object",
@@ -19671,12 +19701,14 @@
                                                   "schedule": {
                                                     "type": "string",
                                                     "description": "The schedule for reading the object, in cron syntax.",
-                                                    "example": "*/15 * * * *"
+                                                    "example": "*/15 * * * *",
+                                                    "x-go-type-skip-optional-pointer": true
                                                   },
                                                   "destination": {
                                                     "description": "The name of the destination that the result should be sent to.",
                                                     "example": "accountWebhook",
-                                                    "type": "string"
+                                                    "type": "string",
+                                                    "x-go-type-skip-optional-pointer": true
                                                   },
                                                   "selectedFields": {
                                                     "type": "object",
@@ -21123,12 +21155,14 @@
                                             "schedule": {
                                               "type": "string",
                                               "description": "The schedule for reading the object, in cron syntax.",
-                                              "example": "*/15 * * * *"
+                                              "example": "*/15 * * * *",
+                                              "x-go-type-skip-optional-pointer": true
                                             },
                                             "destination": {
                                               "description": "The name of the destination that the result should be sent to.",
                                               "example": "accountWebhook",
-                                              "type": "string"
+                                              "type": "string",
+                                              "x-go-type-skip-optional-pointer": true
                                             },
                                             "selectedFields": {
                                               "type": "object",
@@ -21875,12 +21909,14 @@
                                           "schedule": {
                                             "type": "string",
                                             "description": "The schedule for reading the object, in cron syntax.",
-                                            "example": "*/15 * * * *"
+                                            "example": "*/15 * * * *",
+                                            "x-go-type-skip-optional-pointer": true
                                           },
                                           "destination": {
                                             "description": "The name of the destination that the result should be sent to.",
                                             "example": "accountWebhook",
-                                            "type": "string"
+                                            "type": "string",
+                                            "x-go-type-skip-optional-pointer": true
                                           },
                                           "selectedFields": {
                                             "type": "object",
@@ -22171,12 +22207,14 @@
                                               "schedule": {
                                                 "type": "string",
                                                 "description": "The schedule for reading the object, in cron syntax.",
-                                                "example": "*/15 * * * *"
+                                                "example": "*/15 * * * *",
+                                                "x-go-type-skip-optional-pointer": true
                                               },
                                               "destination": {
                                                 "description": "The name of the destination that the result should be sent to.",
                                                 "example": "accountWebhook",
-                                                "type": "string"
+                                                "type": "string",
+                                                "x-go-type-skip-optional-pointer": true
                                               },
                                               "selectedFields": {
                                                 "type": "object",
@@ -22293,12 +22331,14 @@
                                                   "schedule": {
                                                     "type": "string",
                                                     "description": "The schedule for reading the object, in cron syntax.",
-                                                    "example": "*/15 * * * *"
+                                                    "example": "*/15 * * * *",
+                                                    "x-go-type-skip-optional-pointer": true
                                                   },
                                                   "destination": {
                                                     "description": "The name of the destination that the result should be sent to.",
                                                     "example": "accountWebhook",
-                                                    "type": "string"
+                                                    "type": "string",
+                                                    "x-go-type-skip-optional-pointer": true
                                                   },
                                                   "selectedFields": {
                                                     "type": "object",
@@ -24576,12 +24616,14 @@
                                             "schedule": {
                                               "type": "string",
                                               "description": "The schedule for reading the object, in cron syntax.",
-                                              "example": "*/15 * * * *"
+                                              "example": "*/15 * * * *",
+                                              "x-go-type-skip-optional-pointer": true
                                             },
                                             "destination": {
                                               "description": "The name of the destination that the result should be sent to.",
                                               "example": "accountWebhook",
-                                              "type": "string"
+                                              "type": "string",
+                                              "x-go-type-skip-optional-pointer": true
                                             },
                                             "selectedFields": {
                                               "type": "object",
@@ -24872,12 +24914,14 @@
                                                 "schedule": {
                                                   "type": "string",
                                                   "description": "The schedule for reading the object, in cron syntax.",
-                                                  "example": "*/15 * * * *"
+                                                  "example": "*/15 * * * *",
+                                                  "x-go-type-skip-optional-pointer": true
                                                 },
                                                 "destination": {
                                                   "description": "The name of the destination that the result should be sent to.",
                                                   "example": "accountWebhook",
-                                                  "type": "string"
+                                                  "type": "string",
+                                                  "x-go-type-skip-optional-pointer": true
                                                 },
                                                 "selectedFields": {
                                                   "type": "object",
@@ -24994,12 +25038,14 @@
                                                     "schedule": {
                                                       "type": "string",
                                                       "description": "The schedule for reading the object, in cron syntax.",
-                                                      "example": "*/15 * * * *"
+                                                      "example": "*/15 * * * *",
+                                                      "x-go-type-skip-optional-pointer": true
                                                     },
                                                     "destination": {
                                                       "description": "The name of the destination that the result should be sent to.",
                                                       "example": "accountWebhook",
-                                                      "type": "string"
+                                                      "type": "string",
+                                                      "x-go-type-skip-optional-pointer": true
                                                     },
                                                     "selectedFields": {
                                                       "type": "object",
@@ -49277,10 +49323,12 @@
                               "type": "string"
                             },
                             "destination": {
-                              "type": "string"
+                              "type": "string",
+                              "x-go-type-skip-optional-pointer": true
                             },
                             "schedule": {
-                              "type": "string"
+                              "type": "string",
+                              "x-go-type-skip-optional-pointer": true
                             },
                             "mapToName": {
                               "type": "string",
@@ -49710,10 +49758,12 @@
                           "type": "string"
                         },
                         "destination": {
-                          "type": "string"
+                          "type": "string",
+                          "x-go-type-skip-optional-pointer": true
                         },
                         "schedule": {
-                          "type": "string"
+                          "type": "string",
+                          "x-go-type-skip-optional-pointer": true
                         },
                         "mapToName": {
                           "type": "string",
@@ -50980,12 +51030,14 @@
                                 "schedule": {
                                   "type": "string",
                                   "description": "The schedule for reading the object, in cron syntax.",
-                                  "example": "*/15 * * * *"
+                                  "example": "*/15 * * * *",
+                                  "x-go-type-skip-optional-pointer": true
                                 },
                                 "destination": {
                                   "description": "The name of the destination that the result should be sent to.",
                                   "example": "accountWebhook",
-                                  "type": "string"
+                                  "type": "string",
+                                  "x-go-type-skip-optional-pointer": true
                                 },
                                 "selectedFields": {
                                   "type": "object",
@@ -51276,12 +51328,14 @@
                                     "schedule": {
                                       "type": "string",
                                       "description": "The schedule for reading the object, in cron syntax.",
-                                      "example": "*/15 * * * *"
+                                      "example": "*/15 * * * *",
+                                      "x-go-type-skip-optional-pointer": true
                                     },
                                     "destination": {
                                       "description": "The name of the destination that the result should be sent to.",
                                       "example": "accountWebhook",
-                                      "type": "string"
+                                      "type": "string",
+                                      "x-go-type-skip-optional-pointer": true
                                     },
                                     "selectedFields": {
                                       "type": "object",
@@ -51398,12 +51452,14 @@
                                         "schedule": {
                                           "type": "string",
                                           "description": "The schedule for reading the object, in cron syntax.",
-                                          "example": "*/15 * * * *"
+                                          "example": "*/15 * * * *",
+                                          "x-go-type-skip-optional-pointer": true
                                         },
                                         "destination": {
                                           "description": "The name of the destination that the result should be sent to.",
                                           "example": "accountWebhook",
-                                          "type": "string"
+                                          "type": "string",
+                                          "x-go-type-skip-optional-pointer": true
                                         },
                                         "selectedFields": {
                                           "type": "object",
@@ -52162,12 +52218,14 @@
                             "schedule": {
                               "type": "string",
                               "description": "The schedule for reading the object, in cron syntax.",
-                              "example": "*/15 * * * *"
+                              "example": "*/15 * * * *",
+                              "x-go-type-skip-optional-pointer": true
                             },
                             "destination": {
                               "description": "The name of the destination that the result should be sent to.",
                               "example": "accountWebhook",
-                              "type": "string"
+                              "type": "string",
+                              "x-go-type-skip-optional-pointer": true
                             },
                             "selectedFields": {
                               "type": "object",
@@ -52458,12 +52516,14 @@
                                 "schedule": {
                                   "type": "string",
                                   "description": "The schedule for reading the object, in cron syntax.",
-                                  "example": "*/15 * * * *"
+                                  "example": "*/15 * * * *",
+                                  "x-go-type-skip-optional-pointer": true
                                 },
                                 "destination": {
                                   "description": "The name of the destination that the result should be sent to.",
                                   "example": "accountWebhook",
-                                  "type": "string"
+                                  "type": "string",
+                                  "x-go-type-skip-optional-pointer": true
                                 },
                                 "selectedFields": {
                                   "type": "object",
@@ -52580,12 +52640,14 @@
                                     "schedule": {
                                       "type": "string",
                                       "description": "The schedule for reading the object, in cron syntax.",
-                                      "example": "*/15 * * * *"
+                                      "example": "*/15 * * * *",
+                                      "x-go-type-skip-optional-pointer": true
                                     },
                                     "destination": {
                                       "description": "The name of the destination that the result should be sent to.",
                                       "example": "accountWebhook",
-                                      "type": "string"
+                                      "type": "string",
+                                      "x-go-type-skip-optional-pointer": true
                                     },
                                     "selectedFields": {
                                       "type": "object",

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -66,10 +66,12 @@ components:
           type: string
           description: The schedule for reading the object, in cron syntax.
           example: '*/15 * * * *'
+          x-go-type-skip-optional-pointer: true
         destination:
           description: The name of the destination that the result should be sent to.
           example: accountWebhook
           type: string
+          x-go-type-skip-optional-pointer: true
         selectedFields:
           type: object
           description:

--- a/config/generated/config.json
+++ b/config/generated/config.json
@@ -49,12 +49,14 @@
                     "schedule": {
                       "type": "string",
                       "description": "The schedule for reading the object, in cron syntax.",
-                      "example": "*/15 * * * *"
+                      "example": "*/15 * * * *",
+                      "x-go-type-skip-optional-pointer": true
                     },
                     "destination": {
                       "description": "The name of the destination that the result should be sent to.",
                       "example": "accountWebhook",
-                      "type": "string"
+                      "type": "string",
+                      "x-go-type-skip-optional-pointer": true
                     },
                     "selectedFields": {
                       "type": "object",
@@ -349,12 +351,14 @@
                 "schedule": {
                   "type": "string",
                   "description": "The schedule for reading the object, in cron syntax.",
-                  "example": "*/15 * * * *"
+                  "example": "*/15 * * * *",
+                  "x-go-type-skip-optional-pointer": true
                 },
                 "destination": {
                   "description": "The name of the destination that the result should be sent to.",
                   "example": "accountWebhook",
-                  "type": "string"
+                  "type": "string",
+                  "x-go-type-skip-optional-pointer": true
                 },
                 "selectedFields": {
                   "type": "object",
@@ -461,12 +465,14 @@
           "schedule": {
             "type": "string",
             "description": "The schedule for reading the object, in cron syntax.",
-            "example": "*/15 * * * *"
+            "example": "*/15 * * * *",
+            "x-go-type-skip-optional-pointer": true
           },
           "destination": {
             "description": "The name of the destination that the result should be sent to.",
             "example": "accountWebhook",
-            "type": "string"
+            "type": "string",
+            "x-go-type-skip-optional-pointer": true
           },
           "selectedFields": {
             "type": "object",
@@ -1215,12 +1221,14 @@
                         "schedule": {
                           "type": "string",
                           "description": "The schedule for reading the object, in cron syntax.",
-                          "example": "*/15 * * * *"
+                          "example": "*/15 * * * *",
+                          "x-go-type-skip-optional-pointer": true
                         },
                         "destination": {
                           "description": "The name of the destination that the result should be sent to.",
                           "example": "accountWebhook",
-                          "type": "string"
+                          "type": "string",
+                          "x-go-type-skip-optional-pointer": true
                         },
                         "selectedFields": {
                           "type": "object",
@@ -1511,12 +1519,14 @@
                             "schedule": {
                               "type": "string",
                               "description": "The schedule for reading the object, in cron syntax.",
-                              "example": "*/15 * * * *"
+                              "example": "*/15 * * * *",
+                              "x-go-type-skip-optional-pointer": true
                             },
                             "destination": {
                               "description": "The name of the destination that the result should be sent to.",
                               "example": "accountWebhook",
-                              "type": "string"
+                              "type": "string",
+                              "x-go-type-skip-optional-pointer": true
                             },
                             "selectedFields": {
                               "type": "object",
@@ -1633,12 +1643,14 @@
                                 "schedule": {
                                   "type": "string",
                                   "description": "The schedule for reading the object, in cron syntax.",
-                                  "example": "*/15 * * * *"
+                                  "example": "*/15 * * * *",
+                                  "x-go-type-skip-optional-pointer": true
                                 },
                                 "destination": {
                                   "description": "The name of the destination that the result should be sent to.",
                                   "example": "accountWebhook",
-                                  "type": "string"
+                                  "type": "string",
+                                  "x-go-type-skip-optional-pointer": true
                                 },
                                 "selectedFields": {
                                   "type": "object",
@@ -2347,12 +2359,14 @@
                     "schedule": {
                       "type": "string",
                       "description": "The schedule for reading the object, in cron syntax.",
-                      "example": "*/15 * * * *"
+                      "example": "*/15 * * * *",
+                      "x-go-type-skip-optional-pointer": true
                     },
                     "destination": {
                       "description": "The name of the destination that the result should be sent to.",
                       "example": "accountWebhook",
-                      "type": "string"
+                      "type": "string",
+                      "x-go-type-skip-optional-pointer": true
                     },
                     "selectedFields": {
                       "type": "object",
@@ -2469,12 +2483,14 @@
                         "schedule": {
                           "type": "string",
                           "description": "The schedule for reading the object, in cron syntax.",
-                          "example": "*/15 * * * *"
+                          "example": "*/15 * * * *",
+                          "x-go-type-skip-optional-pointer": true
                         },
                         "destination": {
                           "description": "The name of the destination that the result should be sent to.",
                           "example": "accountWebhook",
-                          "type": "string"
+                          "type": "string",
+                          "x-go-type-skip-optional-pointer": true
                         },
                         "selectedFields": {
                           "type": "object",
@@ -2596,12 +2612,14 @@
               "schedule": {
                 "type": "string",
                 "description": "The schedule for reading the object, in cron syntax.",
-                "example": "*/15 * * * *"
+                "example": "*/15 * * * *",
+                "x-go-type-skip-optional-pointer": true
               },
               "destination": {
                 "description": "The name of the destination that the result should be sent to.",
                 "example": "accountWebhook",
-                "type": "string"
+                "type": "string",
+                "x-go-type-skip-optional-pointer": true
               },
               "selectedFields": {
                 "type": "object",
@@ -3593,12 +3611,14 @@
                         "schedule": {
                           "type": "string",
                           "description": "The schedule for reading the object, in cron syntax.",
-                          "example": "*/15 * * * *"
+                          "example": "*/15 * * * *",
+                          "x-go-type-skip-optional-pointer": true
                         },
                         "destination": {
                           "description": "The name of the destination that the result should be sent to.",
                           "example": "accountWebhook",
-                          "type": "string"
+                          "type": "string",
+                          "x-go-type-skip-optional-pointer": true
                         },
                         "selectedFields": {
                           "type": "object",
@@ -3885,12 +3905,14 @@
                     "schedule": {
                       "type": "string",
                       "description": "The schedule for reading the object, in cron syntax.",
-                      "example": "*/15 * * * *"
+                      "example": "*/15 * * * *",
+                      "x-go-type-skip-optional-pointer": true
                     },
                     "destination": {
                       "description": "The name of the destination that the result should be sent to.",
                       "example": "accountWebhook",
-                      "type": "string"
+                      "type": "string",
+                      "x-go-type-skip-optional-pointer": true
                     },
                     "selectedFields": {
                       "type": "object",
@@ -4002,12 +4024,14 @@
               "schedule": {
                 "type": "string",
                 "description": "The schedule for reading the object, in cron syntax.",
-                "example": "*/15 * * * *"
+                "example": "*/15 * * * *",
+                "x-go-type-skip-optional-pointer": true
               },
               "destination": {
                 "description": "The name of the destination that the result should be sent to.",
                 "example": "accountWebhook",
-                "type": "string"
+                "type": "string",
+                "x-go-type-skip-optional-pointer": true
               },
               "selectedFields": {
                 "type": "object",

--- a/manifest/generated/manifest.json
+++ b/manifest/generated/manifest.json
@@ -68,10 +68,12 @@
                             "type": "string"
                           },
                           "destination": {
-                            "type": "string"
+                            "type": "string",
+                            "x-go-type-skip-optional-pointer": true
                           },
                           "schedule": {
-                            "type": "string"
+                            "type": "string",
+                            "x-go-type-skip-optional-pointer": true
                           },
                           "mapToName": {
                             "type": "string",
@@ -475,10 +477,12 @@
                       "type": "string"
                     },
                     "destination": {
-                      "type": "string"
+                      "type": "string",
+                      "x-go-type-skip-optional-pointer": true
                     },
                     "schedule": {
-                      "type": "string"
+                      "type": "string",
+                      "x-go-type-skip-optional-pointer": true
                     },
                     "mapToName": {
                       "type": "string",
@@ -870,10 +874,12 @@
                   "type": "string"
                 },
                 "destination": {
-                  "type": "string"
+                  "type": "string",
+                  "x-go-type-skip-optional-pointer": true
                 },
                 "schedule": {
-                  "type": "string"
+                  "type": "string",
+                  "x-go-type-skip-optional-pointer": true
                 },
                 "mapToName": {
                   "type": "string",
@@ -1231,10 +1237,12 @@
             "type": "string"
           },
           "destination": {
-            "type": "string"
+            "type": "string",
+            "x-go-type-skip-optional-pointer": true
           },
           "schedule": {
-            "type": "string"
+            "type": "string",
+            "x-go-type-skip-optional-pointer": true
           },
           "mapToName": {
             "type": "string",

--- a/manifest/manifest.yaml
+++ b/manifest/manifest.yaml
@@ -106,8 +106,10 @@ components:
           type: string
         destination:
           type: string
+          x-go-type-skip-optional-pointer: true
         schedule:
           type: string
+          x-go-type-skip-optional-pointer: true
         mapToName:
           type: string
           description: An object name to map to.


### PR DESCRIPTION
Previously we made destination and schedule optional, but by doing so made the go type to be poitner. This PR fixes it. 