### PR TITLE
[ENG-3857] Refactor: Providerinfo subscribe support config

### DIFF
--- a/api/generated/api.json
+++ b/api/generated/api.json
@@ -37249,6 +37249,21 @@
                           "type": "string"
                         }
                       },
+                      "subscribeSupportConfig": {
+                        "title": "Subscribe Support Config",
+                        "type": "object",
+                        "properties": {
+                          "registration": {
+                            "type": "boolean"
+                          },
+                          "maintenance": {
+                            "type": "boolean"
+                          },
+                          "postProcess": {
+                            "type": "boolean"
+                          }
+                        }
+                      },
                       "modules": {
                         "title": "Modules that this provider supports",
                         "type": "object",
@@ -38628,6 +38643,21 @@
                       "type": "object",
                       "additionalProperties": {
                         "type": "string"
+                      }
+                    },
+                    "subscribeSupportConfig": {
+                      "title": "Subscribe Support Config",
+                      "type": "object",
+                      "properties": {
+                        "registration": {
+                          "type": "boolean"
+                        },
+                        "maintenance": {
+                          "type": "boolean"
+                        },
+                        "postProcess": {
+                          "type": "boolean"
+                        }
                       }
                     },
                     "modules": {

--- a/api/generated/api.json
+++ b/api/generated/api.json
@@ -37249,7 +37249,7 @@
                           "type": "string"
                         }
                       },
-                      "subscribeSupportConfig": {
+                      "subscribeRequirements": {
                         "title": "Subscribe Support Config",
                         "type": "object",
                         "description": "Declares which auxiliary steps a provider requires to support subscriptions, beyond the per-object subscribe call itself.",
@@ -38649,7 +38649,7 @@
                         "type": "string"
                       }
                     },
-                    "subscribeSupportConfig": {
+                    "subscribeRequirements": {
                       "title": "Subscribe Support Config",
                       "type": "object",
                       "description": "Declares which auxiliary steps a provider requires to support subscriptions, beyond the per-object subscribe call itself.",

--- a/api/generated/api.json
+++ b/api/generated/api.json
@@ -37252,15 +37252,19 @@
                       "subscribeSupportConfig": {
                         "title": "Subscribe Support Config",
                         "type": "object",
+                        "description": "Declares which auxiliary steps a provider requires to support subscriptions, beyond the per-object subscribe call itself.",
                         "properties": {
                           "registration": {
-                            "type": "boolean"
+                            "type": "boolean",
+                            "description": "Whether the provider requires a one-time registration step that is shared across all subscribed objects. The subscribe method is object-scoped, so if a separate API call is needed beyond per-object configuration (e.g., registering a single webhook/endpoint that all object subscriptions hang off of), registration is required."
                           },
                           "maintenance": {
-                            "type": "boolean"
+                            "type": "boolean",
+                            "description": "Whether the subscription requires periodic maintenance. Some providers expire subscriptions/watches after a fixed TTL, so the subscription must be renewed on a schedule to remain active."
                           },
                           "postProcess": {
-                            "type": "boolean"
+                            "type": "boolean",
+                            "description": "Whether subscribing requires a third-party setup step that the connector instance itself cannot perform. Examples: Salesforce requires AWS EventBridge configuration; Gmail requires a Google Pub/Sub topic to be configured. Any configuration that must happen outside the connector falls into post-process."
                           }
                         }
                       },
@@ -38648,15 +38652,19 @@
                     "subscribeSupportConfig": {
                       "title": "Subscribe Support Config",
                       "type": "object",
+                      "description": "Declares which auxiliary steps a provider requires to support subscriptions, beyond the per-object subscribe call itself.",
                       "properties": {
                         "registration": {
-                          "type": "boolean"
+                          "type": "boolean",
+                          "description": "Whether the provider requires a one-time registration step that is shared across all subscribed objects. The subscribe method is object-scoped, so if a separate API call is needed beyond per-object configuration (e.g., registering a single webhook/endpoint that all object subscriptions hang off of), registration is required."
                         },
                         "maintenance": {
-                          "type": "boolean"
+                          "type": "boolean",
+                          "description": "Whether the subscription requires periodic maintenance. Some providers expire subscriptions/watches after a fixed TTL, so the subscription must be renewed on a schedule to remain active."
                         },
                         "postProcess": {
-                          "type": "boolean"
+                          "type": "boolean",
+                          "description": "Whether subscribing requires a third-party setup step that the connector instance itself cannot perform. Examples: Salesforce requires AWS EventBridge configuration; Gmail requires a Google Pub/Sub topic to be configured. Any configuration that must happen outside the connector falls into post-process."
                         }
                       }
                     },

--- a/catalog/catalog.yaml
+++ b/catalog/catalog.yaml
@@ -582,6 +582,8 @@ components:
           $ref: '#/components/schemas/Media'
         labels:
           $ref: '#/components/schemas/Labels'
+        subscribeSupportConfig:
+          $ref: '#/components/schemas/SubscribeSupportConfig'
         modules:
           $ref: '#/components/schemas/Modules'
         metadata:
@@ -640,6 +642,17 @@ components:
         delete:
           type: boolean
         passThrough:
+          type: boolean
+
+    SubscribeSupportConfig:
+      title: Subscribe Support Config
+      type: object
+      properties:
+        registration:
+          type: boolean
+        maintenance:
+          type: boolean
+        postProcess:
           type: boolean
 
     BatchWriteSupport:

--- a/catalog/catalog.yaml
+++ b/catalog/catalog.yaml
@@ -582,8 +582,8 @@ components:
           $ref: '#/components/schemas/Media'
         labels:
           $ref: '#/components/schemas/Labels'
-        subscribeSupportConfig:
-          $ref: '#/components/schemas/SubscribeSupportConfig'
+        subscribeRequirements:
+          $ref: '#/components/schemas/SubscribeRequirements'
         modules:
           $ref: '#/components/schemas/Modules'
         metadata:
@@ -644,7 +644,7 @@ components:
         passThrough:
           type: boolean
 
-    SubscribeSupportConfig:
+    SubscribeRequirements:
       title: Subscribe Support Config
       type: object
       description: Declares which auxiliary steps a provider requires to support subscriptions, beyond the per-object subscribe call itself.

--- a/catalog/catalog.yaml
+++ b/catalog/catalog.yaml
@@ -647,13 +647,25 @@ components:
     SubscribeSupportConfig:
       title: Subscribe Support Config
       type: object
+      description: Declares which auxiliary steps a provider requires to support subscriptions, beyond the per-object subscribe call itself.
       properties:
         registration:
           type: boolean
+          description: >-
+            Whether the provider requires a one-time registration step that is shared across all subscribed objects.
+            The subscribe method is object-scoped, so if a separate API call is needed beyond per-object configuration
+            (e.g., registering a single webhook/endpoint that all object subscriptions hang off of), registration is required.
         maintenance:
           type: boolean
+          description: >-
+            Whether the subscription requires periodic maintenance. Some providers expire subscriptions/watches after
+            a fixed TTL, so the subscription must be renewed on a schedule to remain active.
         postProcess:
           type: boolean
+          description: >-
+            Whether subscribing requires a third-party setup step that the connector instance itself cannot perform.
+            Examples: Salesforce requires AWS EventBridge configuration; Gmail requires a Google Pub/Sub topic to be
+            configured. Any configuration that must happen outside the connector falls into post-process.
 
     BatchWriteSupport:
       required:

--- a/catalog/generated/catalog.json
+++ b/catalog/generated/catalog.json
@@ -2306,7 +2306,7 @@
               "type": "string"
             }
           },
-          "subscribeSupportConfig": {
+          "subscribeRequirements": {
             "title": "Subscribe Support Config",
             "type": "object",
             "description": "Declares which auxiliary steps a provider requires to support subscriptions, beyond the per-object subscribe call itself.",
@@ -3612,7 +3612,7 @@
                     "type": "string"
                   }
                 },
-                "subscribeSupportConfig": {
+                "subscribeRequirements": {
                   "title": "Subscribe Support Config",
                   "type": "object",
                   "description": "Declares which auxiliary steps a provider requires to support subscriptions, beyond the per-object subscribe call itself.",
@@ -4796,7 +4796,7 @@
                 "type": "string"
               }
             },
-            "subscribeSupportConfig": {
+            "subscribeRequirements": {
               "title": "Subscribe Support Config",
               "type": "object",
               "description": "Declares which auxiliary steps a provider requires to support subscriptions, beyond the per-object subscribe call itself.",
@@ -5253,7 +5253,7 @@
           }
         }
       },
-      "SubscribeSupportConfig": {
+      "SubscribeRequirements": {
         "title": "Subscribe Support Config",
         "type": "object",
         "description": "Declares which auxiliary steps a provider requires to support subscriptions, beyond the per-object subscribe call itself.",

--- a/catalog/generated/catalog.json
+++ b/catalog/generated/catalog.json
@@ -2309,15 +2309,19 @@
           "subscribeSupportConfig": {
             "title": "Subscribe Support Config",
             "type": "object",
+            "description": "Declares which auxiliary steps a provider requires to support subscriptions, beyond the per-object subscribe call itself.",
             "properties": {
               "registration": {
-                "type": "boolean"
+                "type": "boolean",
+                "description": "Whether the provider requires a one-time registration step that is shared across all subscribed objects. The subscribe method is object-scoped, so if a separate API call is needed beyond per-object configuration (e.g., registering a single webhook/endpoint that all object subscriptions hang off of), registration is required."
               },
               "maintenance": {
-                "type": "boolean"
+                "type": "boolean",
+                "description": "Whether the subscription requires periodic maintenance. Some providers expire subscriptions/watches after a fixed TTL, so the subscription must be renewed on a schedule to remain active."
               },
               "postProcess": {
-                "type": "boolean"
+                "type": "boolean",
+                "description": "Whether subscribing requires a third-party setup step that the connector instance itself cannot perform. Examples: Salesforce requires AWS EventBridge configuration; Gmail requires a Google Pub/Sub topic to be configured. Any configuration that must happen outside the connector falls into post-process."
               }
             }
           },
@@ -3611,15 +3615,19 @@
                 "subscribeSupportConfig": {
                   "title": "Subscribe Support Config",
                   "type": "object",
+                  "description": "Declares which auxiliary steps a provider requires to support subscriptions, beyond the per-object subscribe call itself.",
                   "properties": {
                     "registration": {
-                      "type": "boolean"
+                      "type": "boolean",
+                      "description": "Whether the provider requires a one-time registration step that is shared across all subscribed objects. The subscribe method is object-scoped, so if a separate API call is needed beyond per-object configuration (e.g., registering a single webhook/endpoint that all object subscriptions hang off of), registration is required."
                     },
                     "maintenance": {
-                      "type": "boolean"
+                      "type": "boolean",
+                      "description": "Whether the subscription requires periodic maintenance. Some providers expire subscriptions/watches after a fixed TTL, so the subscription must be renewed on a schedule to remain active."
                     },
                     "postProcess": {
-                      "type": "boolean"
+                      "type": "boolean",
+                      "description": "Whether subscribing requires a third-party setup step that the connector instance itself cannot perform. Examples: Salesforce requires AWS EventBridge configuration; Gmail requires a Google Pub/Sub topic to be configured. Any configuration that must happen outside the connector falls into post-process."
                     }
                   }
                 },
@@ -4791,15 +4799,19 @@
             "subscribeSupportConfig": {
               "title": "Subscribe Support Config",
               "type": "object",
+              "description": "Declares which auxiliary steps a provider requires to support subscriptions, beyond the per-object subscribe call itself.",
               "properties": {
                 "registration": {
-                  "type": "boolean"
+                  "type": "boolean",
+                  "description": "Whether the provider requires a one-time registration step that is shared across all subscribed objects. The subscribe method is object-scoped, so if a separate API call is needed beyond per-object configuration (e.g., registering a single webhook/endpoint that all object subscriptions hang off of), registration is required."
                 },
                 "maintenance": {
-                  "type": "boolean"
+                  "type": "boolean",
+                  "description": "Whether the subscription requires periodic maintenance. Some providers expire subscriptions/watches after a fixed TTL, so the subscription must be renewed on a schedule to remain active."
                 },
                 "postProcess": {
-                  "type": "boolean"
+                  "type": "boolean",
+                  "description": "Whether subscribing requires a third-party setup step that the connector instance itself cannot perform. Examples: Salesforce requires AWS EventBridge configuration; Gmail requires a Google Pub/Sub topic to be configured. Any configuration that must happen outside the connector falls into post-process."
                 }
               }
             },
@@ -5244,15 +5256,19 @@
       "SubscribeSupportConfig": {
         "title": "Subscribe Support Config",
         "type": "object",
+        "description": "Declares which auxiliary steps a provider requires to support subscriptions, beyond the per-object subscribe call itself.",
         "properties": {
           "registration": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "Whether the provider requires a one-time registration step that is shared across all subscribed objects. The subscribe method is object-scoped, so if a separate API call is needed beyond per-object configuration (e.g., registering a single webhook/endpoint that all object subscriptions hang off of), registration is required."
           },
           "maintenance": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "Whether the subscription requires periodic maintenance. Some providers expire subscriptions/watches after a fixed TTL, so the subscription must be renewed on a schedule to remain active."
           },
           "postProcess": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "Whether subscribing requires a third-party setup step that the connector instance itself cannot perform. Examples: Salesforce requires AWS EventBridge configuration; Gmail requires a Google Pub/Sub topic to be configured. Any configuration that must happen outside the connector falls into post-process."
           }
         }
       },

--- a/catalog/generated/catalog.json
+++ b/catalog/generated/catalog.json
@@ -2306,6 +2306,21 @@
               "type": "string"
             }
           },
+          "subscribeSupportConfig": {
+            "title": "Subscribe Support Config",
+            "type": "object",
+            "properties": {
+              "registration": {
+                "type": "boolean"
+              },
+              "maintenance": {
+                "type": "boolean"
+              },
+              "postProcess": {
+                "type": "boolean"
+              }
+            }
+          },
           "modules": {
             "title": "Modules that this provider supports",
             "type": "object",
@@ -3593,6 +3608,21 @@
                     "type": "string"
                   }
                 },
+                "subscribeSupportConfig": {
+                  "title": "Subscribe Support Config",
+                  "type": "object",
+                  "properties": {
+                    "registration": {
+                      "type": "boolean"
+                    },
+                    "maintenance": {
+                      "type": "boolean"
+                    },
+                    "postProcess": {
+                      "type": "boolean"
+                    }
+                  }
+                },
                 "modules": {
                   "title": "Modules that this provider supports",
                   "type": "object",
@@ -4758,6 +4788,21 @@
                 "type": "string"
               }
             },
+            "subscribeSupportConfig": {
+              "title": "Subscribe Support Config",
+              "type": "object",
+              "properties": {
+                "registration": {
+                  "type": "boolean"
+                },
+                "maintenance": {
+                  "type": "boolean"
+                },
+                "postProcess": {
+                  "type": "boolean"
+                }
+              }
+            },
             "modules": {
               "title": "Modules that this provider supports",
               "type": "object",
@@ -5192,6 +5237,21 @@
             "type": "boolean"
           },
           "passThrough": {
+            "type": "boolean"
+          }
+        }
+      },
+      "SubscribeSupportConfig": {
+        "title": "Subscribe Support Config",
+        "type": "object",
+        "properties": {
+          "registration": {
+            "type": "boolean"
+          },
+          "maintenance": {
+            "type": "boolean"
+          },
+          "postProcess": {
             "type": "boolean"
           }
         }


### PR DESCRIPTION
These registration, maintenance, postprocess configs were in server repo, but we should move to provider info. 