### PR TITLE
[ENG-2545] updating to remove the revisionId as a required field

### DIFF
--- a/api/api.yaml
+++ b/api/api.yaml
@@ -1154,7 +1154,6 @@ paths:
                   description: |
                     Array of field paths specifying which fields to update. Allowed values include:
                     - connectionId
-                    - config.revisionId
                     - config.createdBy
                     - config.content.read.objects.<object-name>
                     - config.content.write.objects.<object-name>

--- a/api/generated/api.json
+++ b/api/generated/api.json
@@ -21091,7 +21091,7 @@
                     "items": {
                       "type": "string"
                     },
-                    "description": "Array of field paths specifying which fields to update. Allowed values include:\n- connectionId\n- config.revisionId\n- config.createdBy\n- config.content.read.objects.<object-name>\n- config.content.write.objects.<object-name>\n- config.content.write.objects\n- config.content.subscribe.objects.<object-name>\n- config.content.proxy.enabled\n\n`<object-name>` means you can specify any object name.\n",
+                    "description": "Array of field paths specifying which fields to update. Allowed values include:\n- connectionId\n- config.createdBy\n- config.content.read.objects.<object-name>\n- config.content.write.objects.<object-name>\n- config.content.write.objects\n- config.content.subscribe.objects.<object-name>\n- config.content.proxy.enabled\n\n`<object-name>` means you can specify any object name.\n",
                     "example": [
                       "config.content.read.objects.contacts",
                       "config.content.write.objects.leads"


### PR DESCRIPTION
A part of this change was already merged [PR](https://github.com/amp-labs/openapi/pull/219). This part was missed in the previous PR. 