### PR TITLE
docs(api): reword Organization.createTime description

### DIFF
--- a/api/api.yaml
+++ b/api/api.yaml
@@ -4835,7 +4835,7 @@ components:
           description: The ID of the Everyone team for the org.
         createTime:
           type: string
-          description: The time the organization was created.
+          description: The time at which the organization was created.
           format: date-time
         updateTime:
           type: string

--- a/api/generated/api.json
+++ b/api/generated/api.json
@@ -51359,7 +51359,7 @@
                     },
                     "createTime": {
                       "type": "string",
-                      "description": "The time the organization was created.",
+                      "description": "The time at which the organization was created.",
                       "format": "date-time"
                     },
                     "updateTime": {
@@ -51562,7 +51562,7 @@
                     },
                     "createTime": {
                       "type": "string",
-                      "description": "The time the organization was created.",
+                      "description": "The time at which the organization was created.",
                       "format": "date-time"
                     },
                     "updateTime": {
@@ -52122,7 +52122,7 @@
                     },
                     "createTime": {
                       "type": "string",
-                      "description": "The time the organization was created.",
+                      "description": "The time at which the organization was created.",
                       "format": "date-time"
                     },
                     "updateTime": {
@@ -55324,7 +55324,7 @@
                             },
                             "createTime": {
                               "type": "string",
-                              "description": "The time the organization was created.",
+                              "description": "The time at which the organization was created.",
                               "format": "date-time"
                             },
                             "updateTime": {
@@ -55730,7 +55730,7 @@
                             },
                             "createTime": {
                               "type": "string",
-                              "description": "The time the organization was created.",
+                              "description": "The time at which the organization was created.",
                               "format": "date-time"
                             },
                             "updateTime": {
@@ -66414,7 +66414,7 @@
           },
           "createTime": {
             "type": "string",
-            "description": "The time the organization was created.",
+            "description": "The time at which the organization was created.",
             "format": "date-time"
           },
           "updateTime": {
@@ -74032,7 +74032,7 @@
                   },
                   "createTime": {
                     "type": "string",
-                    "description": "The time the organization was created.",
+                    "description": "The time at which the organization was created.",
                     "format": "date-time"
                   },
                   "updateTime": {


### PR DESCRIPTION
Small wording tweak to `Organization.createTime`'s description ("The time the organization was created." → "The time at which the organization was created.").

Purpose: an end-to-end test of the type-sync automation. On merge it should cascade:
**openapi → amp-common (api.gen.go) → connectors + server (go.mod bumps)**.

Schema descriptions become Go doc comments, so this produces a real (2-line) `api.gen.go` diff downstream. `api/generated/api.json` regenerated to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)