### PR TITLE
fix: merge conflicting integration ID/name path into one path item

### DIFF
--- a/api/api.yaml
+++ b/api/api.yaml
@@ -747,7 +747,6 @@ paths:
             application/problem+json:
               schema:
                 $ref: "../problem/problem.yaml#/components/schemas/ApiProblem"
-  /projects/{projectIdOrName}/integrations/{integrationId}:
     delete:
       summary: Delete an integration
       operationId: deleteIntegration
@@ -761,10 +760,10 @@ paths:
           schema:
             type: string
           example: my-project
-        - name: integrationId
+        - name: integrationIdOrName
           in: path
           required: true
-          description: The integration ID.
+          description: The integration ID or name.
           schema:
             type: string
           example: 123e4567-e89b-12d3-a456-426614174000

--- a/api/generated/api.json
+++ b/api/generated/api.json
@@ -8720,9 +8720,7 @@
             }
           }
         }
-      }
-    },
-    "/projects/{projectIdOrName}/integrations/{integrationId}": {
+      },
       "delete": {
         "summary": "Delete an integration",
         "operationId": "deleteIntegration",
@@ -8742,10 +8740,10 @@
             "example": "my-project"
           },
           {
-            "name": "integrationId",
+            "name": "integrationIdOrName",
             "in": "path",
             "required": true,
-            "description": "The integration ID.",
+            "description": "The integration ID or name.",
             "schema": {
               "type": "string"
             },


### PR DESCRIPTION
## Problem

The API spec declared two separate path items that are identical except for the path-parameter name:

```
GET    /projects/{projectIdOrName}/integrations/{integrationIdOrName}   # getIntegration
DELETE /projects/{projectIdOrName}/integrations/{integrationId}          # deleteIntegration
```

Per the OpenAPI specification, two paths that differ only by parameter name are ambiguous and not allowed. Older versions of `kin-openapi` silently tolerated this, but `v0.140.0` correctly rejects it:

```
invalid paths: conflicting paths
"/projects/{projectIdOrName}/integrations/{integrationId}" and
"/projects/{projectIdOrName}/integrations/{integrationIdOrName}"
```

This broke OpenAPI schema validation in `server`'s builder-mcp openapi tools once `kin-openapi` was bumped to 0.140.0 (the `builder-mcp/tools/operations` test suite).

## Fix

Merge both operations under a single path item keyed on `{integrationIdOrName}`.

This is also more *accurate*: both operations resolve identically on the server. `DeleteIntegration` uses `GetIntegrationIdFromCtx`, which accepts an **ID or a name** — confirmed by the passing `TestDeleteIntegration_ByName` test in server. So the delete parameter is renamed `integrationId` → `integrationIdOrName` and its description updated to "The integration ID or name."

## Note on consumers

This changes the `deleteIntegration` path parameter name in generated SDKs (`integrationId` → `integrationIdOrName`). The actual route and behavior are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)