### PR TITLE
feat(api): add logRetention to project entitlements

### DIFF
--- a/api/api.yaml
+++ b/api/api.yaml
@@ -4951,7 +4951,7 @@ components:
                 value:
                   type: boolean
                   description: True if Ampersand branding has been removed for this project.
-            logRetention:
+            logRetentionDays:
               type: object
               required:
                 - value

--- a/api/api.yaml
+++ b/api/api.yaml
@@ -4951,6 +4951,16 @@ components:
                 value:
                   type: boolean
                   description: True if Ampersand branding has been removed for this project.
+            logRetention:
+              type: object
+              required:
+                - value
+              x-go-type-skip-optional-pointer: true
+              description: The number of days that logs are retained for this project.
+              properties:
+                value:
+                  type: integer
+                  description: The log retention period for this project, in days.
     ProviderApp:
       title: Provider App
       required:

--- a/api/generated/api.json
+++ b/api/generated/api.json
@@ -1212,6 +1212,20 @@
                                 "description": "True if Ampersand branding has been removed for this project."
                               }
                             }
+                          },
+                          "logRetention": {
+                            "type": "object",
+                            "required": [
+                              "value"
+                            ],
+                            "x-go-type-skip-optional-pointer": true,
+                            "description": "The number of days that logs are retained for this project.",
+                            "properties": {
+                              "value": {
+                                "type": "integer",
+                                "description": "The log retention period for this project, in days."
+                              }
+                            }
                           }
                         }
                       }
@@ -1473,6 +1487,20 @@
                             "value": {
                               "type": "boolean",
                               "description": "True if Ampersand branding has been removed for this project."
+                            }
+                          }
+                        },
+                        "logRetention": {
+                          "type": "object",
+                          "required": [
+                            "value"
+                          ],
+                          "x-go-type-skip-optional-pointer": true,
+                          "description": "The number of days that logs are retained for this project.",
+                          "properties": {
+                            "value": {
+                              "type": "integer",
+                              "description": "The log retention period for this project, in days."
                             }
                           }
                         }
@@ -2039,6 +2067,20 @@
                               "description": "True if Ampersand branding has been removed for this project."
                             }
                           }
+                        },
+                        "logRetention": {
+                          "type": "object",
+                          "required": [
+                            "value"
+                          ],
+                          "x-go-type-skip-optional-pointer": true,
+                          "description": "The number of days that logs are retained for this project.",
+                          "properties": {
+                            "value": {
+                              "type": "integer",
+                              "description": "The log retention period for this project, in days."
+                            }
+                          }
                         }
                       }
                     }
@@ -2314,6 +2356,20 @@
                             "value": {
                               "type": "boolean",
                               "description": "True if Ampersand branding has been removed for this project."
+                            }
+                          }
+                        },
+                        "logRetention": {
+                          "type": "object",
+                          "required": [
+                            "value"
+                          ],
+                          "x-go-type-skip-optional-pointer": true,
+                          "description": "The number of days that logs are retained for this project.",
+                          "properties": {
+                            "value": {
+                              "type": "integer",
+                              "description": "The log retention period for this project, in days."
                             }
                           }
                         }
@@ -54735,6 +54791,20 @@
                                         "description": "True if Ampersand branding has been removed for this project."
                                       }
                                     }
+                                  },
+                                  "logRetention": {
+                                    "type": "object",
+                                    "required": [
+                                      "value"
+                                    ],
+                                    "x-go-type-skip-optional-pointer": true,
+                                    "description": "The number of days that logs are retained for this project.",
+                                    "properties": {
+                                      "value": {
+                                        "type": "integer",
+                                        "description": "The log retention period for this project, in days."
+                                      }
+                                    }
                                   }
                                 }
                               }
@@ -55125,6 +55195,20 @@
                                       "value": {
                                         "type": "boolean",
                                         "description": "True if Ampersand branding has been removed for this project."
+                                      }
+                                    }
+                                  },
+                                  "logRetention": {
+                                    "type": "object",
+                                    "required": [
+                                      "value"
+                                    ],
+                                    "x-go-type-skip-optional-pointer": true,
+                                    "description": "The number of days that logs are retained for this project.",
+                                    "properties": {
+                                      "value": {
+                                        "type": "integer",
+                                        "description": "The log retention period for this project, in days."
                                       }
                                     }
                                   }
@@ -66095,6 +66179,20 @@
                     "description": "True if Ampersand branding has been removed for this project."
                   }
                 }
+              },
+              "logRetention": {
+                "type": "object",
+                "required": [
+                  "value"
+                ],
+                "x-go-type-skip-optional-pointer": true,
+                "description": "The number of days that logs are retained for this project.",
+                "properties": {
+                  "value": {
+                    "type": "integer",
+                    "description": "The log retention period for this project, in days."
+                  }
+                }
               }
             }
           }
@@ -73363,6 +73461,20 @@
                             "value": {
                               "type": "boolean",
                               "description": "True if Ampersand branding has been removed for this project."
+                            }
+                          }
+                        },
+                        "logRetention": {
+                          "type": "object",
+                          "required": [
+                            "value"
+                          ],
+                          "x-go-type-skip-optional-pointer": true,
+                          "description": "The number of days that logs are retained for this project.",
+                          "properties": {
+                            "value": {
+                              "type": "integer",
+                              "description": "The log retention period for this project, in days."
                             }
                           }
                         }

--- a/api/generated/api.json
+++ b/api/generated/api.json
@@ -1213,7 +1213,7 @@
                               }
                             }
                           },
-                          "logRetention": {
+                          "logRetentionDays": {
                             "type": "object",
                             "required": [
                               "value"
@@ -1490,7 +1490,7 @@
                             }
                           }
                         },
-                        "logRetention": {
+                        "logRetentionDays": {
                           "type": "object",
                           "required": [
                             "value"
@@ -2068,7 +2068,7 @@
                             }
                           }
                         },
-                        "logRetention": {
+                        "logRetentionDays": {
                           "type": "object",
                           "required": [
                             "value"
@@ -2359,7 +2359,7 @@
                             }
                           }
                         },
-                        "logRetention": {
+                        "logRetentionDays": {
                           "type": "object",
                           "required": [
                             "value"
@@ -54792,7 +54792,7 @@
                                       }
                                     }
                                   },
-                                  "logRetention": {
+                                  "logRetentionDays": {
                                     "type": "object",
                                     "required": [
                                       "value"
@@ -55198,7 +55198,7 @@
                                       }
                                     }
                                   },
-                                  "logRetention": {
+                                  "logRetentionDays": {
                                     "type": "object",
                                     "required": [
                                       "value"
@@ -66180,7 +66180,7 @@
                   }
                 }
               },
-              "logRetention": {
+              "logRetentionDays": {
                 "type": "object",
                 "required": [
                   "value"
@@ -73464,7 +73464,7 @@
                             }
                           }
                         },
-                        "logRetention": {
+                        "logRetentionDays": {
                           "type": "object",
                           "required": [
                             "value"


### PR DESCRIPTION
## What

Adds the **logRetention** entitlement (the number of days logs are retained) to the `Project` schema's `entitlements`, alongside `brandingRemoval`.

This lets generated clients read `entitlements.logRetention.value` from `GetProject` when `includeEntitlements=true`.

## Changes

- `api/api.yaml`: added `logRetention` (object with an integer `value`) under the `Project` `entitlements` properties.
- `api/generated/api.json`: regenerated via `pnpm run gen:json`.

## Schema

```yaml
logRetention:
  type: object
  required: [value]
  description: The number of days that logs are retained for this project.
  properties:
    value:
      type: integer
      description: The log retention period for this project, in days.
```

## Related

Companion server PR (populates the field): amp-labs/server#<server-pr>

🤖 Generated with [Claude Code](https://claude.com/claude-code)