### PR TITLE
docs(api): add missing periods to Destination name/type descriptions

### DIFF
--- a/api/api.yaml
+++ b/api/api.yaml
@@ -4857,11 +4857,11 @@ components:
           description: The destination ID.
         name:
           type: string
-          description: User-defined name for the destination
+          description: User-defined name for the destination.
           example: leadConvertedWebhook
         type:
           type: string
-          description: The type of the destination
+          description: The type of the destination.
           example: webhook
         metadata:
           type: object
@@ -4921,11 +4921,11 @@ components:
           description: The destination ID.
         name:
           type: string
-          description: User-defined name for the destination
+          description: User-defined name for the destination.
           example: leadConvertedWebhook
         type:
           type: string
-          description: The type of the destination
+          description: The type of the destination.
           example: webhook
         metadata:
           type: object

--- a/api/generated/api.json
+++ b/api/generated/api.json
@@ -47540,12 +47540,12 @@
                     },
                     "name": {
                       "type": "string",
-                      "description": "User-defined name for the destination",
+                      "description": "User-defined name for the destination.",
                       "example": "leadConvertedWebhook"
                     },
                     "type": {
                       "type": "string",
-                      "description": "The type of the destination",
+                      "description": "The type of the destination.",
                       "example": "webhook"
                     },
                     "metadata": {
@@ -48444,12 +48444,12 @@
                       },
                       "name": {
                         "type": "string",
-                        "description": "User-defined name for the destination",
+                        "description": "User-defined name for the destination.",
                         "example": "leadConvertedWebhook"
                       },
                       "type": {
                         "type": "string",
-                        "description": "The type of the destination",
+                        "description": "The type of the destination.",
                         "example": "webhook"
                       },
                       "metadata": {
@@ -48731,12 +48731,12 @@
                     },
                     "name": {
                       "type": "string",
-                      "description": "User-defined name for the destination",
+                      "description": "User-defined name for the destination.",
                       "example": "leadConvertedWebhook"
                     },
                     "type": {
                       "type": "string",
-                      "description": "The type of the destination",
+                      "description": "The type of the destination.",
                       "example": "webhook"
                     },
                     "metadata": {
@@ -49445,12 +49445,12 @@
                     },
                     "name": {
                       "type": "string",
-                      "description": "User-defined name for the destination",
+                      "description": "User-defined name for the destination.",
                       "example": "leadConvertedWebhook"
                     },
                     "type": {
                       "type": "string",
-                      "description": "The type of the destination",
+                      "description": "The type of the destination.",
                       "example": "webhook"
                     },
                     "metadata": {
@@ -66441,12 +66441,12 @@
           },
           "name": {
             "type": "string",
-            "description": "User-defined name for the destination",
+            "description": "User-defined name for the destination.",
             "example": "leadConvertedWebhook"
           },
           "type": {
             "type": "string",
-            "description": "The type of the destination",
+            "description": "The type of the destination.",
             "example": "webhook"
           },
           "metadata": {
@@ -66532,12 +66532,12 @@
           },
           "name": {
             "type": "string",
-            "description": "User-defined name for the destination",
+            "description": "User-defined name for the destination.",
             "example": "leadConvertedWebhook"
           },
           "type": {
             "type": "string",
-            "description": "The type of the destination",
+            "description": "The type of the destination.",
             "example": "webhook"
           },
           "metadata": {


### PR DESCRIPTION
## What
The `Destination` schema's `id` description ends with a period, but the sibling `name` and `type` descriptions did not. This adds the missing periods for consistency.

- `api/api.yaml`: `name` and `type` descriptions (schema appears twice).
- `api/generated/api.json`: regenerated deref'd spec to match.

## Why now (testing the new automation)
This is also a live test of the [openapi → amp-common Go-type automation](https://github.com/amp-labs/openapi/pull/365). On merge, the `trigger-amp-common-gen` workflow fires a `repository_dispatch` at amp-common, which regenerates `openapi/api.gen.go`. These descriptions surface as Go doc comments, so the auto-PR will contain exactly this 4-line change:

```
- // Name User-defined name for the destination
+ // Name User-defined name for the destination.
- // Type The type of the destination
+ // Type The type of the destination.
```
(×2 — the schema is generated in two places.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)