### PR TITLE
Add subscription to subscription requirment

### DIFF
--- a/api/generated/api.json
+++ b/api/generated/api.json
@@ -37266,7 +37266,7 @@
                             "type": "boolean",
                             "description": "Whether subscribing requires a third-party setup step that the connector instance itself cannot perform. Examples: Salesforce requires AWS EventBridge configuration; Gmail requires a Google Pub/Sub topic to be configured. Any configuration that must happen outside the connector falls into post-process."
                           },
-                          "subscription": {
+                          "subscribeByAPI": {
                             "type": "boolean",
                             "description": "Whether the provider supports programmatic subscription via API. If false, provider may still support webhooks via manual configuration in UI. "
                           }
@@ -37506,7 +37506,7 @@
                                   "type": "boolean",
                                   "description": "Whether subscribing requires a third-party setup step that the connector instance itself cannot perform. Examples: Salesforce requires AWS EventBridge configuration; Gmail requires a Google Pub/Sub topic to be configured. Any configuration that must happen outside the connector falls into post-process."
                                 },
-                                "subscription": {
+                                "subscribeByAPI": {
                                   "type": "boolean",
                                   "description": "Whether the provider supports programmatic subscription via API. If false, provider may still support webhooks via manual configuration in UI. "
                                 }
@@ -38693,7 +38693,7 @@
                           "type": "boolean",
                           "description": "Whether subscribing requires a third-party setup step that the connector instance itself cannot perform. Examples: Salesforce requires AWS EventBridge configuration; Gmail requires a Google Pub/Sub topic to be configured. Any configuration that must happen outside the connector falls into post-process."
                         },
-                        "subscription": {
+                        "subscribeByAPI": {
                           "type": "boolean",
                           "description": "Whether the provider supports programmatic subscription via API. If false, provider may still support webhooks via manual configuration in UI. "
                         }
@@ -38933,7 +38933,7 @@
                                 "type": "boolean",
                                 "description": "Whether subscribing requires a third-party setup step that the connector instance itself cannot perform. Examples: Salesforce requires AWS EventBridge configuration; Gmail requires a Google Pub/Sub topic to be configured. Any configuration that must happen outside the connector falls into post-process."
                               },
-                              "subscription": {
+                              "subscribeByAPI": {
                                 "type": "boolean",
                                 "description": "Whether the provider supports programmatic subscription via API. If false, provider may still support webhooks via manual configuration in UI. "
                               }

--- a/api/generated/api.json
+++ b/api/generated/api.json
@@ -37265,6 +37265,10 @@
                           "postProcess": {
                             "type": "boolean",
                             "description": "Whether subscribing requires a third-party setup step that the connector instance itself cannot perform. Examples: Salesforce requires AWS EventBridge configuration; Gmail requires a Google Pub/Sub topic to be configured. Any configuration that must happen outside the connector falls into post-process."
+                          },
+                          "subscription": {
+                            "type": "boolean",
+                            "description": "Whether the provider supports programmatic subscription via API. If false, provider may still support webhooks via manual configuration in UI. "
                           }
                         }
                       },
@@ -37501,6 +37505,10 @@
                                 "postProcess": {
                                   "type": "boolean",
                                   "description": "Whether subscribing requires a third-party setup step that the connector instance itself cannot perform. Examples: Salesforce requires AWS EventBridge configuration; Gmail requires a Google Pub/Sub topic to be configured. Any configuration that must happen outside the connector falls into post-process."
+                                },
+                                "subscription": {
+                                  "type": "boolean",
+                                  "description": "Whether the provider supports programmatic subscription via API. If false, provider may still support webhooks via manual configuration in UI. "
                                 }
                               }
                             }
@@ -38684,6 +38692,10 @@
                         "postProcess": {
                           "type": "boolean",
                           "description": "Whether subscribing requires a third-party setup step that the connector instance itself cannot perform. Examples: Salesforce requires AWS EventBridge configuration; Gmail requires a Google Pub/Sub topic to be configured. Any configuration that must happen outside the connector falls into post-process."
+                        },
+                        "subscription": {
+                          "type": "boolean",
+                          "description": "Whether the provider supports programmatic subscription via API. If false, provider may still support webhooks via manual configuration in UI. "
                         }
                       }
                     },
@@ -38920,6 +38932,10 @@
                               "postProcess": {
                                 "type": "boolean",
                                 "description": "Whether subscribing requires a third-party setup step that the connector instance itself cannot perform. Examples: Salesforce requires AWS EventBridge configuration; Gmail requires a Google Pub/Sub topic to be configured. Any configuration that must happen outside the connector falls into post-process."
+                              },
+                              "subscription": {
+                                "type": "boolean",
+                                "description": "Whether the provider supports programmatic subscription via API. If false, provider may still support webhooks via manual configuration in UI. "
                               }
                             }
                           }

--- a/catalog/catalog.yaml
+++ b/catalog/catalog.yaml
@@ -668,7 +668,7 @@ components:
             Whether subscribing requires a third-party setup step that the connector instance itself cannot perform.
             Examples: Salesforce requires AWS EventBridge configuration; Gmail requires a Google Pub/Sub topic to be
             configured. Any configuration that must happen outside the connector falls into post-process.
-        subscription:
+        subscribeByAPI:
           type: boolean
           description: >-
             Whether the provider supports programmatic subscription via API.

--- a/catalog/catalog.yaml
+++ b/catalog/catalog.yaml
@@ -668,6 +668,11 @@ components:
             Whether subscribing requires a third-party setup step that the connector instance itself cannot perform.
             Examples: Salesforce requires AWS EventBridge configuration; Gmail requires a Google Pub/Sub topic to be
             configured. Any configuration that must happen outside the connector falls into post-process.
+        subscription:
+          type: boolean
+          description: >-
+            Whether the provider supports programmatic subscription via API.
+            If false, provider may still support webhooks via manual configuration in UI. 
 
     BatchWriteSupport:
       required:

--- a/catalog/generated/catalog.json
+++ b/catalog/generated/catalog.json
@@ -1360,7 +1360,7 @@
                   "type": "boolean",
                   "description": "Whether subscribing requires a third-party setup step that the connector instance itself cannot perform. Examples: Salesforce requires AWS EventBridge configuration; Gmail requires a Google Pub/Sub topic to be configured. Any configuration that must happen outside the connector falls into post-process."
                 },
-                "subscription": {
+                "subscribeByAPI": {
                   "type": "boolean",
                   "description": "Whether the provider supports programmatic subscription via API. If false, provider may still support webhooks via manual configuration in UI. "
                 }
@@ -1599,7 +1599,7 @@
                 "type": "boolean",
                 "description": "Whether subscribing requires a third-party setup step that the connector instance itself cannot perform. Examples: Salesforce requires AWS EventBridge configuration; Gmail requires a Google Pub/Sub topic to be configured. Any configuration that must happen outside the connector falls into post-process."
               },
-              "subscription": {
+              "subscribeByAPI": {
                 "type": "boolean",
                 "description": "Whether the provider supports programmatic subscription via API. If false, provider may still support webhooks via manual configuration in UI. "
               }
@@ -2369,7 +2369,7 @@
                 "type": "boolean",
                 "description": "Whether subscribing requires a third-party setup step that the connector instance itself cannot perform. Examples: Salesforce requires AWS EventBridge configuration; Gmail requires a Google Pub/Sub topic to be configured. Any configuration that must happen outside the connector falls into post-process."
               },
-              "subscription": {
+              "subscribeByAPI": {
                 "type": "boolean",
                 "description": "Whether the provider supports programmatic subscription via API. If false, provider may still support webhooks via manual configuration in UI. "
               }
@@ -2609,7 +2609,7 @@
                       "type": "boolean",
                       "description": "Whether subscribing requires a third-party setup step that the connector instance itself cannot perform. Examples: Salesforce requires AWS EventBridge configuration; Gmail requires a Google Pub/Sub topic to be configured. Any configuration that must happen outside the connector falls into post-process."
                     },
-                    "subscription": {
+                    "subscribeByAPI": {
                       "type": "boolean",
                       "description": "Whether the provider supports programmatic subscription via API. If false, provider may still support webhooks via manual configuration in UI. "
                     }
@@ -3702,7 +3702,7 @@
                       "type": "boolean",
                       "description": "Whether subscribing requires a third-party setup step that the connector instance itself cannot perform. Examples: Salesforce requires AWS EventBridge configuration; Gmail requires a Google Pub/Sub topic to be configured. Any configuration that must happen outside the connector falls into post-process."
                     },
-                    "subscription": {
+                    "subscribeByAPI": {
                       "type": "boolean",
                       "description": "Whether the provider supports programmatic subscription via API. If false, provider may still support webhooks via manual configuration in UI. "
                     }
@@ -3942,7 +3942,7 @@
                             "type": "boolean",
                             "description": "Whether subscribing requires a third-party setup step that the connector instance itself cannot perform. Examples: Salesforce requires AWS EventBridge configuration; Gmail requires a Google Pub/Sub topic to be configured. Any configuration that must happen outside the connector falls into post-process."
                           },
-                          "subscription": {
+                          "subscribeByAPI": {
                             "type": "boolean",
                             "description": "Whether the provider supports programmatic subscription via API. If false, provider may still support webhooks via manual configuration in UI. "
                           }
@@ -4913,7 +4913,7 @@
                   "type": "boolean",
                   "description": "Whether subscribing requires a third-party setup step that the connector instance itself cannot perform. Examples: Salesforce requires AWS EventBridge configuration; Gmail requires a Google Pub/Sub topic to be configured. Any configuration that must happen outside the connector falls into post-process."
                 },
-                "subscription": {
+                "subscribeByAPI": {
                   "type": "boolean",
                   "description": "Whether the provider supports programmatic subscription via API. If false, provider may still support webhooks via manual configuration in UI. "
                 }
@@ -5153,7 +5153,7 @@
                         "type": "boolean",
                         "description": "Whether subscribing requires a third-party setup step that the connector instance itself cannot perform. Examples: Salesforce requires AWS EventBridge configuration; Gmail requires a Google Pub/Sub topic to be configured. Any configuration that must happen outside the connector falls into post-process."
                       },
-                      "subscription": {
+                      "subscribeByAPI": {
                         "type": "boolean",
                         "description": "Whether the provider supports programmatic subscription via API. If false, provider may still support webhooks via manual configuration in UI. "
                       }
@@ -5397,7 +5397,7 @@
             "type": "boolean",
             "description": "Whether subscribing requires a third-party setup step that the connector instance itself cannot perform. Examples: Salesforce requires AWS EventBridge configuration; Gmail requires a Google Pub/Sub topic to be configured. Any configuration that must happen outside the connector falls into post-process."
           },
-          "subscription": {
+          "subscribeByAPI": {
             "type": "boolean",
             "description": "Whether the provider supports programmatic subscription via API. If false, provider may still support webhooks via manual configuration in UI. "
           }

--- a/catalog/generated/catalog.json
+++ b/catalog/generated/catalog.json
@@ -1359,6 +1359,10 @@
                 "postProcess": {
                   "type": "boolean",
                   "description": "Whether subscribing requires a third-party setup step that the connector instance itself cannot perform. Examples: Salesforce requires AWS EventBridge configuration; Gmail requires a Google Pub/Sub topic to be configured. Any configuration that must happen outside the connector falls into post-process."
+                },
+                "subscription": {
+                  "type": "boolean",
+                  "description": "Whether the provider supports programmatic subscription via API. If false, provider may still support webhooks via manual configuration in UI. "
                 }
               }
             }
@@ -1594,6 +1598,10 @@
               "postProcess": {
                 "type": "boolean",
                 "description": "Whether subscribing requires a third-party setup step that the connector instance itself cannot perform. Examples: Salesforce requires AWS EventBridge configuration; Gmail requires a Google Pub/Sub topic to be configured. Any configuration that must happen outside the connector falls into post-process."
+              },
+              "subscription": {
+                "type": "boolean",
+                "description": "Whether the provider supports programmatic subscription via API. If false, provider may still support webhooks via manual configuration in UI. "
               }
             }
           }
@@ -2360,6 +2368,10 @@
               "postProcess": {
                 "type": "boolean",
                 "description": "Whether subscribing requires a third-party setup step that the connector instance itself cannot perform. Examples: Salesforce requires AWS EventBridge configuration; Gmail requires a Google Pub/Sub topic to be configured. Any configuration that must happen outside the connector falls into post-process."
+              },
+              "subscription": {
+                "type": "boolean",
+                "description": "Whether the provider supports programmatic subscription via API. If false, provider may still support webhooks via manual configuration in UI. "
               }
             }
           },
@@ -2596,6 +2608,10 @@
                     "postProcess": {
                       "type": "boolean",
                       "description": "Whether subscribing requires a third-party setup step that the connector instance itself cannot perform. Examples: Salesforce requires AWS EventBridge configuration; Gmail requires a Google Pub/Sub topic to be configured. Any configuration that must happen outside the connector falls into post-process."
+                    },
+                    "subscription": {
+                      "type": "boolean",
+                      "description": "Whether the provider supports programmatic subscription via API. If false, provider may still support webhooks via manual configuration in UI. "
                     }
                   }
                 }
@@ -3685,6 +3701,10 @@
                     "postProcess": {
                       "type": "boolean",
                       "description": "Whether subscribing requires a third-party setup step that the connector instance itself cannot perform. Examples: Salesforce requires AWS EventBridge configuration; Gmail requires a Google Pub/Sub topic to be configured. Any configuration that must happen outside the connector falls into post-process."
+                    },
+                    "subscription": {
+                      "type": "boolean",
+                      "description": "Whether the provider supports programmatic subscription via API. If false, provider may still support webhooks via manual configuration in UI. "
                     }
                   }
                 },
@@ -3921,6 +3941,10 @@
                           "postProcess": {
                             "type": "boolean",
                             "description": "Whether subscribing requires a third-party setup step that the connector instance itself cannot perform. Examples: Salesforce requires AWS EventBridge configuration; Gmail requires a Google Pub/Sub topic to be configured. Any configuration that must happen outside the connector falls into post-process."
+                          },
+                          "subscription": {
+                            "type": "boolean",
+                            "description": "Whether the provider supports programmatic subscription via API. If false, provider may still support webhooks via manual configuration in UI. "
                           }
                         }
                       }
@@ -4888,6 +4912,10 @@
                 "postProcess": {
                   "type": "boolean",
                   "description": "Whether subscribing requires a third-party setup step that the connector instance itself cannot perform. Examples: Salesforce requires AWS EventBridge configuration; Gmail requires a Google Pub/Sub topic to be configured. Any configuration that must happen outside the connector falls into post-process."
+                },
+                "subscription": {
+                  "type": "boolean",
+                  "description": "Whether the provider supports programmatic subscription via API. If false, provider may still support webhooks via manual configuration in UI. "
                 }
               }
             },
@@ -5124,6 +5152,10 @@
                       "postProcess": {
                         "type": "boolean",
                         "description": "Whether subscribing requires a third-party setup step that the connector instance itself cannot perform. Examples: Salesforce requires AWS EventBridge configuration; Gmail requires a Google Pub/Sub topic to be configured. Any configuration that must happen outside the connector falls into post-process."
+                      },
+                      "subscription": {
+                        "type": "boolean",
+                        "description": "Whether the provider supports programmatic subscription via API. If false, provider may still support webhooks via manual configuration in UI. "
                       }
                     }
                   }
@@ -5364,6 +5396,10 @@
           "postProcess": {
             "type": "boolean",
             "description": "Whether subscribing requires a third-party setup step that the connector instance itself cannot perform. Examples: Salesforce requires AWS EventBridge configuration; Gmail requires a Google Pub/Sub topic to be configured. Any configuration that must happen outside the connector falls into post-process."
+          },
+          "subscription": {
+            "type": "boolean",
+            "description": "Whether the provider supports programmatic subscription via API. If false, provider may still support webhooks via manual configuration in UI. "
           }
         }
       },


### PR DESCRIPTION
Added Subscription field in SubscriptionRequirement schema. 

This will indicate if programmatic subscription is possible for the provider. If false, the provider may still be subscribed in UI. 

In the server, we have a LookUpOnly Provider list (Hubspot, Gong, HouseCall), and this will replace the server's list. 