### PR TITLE
[ENG-2525] fixed indentation error for orgUpdate and invite

### DIFF
--- a/api/api.yaml
+++ b/api/api.yaml
@@ -2428,7 +2428,7 @@ paths:
             application/problem+json:
               schema:
                 $ref: "../problem/problem.yaml#/components/schemas/ApiProblem"
-        x-codegen-request-body-name: orgUpdate
+      x-codegen-request-body-name: orgUpdate
   /orgs/{orgId}/builders:
     get:
       summary: List builders for an organization
@@ -2502,7 +2502,7 @@ paths:
             application/problem+json:
               schema:
                 $ref: "../problem/problem.yaml#/components/schemas/ApiProblem"
-        x-codegen-request-body-name: invite
+      x-codegen-request-body-name: invite
     get:
       x-speakeasy-ignore: true
       summary: List invites for an organization

--- a/api/generated/api.json
+++ b/api/generated/api.json
@@ -43280,9 +43280,9 @@
                 }
               }
             }
-          },
-          "x-codegen-request-body-name": "orgUpdate"
-        }
+          }
+        },
+        "x-codegen-request-body-name": "orgUpdate"
       }
     },
     "/orgs/{orgId}/builders": {
@@ -44054,9 +44054,9 @@
                 }
               }
             }
-          },
-          "x-codegen-request-body-name": "invite"
-        }
+          }
+        },
+        "x-codegen-request-body-name": "invite"
       },
       "get": {
         "x-speakeasy-ignore": true,


### PR DESCRIPTION
Fixed indentation for orgUpdate and invite so that it lines up with other parts of the code. API docs correctly appear.

<img width="2144" height="1187" alt="Screenshot 2025-08-28 at 5 36 10 PM" src="https://github.com/user-attachments/assets/36537d21-e8fb-4001-bb84-d8b9c6ff6cc3" />
<img width="2161" height="1162" alt="Screenshot 2025-08-28 at 5 36 18 PM" src="https://github.com/user-attachments/assets/b294113e-0bd0-4f75-9934-1da37c1ce2da" />



