### PR TITLE
feat: add streamName, region, and partitionKeyTemplate to destination metadata

### DIFF
--- a/api/api.yaml
+++ b/api/api.yaml
@@ -3475,6 +3475,18 @@ components:
               example: https://webhooks.mailmonkey.com/salesforce-lead-converted
             headers:
               $ref: "#/components/schemas/WebhookHeaders"
+            streamName:
+              type: string
+              description: The name of the Kinesis stream
+              example: my-data-stream
+            region:
+              type: string
+              description: The AWS region for the destination
+              example: us-east-1
+            partitionKeyTemplate:
+              type: string
+              description: Template for generating partition keys
+              example: "{{.integration_id}}"
         createTime:
           type: string
           description: The time the destination was created.

--- a/api/generated/api.json
+++ b/api/generated/api.json
@@ -40563,6 +40563,21 @@
                           "example": {
                             "Authorization": "Bearer 1234"
                           }
+                        },
+                        "streamName": {
+                          "type": "string",
+                          "description": "The name of the Kinesis stream",
+                          "example": "my-data-stream"
+                        },
+                        "region": {
+                          "type": "string",
+                          "description": "The AWS region for the destination",
+                          "example": "us-east-1"
+                        },
+                        "partitionKeyTemplate": {
+                          "type": "string",
+                          "description": "Template for generating partition keys",
+                          "example": "{{.integration_id}}"
                         }
                       }
                     },
@@ -41447,6 +41462,21 @@
                             "example": {
                               "Authorization": "Bearer 1234"
                             }
+                          },
+                          "streamName": {
+                            "type": "string",
+                            "description": "The name of the Kinesis stream",
+                            "example": "my-data-stream"
+                          },
+                          "region": {
+                            "type": "string",
+                            "description": "The AWS region for the destination",
+                            "example": "us-east-1"
+                          },
+                          "partitionKeyTemplate": {
+                            "type": "string",
+                            "description": "Template for generating partition keys",
+                            "example": "{{.integration_id}}"
                           }
                         }
                       },
@@ -41713,6 +41743,21 @@
                           "example": {
                             "Authorization": "Bearer 1234"
                           }
+                        },
+                        "streamName": {
+                          "type": "string",
+                          "description": "The name of the Kinesis stream",
+                          "example": "my-data-stream"
+                        },
+                        "region": {
+                          "type": "string",
+                          "description": "The AWS region for the destination",
+                          "example": "us-east-1"
+                        },
+                        "partitionKeyTemplate": {
+                          "type": "string",
+                          "description": "Template for generating partition keys",
+                          "example": "{{.integration_id}}"
                         }
                       }
                     },
@@ -42382,6 +42427,21 @@
                           "example": {
                             "Authorization": "Bearer 1234"
                           }
+                        },
+                        "streamName": {
+                          "type": "string",
+                          "description": "The name of the Kinesis stream",
+                          "example": "my-data-stream"
+                        },
+                        "region": {
+                          "type": "string",
+                          "description": "The AWS region for the destination",
+                          "example": "us-east-1"
+                        },
+                        "partitionKeyTemplate": {
+                          "type": "string",
+                          "description": "Template for generating partition keys",
+                          "example": "{{.integration_id}}"
                         }
                       }
                     },
@@ -51225,6 +51285,21 @@
                 "example": {
                   "Authorization": "Bearer 1234"
                 }
+              },
+              "streamName": {
+                "type": "string",
+                "description": "The name of the Kinesis stream",
+                "example": "my-data-stream"
+              },
+              "region": {
+                "type": "string",
+                "description": "The AWS region for the destination",
+                "example": "us-east-1"
+              },
+              "partitionKeyTemplate": {
+                "type": "string",
+                "description": "Template for generating partition keys",
+                "example": "{{.integration_id}}"
               }
             }
           },


### PR DESCRIPTION
## Summary
- Add `streamName`, `region`, and `partitionKeyTemplate` fields to destination metadata schema
- These fields are now returned in the `listDestinations` endpoint response
- Enables better support for Kinesis-based destinations with configurable stream names, regions, and partition key templates

## Test plan
- [ ] Verify OpenAPI schema validation passes
- [ ] Test that `listDestinations` endpoint returns the new fields in response
- [ ] Confirm backward compatibility with existing destination objects

🤖 Generated with [Claude Code](https://claude.ai/code)