### PR TITLE
ci: trigger amp-common Go type regeneration on API spec changes

### DIFF
--- a/.github/workflows/trigger-amp-common-gen.yml
+++ b/.github/workflows/trigger-amp-common-gen.yml
@@ -1,0 +1,26 @@
+name: Trigger amp-common Go type generation
+
+# When the API spec changes on main, tell amp-common to regenerate the Go types
+# it derives from api/api.yaml (via api/generated/api.json) and open a PR.
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'api/**'
+  workflow_dispatch:
+
+jobs:
+  trigger:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dispatch to amp-common
+        run: |
+          curl -L \
+            -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${{ secrets.AMPERSAND_OPS_PAT }}" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/repos/amp-labs/amp-common/dispatches \
+            -d '{"event_type":"gen-openapi-types","client_payload":{"repository":"${{ github.repository }}","sha":"${{ github.sha }}"}}'


### PR DESCRIPTION
## What

Adds `.github/workflows/trigger-amp-common-gen.yml`. On a push to `main` that touches `api/**`, it fires a `repository_dispatch` (`event_type: gen-openapi-types`) at `amp-labs/amp-common`.

## Why

We want the Go structs derived from `api/api.yaml`'s component schemas to stay in sync automatically. This trigger is the openapi-side half; the amp-common side (receiver workflow that regenerates `openapi/api.gen.go` and opens a PR) is in a companion PR on amp-common.

Mirrors the existing `trigger-docs-gen.yml` and `trigger-postman.yml` workflows.

## Prerequisite

Relies on the org `AMPERSAND_OPS_PAT` secret (already used by the sibling trigger workflows) having permission to dispatch to `amp-common`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)