### PR TITLE
feat(config): add mapToName to BaseReadConfigObject

### DIFF
--- a/api/generated/api.json
+++ b/api/generated/api.json
@@ -12687,6 +12687,12 @@
                                               "type": "string",
                                               "x-go-type-skip-optional-pointer": true
                                             },
+                                            "mapToName": {
+                                              "type": "string",
+                                              "description": "An object name to map to when the result is delivered to the destination. Overrides the manifest's mapToName for this object.",
+                                              "example": "people",
+                                              "x-go-type-skip-optional-pointer": true
+                                            },
                                             "selectedFields": {
                                               "type": "object",
                                               "description": "This is a map of field names to booleans indicating whether they should be read. If a field is already included in `selectedFieldMappings`, it does not need to be included here.",
@@ -13117,6 +13123,12 @@
                                                   "type": "string",
                                                   "x-go-type-skip-optional-pointer": true
                                                 },
+                                                "mapToName": {
+                                                  "type": "string",
+                                                  "description": "An object name to map to when the result is delivered to the destination. Overrides the manifest's mapToName for this object.",
+                                                  "example": "people",
+                                                  "x-go-type-skip-optional-pointer": true
+                                                },
                                                 "selectedFields": {
                                                   "type": "object",
                                                   "description": "This is a map of field names to booleans indicating whether they should be read. If a field is already included in `selectedFieldMappings`, it does not need to be included here.",
@@ -13360,6 +13372,12 @@
                                                       "description": "The name of the destination that the result should be sent to.",
                                                       "example": "accountWebhook",
                                                       "type": "string",
+                                                      "x-go-type-skip-optional-pointer": true
+                                                    },
+                                                    "mapToName": {
+                                                      "type": "string",
+                                                      "description": "An object name to map to when the result is delivered to the destination. Overrides the manifest's mapToName for this object.",
+                                                      "example": "people",
                                                       "x-go-type-skip-optional-pointer": true
                                                     },
                                                     "selectedFields": {
@@ -14855,6 +14873,12 @@
                                           "type": "string",
                                           "x-go-type-skip-optional-pointer": true
                                         },
+                                        "mapToName": {
+                                          "type": "string",
+                                          "description": "An object name to map to when the result is delivered to the destination. Overrides the manifest's mapToName for this object.",
+                                          "example": "people",
+                                          "x-go-type-skip-optional-pointer": true
+                                        },
                                         "selectedFields": {
                                           "type": "object",
                                           "description": "This is a map of field names to booleans indicating whether they should be read. If a field is already included in `selectedFieldMappings`, it does not need to be included here.",
@@ -15285,6 +15309,12 @@
                                               "type": "string",
                                               "x-go-type-skip-optional-pointer": true
                                             },
+                                            "mapToName": {
+                                              "type": "string",
+                                              "description": "An object name to map to when the result is delivered to the destination. Overrides the manifest's mapToName for this object.",
+                                              "example": "people",
+                                              "x-go-type-skip-optional-pointer": true
+                                            },
                                             "selectedFields": {
                                               "type": "object",
                                               "description": "This is a map of field names to booleans indicating whether they should be read. If a field is already included in `selectedFieldMappings`, it does not need to be included here.",
@@ -15528,6 +15558,12 @@
                                                   "description": "The name of the destination that the result should be sent to.",
                                                   "example": "accountWebhook",
                                                   "type": "string",
+                                                  "x-go-type-skip-optional-pointer": true
+                                                },
+                                                "mapToName": {
+                                                  "type": "string",
+                                                  "description": "An object name to map to when the result is delivered to the destination. Overrides the manifest's mapToName for this object.",
+                                                  "example": "people",
                                                   "x-go-type-skip-optional-pointer": true
                                                 },
                                                 "selectedFields": {
@@ -16985,6 +17021,12 @@
                                             "type": "string",
                                             "x-go-type-skip-optional-pointer": true
                                           },
+                                          "mapToName": {
+                                            "type": "string",
+                                            "description": "An object name to map to when the result is delivered to the destination. Overrides the manifest's mapToName for this object.",
+                                            "example": "people",
+                                            "x-go-type-skip-optional-pointer": true
+                                          },
                                           "selectedFields": {
                                             "type": "object",
                                             "description": "This is a map of field names to booleans indicating whether they should be read. If a field is already included in `selectedFieldMappings`, it does not need to be included here.",
@@ -17415,6 +17457,12 @@
                                                 "type": "string",
                                                 "x-go-type-skip-optional-pointer": true
                                               },
+                                              "mapToName": {
+                                                "type": "string",
+                                                "description": "An object name to map to when the result is delivered to the destination. Overrides the manifest's mapToName for this object.",
+                                                "example": "people",
+                                                "x-go-type-skip-optional-pointer": true
+                                              },
                                               "selectedFields": {
                                                 "type": "object",
                                                 "description": "This is a map of field names to booleans indicating whether they should be read. If a field is already included in `selectedFieldMappings`, it does not need to be included here.",
@@ -17658,6 +17706,12 @@
                                                     "description": "The name of the destination that the result should be sent to.",
                                                     "example": "accountWebhook",
                                                     "type": "string",
+                                                    "x-go-type-skip-optional-pointer": true
+                                                  },
+                                                  "mapToName": {
+                                                    "type": "string",
+                                                    "description": "An object name to map to when the result is delivered to the destination. Overrides the manifest's mapToName for this object.",
+                                                    "example": "people",
                                                     "x-go-type-skip-optional-pointer": true
                                                   },
                                                   "selectedFields": {
@@ -19875,6 +19929,12 @@
                                             "type": "string",
                                             "x-go-type-skip-optional-pointer": true
                                           },
+                                          "mapToName": {
+                                            "type": "string",
+                                            "description": "An object name to map to when the result is delivered to the destination. Overrides the manifest's mapToName for this object.",
+                                            "example": "people",
+                                            "x-go-type-skip-optional-pointer": true
+                                          },
                                           "selectedFields": {
                                             "type": "object",
                                             "description": "This is a map of field names to booleans indicating whether they should be read. If a field is already included in `selectedFieldMappings`, it does not need to be included here.",
@@ -20305,6 +20365,12 @@
                                                 "type": "string",
                                                 "x-go-type-skip-optional-pointer": true
                                               },
+                                              "mapToName": {
+                                                "type": "string",
+                                                "description": "An object name to map to when the result is delivered to the destination. Overrides the manifest's mapToName for this object.",
+                                                "example": "people",
+                                                "x-go-type-skip-optional-pointer": true
+                                              },
                                               "selectedFields": {
                                                 "type": "object",
                                                 "description": "This is a map of field names to booleans indicating whether they should be read. If a field is already included in `selectedFieldMappings`, it does not need to be included here.",
@@ -20548,6 +20614,12 @@
                                                     "description": "The name of the destination that the result should be sent to.",
                                                     "example": "accountWebhook",
                                                     "type": "string",
+                                                    "x-go-type-skip-optional-pointer": true
+                                                  },
+                                                  "mapToName": {
+                                                    "type": "string",
+                                                    "description": "An object name to map to when the result is delivered to the destination. Overrides the manifest's mapToName for this object.",
+                                                    "example": "people",
                                                     "x-go-type-skip-optional-pointer": true
                                                   },
                                                   "selectedFields": {
@@ -22233,6 +22305,12 @@
                                               "type": "string",
                                               "x-go-type-skip-optional-pointer": true
                                             },
+                                            "mapToName": {
+                                              "type": "string",
+                                              "description": "An object name to map to when the result is delivered to the destination. Overrides the manifest's mapToName for this object.",
+                                              "example": "people",
+                                              "x-go-type-skip-optional-pointer": true
+                                            },
                                             "selectedFields": {
                                               "type": "object",
                                               "description": "This is a map of field names to booleans indicating whether they should be read. If a field is already included in `selectedFieldMappings`, it does not need to be included here.",
@@ -23321,6 +23399,12 @@
                                             "type": "string",
                                             "x-go-type-skip-optional-pointer": true
                                           },
+                                          "mapToName": {
+                                            "type": "string",
+                                            "description": "An object name to map to when the result is delivered to the destination. Overrides the manifest's mapToName for this object.",
+                                            "example": "people",
+                                            "x-go-type-skip-optional-pointer": true
+                                          },
                                           "selectedFields": {
                                             "type": "object",
                                             "description": "This is a map of field names to booleans indicating whether they should be read. If a field is already included in `selectedFieldMappings`, it does not need to be included here.",
@@ -23751,6 +23835,12 @@
                                                 "type": "string",
                                                 "x-go-type-skip-optional-pointer": true
                                               },
+                                              "mapToName": {
+                                                "type": "string",
+                                                "description": "An object name to map to when the result is delivered to the destination. Overrides the manifest's mapToName for this object.",
+                                                "example": "people",
+                                                "x-go-type-skip-optional-pointer": true
+                                              },
                                               "selectedFields": {
                                                 "type": "object",
                                                 "description": "This is a map of field names to booleans indicating whether they should be read. If a field is already included in `selectedFieldMappings`, it does not need to be included here.",
@@ -23994,6 +24084,12 @@
                                                     "description": "The name of the destination that the result should be sent to.",
                                                     "example": "accountWebhook",
                                                     "type": "string",
+                                                    "x-go-type-skip-optional-pointer": true
+                                                  },
+                                                  "mapToName": {
+                                                    "type": "string",
+                                                    "description": "An object name to map to when the result is delivered to the destination. Overrides the manifest's mapToName for this object.",
+                                                    "example": "people",
                                                     "x-go-type-skip-optional-pointer": true
                                                   },
                                                   "selectedFields": {
@@ -26053,6 +26149,12 @@
                                             "type": "string",
                                             "x-go-type-skip-optional-pointer": true
                                           },
+                                          "mapToName": {
+                                            "type": "string",
+                                            "description": "An object name to map to when the result is delivered to the destination. Overrides the manifest's mapToName for this object.",
+                                            "example": "people",
+                                            "x-go-type-skip-optional-pointer": true
+                                          },
                                           "selectedFields": {
                                             "type": "object",
                                             "description": "This is a map of field names to booleans indicating whether they should be read. If a field is already included in `selectedFieldMappings`, it does not need to be included here.",
@@ -26483,6 +26585,12 @@
                                                 "type": "string",
                                                 "x-go-type-skip-optional-pointer": true
                                               },
+                                              "mapToName": {
+                                                "type": "string",
+                                                "description": "An object name to map to when the result is delivered to the destination. Overrides the manifest's mapToName for this object.",
+                                                "example": "people",
+                                                "x-go-type-skip-optional-pointer": true
+                                              },
                                               "selectedFields": {
                                                 "type": "object",
                                                 "description": "This is a map of field names to booleans indicating whether they should be read. If a field is already included in `selectedFieldMappings`, it does not need to be included here.",
@@ -26726,6 +26834,12 @@
                                                     "description": "The name of the destination that the result should be sent to.",
                                                     "example": "accountWebhook",
                                                     "type": "string",
+                                                    "x-go-type-skip-optional-pointer": true
+                                                  },
+                                                  "mapToName": {
+                                                    "type": "string",
+                                                    "description": "An object name to map to when the result is delivered to the destination. Overrides the manifest's mapToName for this object.",
+                                                    "example": "people",
                                                     "x-go-type-skip-optional-pointer": true
                                                   },
                                                   "selectedFields": {
@@ -29306,6 +29420,12 @@
                                               "type": "string",
                                               "x-go-type-skip-optional-pointer": true
                                             },
+                                            "mapToName": {
+                                              "type": "string",
+                                              "description": "An object name to map to when the result is delivered to the destination. Overrides the manifest's mapToName for this object.",
+                                              "example": "people",
+                                              "x-go-type-skip-optional-pointer": true
+                                            },
                                             "selectedFields": {
                                               "type": "object",
                                               "description": "This is a map of field names to booleans indicating whether they should be read. If a field is already included in `selectedFieldMappings`, it does not need to be included here.",
@@ -29736,6 +29856,12 @@
                                                   "type": "string",
                                                   "x-go-type-skip-optional-pointer": true
                                                 },
+                                                "mapToName": {
+                                                  "type": "string",
+                                                  "description": "An object name to map to when the result is delivered to the destination. Overrides the manifest's mapToName for this object.",
+                                                  "example": "people",
+                                                  "x-go-type-skip-optional-pointer": true
+                                                },
                                                 "selectedFields": {
                                                   "type": "object",
                                                   "description": "This is a map of field names to booleans indicating whether they should be read. If a field is already included in `selectedFieldMappings`, it does not need to be included here.",
@@ -29979,6 +30105,12 @@
                                                       "description": "The name of the destination that the result should be sent to.",
                                                       "example": "accountWebhook",
                                                       "type": "string",
+                                                      "x-go-type-skip-optional-pointer": true
+                                                    },
+                                                    "mapToName": {
+                                                      "type": "string",
+                                                      "description": "An object name to map to when the result is delivered to the destination. Overrides the manifest's mapToName for this object.",
+                                                      "example": "people",
                                                       "x-go-type-skip-optional-pointer": true
                                                     },
                                                     "selectedFields": {
@@ -68326,6 +68458,12 @@
                                   "type": "string",
                                   "x-go-type-skip-optional-pointer": true
                                 },
+                                "mapToName": {
+                                  "type": "string",
+                                  "description": "An object name to map to when the result is delivered to the destination. Overrides the manifest's mapToName for this object.",
+                                  "example": "people",
+                                  "x-go-type-skip-optional-pointer": true
+                                },
                                 "selectedFields": {
                                   "type": "object",
                                   "description": "This is a map of field names to booleans indicating whether they should be read. If a field is already included in `selectedFieldMappings`, it does not need to be included here.",
@@ -68756,6 +68894,12 @@
                                       "type": "string",
                                       "x-go-type-skip-optional-pointer": true
                                     },
+                                    "mapToName": {
+                                      "type": "string",
+                                      "description": "An object name to map to when the result is delivered to the destination. Overrides the manifest's mapToName for this object.",
+                                      "example": "people",
+                                      "x-go-type-skip-optional-pointer": true
+                                    },
                                     "selectedFields": {
                                       "type": "object",
                                       "description": "This is a map of field names to booleans indicating whether they should be read. If a field is already included in `selectedFieldMappings`, it does not need to be included here.",
@@ -68999,6 +69143,12 @@
                                           "description": "The name of the destination that the result should be sent to.",
                                           "example": "accountWebhook",
                                           "type": "string",
+                                          "x-go-type-skip-optional-pointer": true
+                                        },
+                                        "mapToName": {
+                                          "type": "string",
+                                          "description": "An object name to map to when the result is delivered to the destination. Overrides the manifest's mapToName for this object.",
+                                          "example": "people",
                                           "x-go-type-skip-optional-pointer": true
                                         },
                                         "selectedFields": {
@@ -69966,6 +70116,12 @@
                               "type": "string",
                               "x-go-type-skip-optional-pointer": true
                             },
+                            "mapToName": {
+                              "type": "string",
+                              "description": "An object name to map to when the result is delivered to the destination. Overrides the manifest's mapToName for this object.",
+                              "example": "people",
+                              "x-go-type-skip-optional-pointer": true
+                            },
                             "selectedFields": {
                               "type": "object",
                               "description": "This is a map of field names to booleans indicating whether they should be read. If a field is already included in `selectedFieldMappings`, it does not need to be included here.",
@@ -70396,6 +70552,12 @@
                                   "type": "string",
                                   "x-go-type-skip-optional-pointer": true
                                 },
+                                "mapToName": {
+                                  "type": "string",
+                                  "description": "An object name to map to when the result is delivered to the destination. Overrides the manifest's mapToName for this object.",
+                                  "example": "people",
+                                  "x-go-type-skip-optional-pointer": true
+                                },
                                 "selectedFields": {
                                   "type": "object",
                                   "description": "This is a map of field names to booleans indicating whether they should be read. If a field is already included in `selectedFieldMappings`, it does not need to be included here.",
@@ -70639,6 +70801,12 @@
                                       "description": "The name of the destination that the result should be sent to.",
                                       "example": "accountWebhook",
                                       "type": "string",
+                                      "x-go-type-skip-optional-pointer": true
+                                    },
+                                    "mapToName": {
+                                      "type": "string",
+                                      "description": "An object name to map to when the result is delivered to the destination. Overrides the manifest's mapToName for this object.",
+                                      "example": "people",
                                       "x-go-type-skip-optional-pointer": true
                                     },
                                     "selectedFields": {

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -68,6 +68,11 @@ components:
           example: accountWebhook
           type: string
           x-go-type-skip-optional-pointer: true
+        mapToName:
+          type: string
+          description: An object name to map to when the result is delivered to the destination. Overrides the manifest's mapToName for this object.
+          example: people
+          x-go-type-skip-optional-pointer: true
         selectedFields:
           type: object
           description:

--- a/config/generated/config.json
+++ b/config/generated/config.json
@@ -57,6 +57,12 @@
                       "type": "string",
                       "x-go-type-skip-optional-pointer": true
                     },
+                    "mapToName": {
+                      "type": "string",
+                      "description": "An object name to map to when the result is delivered to the destination. Overrides the manifest's mapToName for this object.",
+                      "example": "people",
+                      "x-go-type-skip-optional-pointer": true
+                    },
                     "selectedFields": {
                       "type": "object",
                       "description": "This is a map of field names to booleans indicating whether they should be read. If a field is already included in `selectedFieldMappings`, it does not need to be included here.",
@@ -487,6 +493,12 @@
                   "type": "string",
                   "x-go-type-skip-optional-pointer": true
                 },
+                "mapToName": {
+                  "type": "string",
+                  "description": "An object name to map to when the result is delivered to the destination. Overrides the manifest's mapToName for this object.",
+                  "example": "people",
+                  "x-go-type-skip-optional-pointer": true
+                },
                 "selectedFields": {
                   "type": "object",
                   "description": "This is a map of field names to booleans indicating whether they should be read. If a field is already included in `selectedFieldMappings`, it does not need to be included here.",
@@ -720,6 +732,12 @@
             "description": "The name of the destination that the result should be sent to.",
             "example": "accountWebhook",
             "type": "string",
+            "x-go-type-skip-optional-pointer": true
+          },
+          "mapToName": {
+            "type": "string",
+            "description": "An object name to map to when the result is delivered to the destination. Overrides the manifest's mapToName for this object.",
+            "example": "people",
             "x-go-type-skip-optional-pointer": true
           },
           "selectedFields": {
@@ -1723,6 +1741,12 @@
                           "type": "string",
                           "x-go-type-skip-optional-pointer": true
                         },
+                        "mapToName": {
+                          "type": "string",
+                          "description": "An object name to map to when the result is delivered to the destination. Overrides the manifest's mapToName for this object.",
+                          "example": "people",
+                          "x-go-type-skip-optional-pointer": true
+                        },
                         "selectedFields": {
                           "type": "object",
                           "description": "This is a map of field names to booleans indicating whether they should be read. If a field is already included in `selectedFieldMappings`, it does not need to be included here.",
@@ -2153,6 +2177,12 @@
                               "type": "string",
                               "x-go-type-skip-optional-pointer": true
                             },
+                            "mapToName": {
+                              "type": "string",
+                              "description": "An object name to map to when the result is delivered to the destination. Overrides the manifest's mapToName for this object.",
+                              "example": "people",
+                              "x-go-type-skip-optional-pointer": true
+                            },
                             "selectedFields": {
                               "type": "object",
                               "description": "This is a map of field names to booleans indicating whether they should be read. If a field is already included in `selectedFieldMappings`, it does not need to be included here.",
@@ -2396,6 +2426,12 @@
                                   "description": "The name of the destination that the result should be sent to.",
                                   "example": "accountWebhook",
                                   "type": "string",
+                                  "x-go-type-skip-optional-pointer": true
+                                },
+                                "mapToName": {
+                                  "type": "string",
+                                  "description": "An object name to map to when the result is delivered to the destination. Overrides the manifest's mapToName for this object.",
+                                  "example": "people",
                                   "x-go-type-skip-optional-pointer": true
                                 },
                                 "selectedFields": {
@@ -3289,6 +3325,12 @@
                       "type": "string",
                       "x-go-type-skip-optional-pointer": true
                     },
+                    "mapToName": {
+                      "type": "string",
+                      "description": "An object name to map to when the result is delivered to the destination. Overrides the manifest's mapToName for this object.",
+                      "example": "people",
+                      "x-go-type-skip-optional-pointer": true
+                    },
                     "selectedFields": {
                       "type": "object",
                       "description": "This is a map of field names to booleans indicating whether they should be read. If a field is already included in `selectedFieldMappings`, it does not need to be included here.",
@@ -3532,6 +3574,12 @@
                           "description": "The name of the destination that the result should be sent to.",
                           "example": "accountWebhook",
                           "type": "string",
+                          "x-go-type-skip-optional-pointer": true
+                        },
+                        "mapToName": {
+                          "type": "string",
+                          "description": "An object name to map to when the result is delivered to the destination. Overrides the manifest's mapToName for this object.",
+                          "example": "people",
                           "x-go-type-skip-optional-pointer": true
                         },
                         "selectedFields": {
@@ -3782,6 +3830,12 @@
                 "description": "The name of the destination that the result should be sent to.",
                 "example": "accountWebhook",
                 "type": "string",
+                "x-go-type-skip-optional-pointer": true
+              },
+              "mapToName": {
+                "type": "string",
+                "description": "An object name to map to when the result is delivered to the destination. Overrides the manifest's mapToName for this object.",
+                "example": "people",
                 "x-go-type-skip-optional-pointer": true
               },
               "selectedFields": {
@@ -4977,6 +5031,12 @@
                           "description": "The name of the destination that the result should be sent to.",
                           "example": "accountWebhook",
                           "type": "string",
+                          "x-go-type-skip-optional-pointer": true
+                        },
+                        "mapToName": {
+                          "type": "string",
+                          "description": "An object name to map to when the result is delivered to the destination. Overrides the manifest's mapToName for this object.",
+                          "example": "people",
                           "x-go-type-skip-optional-pointer": true
                         },
                         "selectedFields": {


### PR DESCRIPTION
## Summary

Adds optional `mapToName` to `BaseReadConfigObject` so an installation can rename a read object's delivered name per-customer (mirrors the existing manifest-level field on `IntegrationObject`).

## Motivation

Today object-level `mapToName` only exists on the manifest. Builders who want per-customer object aliases — e.g. Aurasell delivering custom event types under their internal naming scheme — have to either declare every variant in the manifest or accept the provider object name on the wire.

This is the first half of the install-level `mapToName` work. The server PR ([amp-labs/server#TBD]) consumes the new field by updating `getMappedObjectName` to consult the installation's `ReadConfigObject.MapToName` first, falling back to the revision's mapping.

## Changes

- `config/config.yaml` — add `mapToName` to `BaseReadConfigObject`.
- `config/generated/config.json` — regen.
- `api/generated/api.json` — regen (inlined references).

## Test plan

- [ ] Schema validation (`make lint`)
- [ ] Consumed by amp-labs/server PR before merge