### PR TITLE
[ENG-4159] config: add salesforceQuotaOptimization to subscribe config objects

### DIFF
--- a/api/generated/api.bundled.json
+++ b/api/generated/api.bundled.json
@@ -11477,6 +11477,21 @@
           ]
         }
       },
+      "SalesforceQuotaOptimizationConfig": {
+        "title": "Salesforce Quota Optimization Config",
+        "description": "Salesforce only. Reduces Salesforce API quota consumption for update events by filtering irrelevant change events at the source: Ampersand creates a checkbox field on the object and an Apex trigger that sets it when a watched field changes, then only delivers update events where the checkbox is set. Requires `updateEvent.requiredWatchFields` to be non-empty; it cannot be used with `updateEvent.watchFieldsAuto: all`.\n",
+        "type": "object",
+        "required": [
+          "enabled"
+        ],
+        "properties": {
+          "enabled": {
+            "type": "boolean",
+            "description": "Whether quota optimization is enabled for this object.",
+            "example": true
+          }
+        }
+      },
       "BaseSubscribeConfigObject": {
         "title": "Base Subscribe Config Object",
         "type": "object",
@@ -11515,6 +11530,9 @@
           },
           "otherEvents": {
             "$ref": "#/components/schemas/ConfigOtherEvents"
+          },
+          "salesforceQuotaOptimization": {
+            "$ref": "#/components/schemas/SalesforceQuotaOptimizationConfig"
           }
         }
       },

--- a/api/generated/api.json
+++ b/api/generated/api.json
@@ -15088,6 +15088,21 @@
                                                       "object.restored"
                                                     ]
                                                   }
+                                                },
+                                                "salesforceQuotaOptimization": {
+                                                  "title": "Salesforce Quota Optimization Config",
+                                                  "description": "Salesforce only. Reduces Salesforce API quota consumption for update events by filtering irrelevant change events at the source: Ampersand creates a checkbox field on the object and an Apex trigger that sets it when a watched field changes, then only delivers update events where the checkbox is set. Requires `updateEvent.requiredWatchFields` to be non-empty; it cannot be used with `updateEvent.watchFieldsAuto: all`.\n",
+                                                  "type": "object",
+                                                  "required": [
+                                                    "enabled"
+                                                  ],
+                                                  "properties": {
+                                                    "enabled": {
+                                                      "type": "boolean",
+                                                      "description": "Whether quota optimization is enabled for this object.",
+                                                      "example": true
+                                                    }
+                                                  }
                                                 }
                                               }
                                             }
@@ -15222,6 +15237,21 @@
                                                           "object.merged",
                                                           "object.restored"
                                                         ]
+                                                      }
+                                                    },
+                                                    "salesforceQuotaOptimization": {
+                                                      "title": "Salesforce Quota Optimization Config",
+                                                      "description": "Salesforce only. Reduces Salesforce API quota consumption for update events by filtering irrelevant change events at the source: Ampersand creates a checkbox field on the object and an Apex trigger that sets it when a watched field changes, then only delivers update events where the checkbox is set. Requires `updateEvent.requiredWatchFields` to be non-empty; it cannot be used with `updateEvent.watchFieldsAuto: all`.\n",
+                                                      "type": "object",
+                                                      "required": [
+                                                        "enabled"
+                                                      ],
+                                                      "properties": {
+                                                        "enabled": {
+                                                          "type": "boolean",
+                                                          "description": "Whether quota optimization is enabled for this object.",
+                                                          "example": true
+                                                        }
                                                       }
                                                     }
                                                   }
@@ -17266,6 +17296,21 @@
                                                   "object.restored"
                                                 ]
                                               }
+                                            },
+                                            "salesforceQuotaOptimization": {
+                                              "title": "Salesforce Quota Optimization Config",
+                                              "description": "Salesforce only. Reduces Salesforce API quota consumption for update events by filtering irrelevant change events at the source: Ampersand creates a checkbox field on the object and an Apex trigger that sets it when a watched field changes, then only delivers update events where the checkbox is set. Requires `updateEvent.requiredWatchFields` to be non-empty; it cannot be used with `updateEvent.watchFieldsAuto: all`.\n",
+                                              "type": "object",
+                                              "required": [
+                                                "enabled"
+                                              ],
+                                              "properties": {
+                                                "enabled": {
+                                                  "type": "boolean",
+                                                  "description": "Whether quota optimization is enabled for this object.",
+                                                  "example": true
+                                                }
+                                              }
                                             }
                                           }
                                         }
@@ -17400,6 +17445,21 @@
                                                       "object.merged",
                                                       "object.restored"
                                                     ]
+                                                  }
+                                                },
+                                                "salesforceQuotaOptimization": {
+                                                  "title": "Salesforce Quota Optimization Config",
+                                                  "description": "Salesforce only. Reduces Salesforce API quota consumption for update events by filtering irrelevant change events at the source: Ampersand creates a checkbox field on the object and an Apex trigger that sets it when a watched field changes, then only delivers update events where the checkbox is set. Requires `updateEvent.requiredWatchFields` to be non-empty; it cannot be used with `updateEvent.watchFieldsAuto: all`.\n",
+                                                  "type": "object",
+                                                  "required": [
+                                                    "enabled"
+                                                  ],
+                                                  "properties": {
+                                                    "enabled": {
+                                                      "type": "boolean",
+                                                      "description": "Whether quota optimization is enabled for this object.",
+                                                      "example": true
+                                                    }
                                                   }
                                                 }
                                               }
@@ -19396,6 +19456,21 @@
                                                     "object.restored"
                                                   ]
                                                 }
+                                              },
+                                              "salesforceQuotaOptimization": {
+                                                "title": "Salesforce Quota Optimization Config",
+                                                "description": "Salesforce only. Reduces Salesforce API quota consumption for update events by filtering irrelevant change events at the source: Ampersand creates a checkbox field on the object and an Apex trigger that sets it when a watched field changes, then only delivers update events where the checkbox is set. Requires `updateEvent.requiredWatchFields` to be non-empty; it cannot be used with `updateEvent.watchFieldsAuto: all`.\n",
+                                                "type": "object",
+                                                "required": [
+                                                  "enabled"
+                                                ],
+                                                "properties": {
+                                                  "enabled": {
+                                                    "type": "boolean",
+                                                    "description": "Whether quota optimization is enabled for this object.",
+                                                    "example": true
+                                                  }
+                                                }
                                               }
                                             }
                                           }
@@ -19530,6 +19605,21 @@
                                                         "object.merged",
                                                         "object.restored"
                                                       ]
+                                                    }
+                                                  },
+                                                  "salesforceQuotaOptimization": {
+                                                    "title": "Salesforce Quota Optimization Config",
+                                                    "description": "Salesforce only. Reduces Salesforce API quota consumption for update events by filtering irrelevant change events at the source: Ampersand creates a checkbox field on the object and an Apex trigger that sets it when a watched field changes, then only delivers update events where the checkbox is set. Requires `updateEvent.requiredWatchFields` to be non-empty; it cannot be used with `updateEvent.watchFieldsAuto: all`.\n",
+                                                    "type": "object",
+                                                    "required": [
+                                                      "enabled"
+                                                    ],
+                                                    "properties": {
+                                                      "enabled": {
+                                                        "type": "boolean",
+                                                        "description": "Whether quota optimization is enabled for this object.",
+                                                        "example": true
+                                                      }
                                                     }
                                                   }
                                                 }
@@ -22286,6 +22376,21 @@
                                                     "object.restored"
                                                   ]
                                                 }
+                                              },
+                                              "salesforceQuotaOptimization": {
+                                                "title": "Salesforce Quota Optimization Config",
+                                                "description": "Salesforce only. Reduces Salesforce API quota consumption for update events by filtering irrelevant change events at the source: Ampersand creates a checkbox field on the object and an Apex trigger that sets it when a watched field changes, then only delivers update events where the checkbox is set. Requires `updateEvent.requiredWatchFields` to be non-empty; it cannot be used with `updateEvent.watchFieldsAuto: all`.\n",
+                                                "type": "object",
+                                                "required": [
+                                                  "enabled"
+                                                ],
+                                                "properties": {
+                                                  "enabled": {
+                                                    "type": "boolean",
+                                                    "description": "Whether quota optimization is enabled for this object.",
+                                                    "example": true
+                                                  }
+                                                }
                                               }
                                             }
                                           }
@@ -22420,6 +22525,21 @@
                                                         "object.merged",
                                                         "object.restored"
                                                       ]
+                                                    }
+                                                  },
+                                                  "salesforceQuotaOptimization": {
+                                                    "title": "Salesforce Quota Optimization Config",
+                                                    "description": "Salesforce only. Reduces Salesforce API quota consumption for update events by filtering irrelevant change events at the source: Ampersand creates a checkbox field on the object and an Apex trigger that sets it when a watched field changes, then only delivers update events where the checkbox is set. Requires `updateEvent.requiredWatchFields` to be non-empty; it cannot be used with `updateEvent.watchFieldsAuto: all`.\n",
+                                                    "type": "object",
+                                                    "required": [
+                                                      "enabled"
+                                                    ],
+                                                    "properties": {
+                                                      "enabled": {
+                                                        "type": "boolean",
+                                                        "description": "Whether quota optimization is enabled for this object.",
+                                                        "example": true
+                                                      }
                                                     }
                                                   }
                                                 }
@@ -23796,6 +23916,21 @@
                                                   "object.merged",
                                                   "object.restored"
                                                 ]
+                                              }
+                                            },
+                                            "salesforceQuotaOptimization": {
+                                              "title": "Salesforce Quota Optimization Config",
+                                              "description": "Salesforce only. Reduces Salesforce API quota consumption for update events by filtering irrelevant change events at the source: Ampersand creates a checkbox field on the object and an Apex trigger that sets it when a watched field changes, then only delivers update events where the checkbox is set. Requires `updateEvent.requiredWatchFields` to be non-empty; it cannot be used with `updateEvent.watchFieldsAuto: all`.\n",
+                                              "type": "object",
+                                              "required": [
+                                                "enabled"
+                                              ],
+                                              "properties": {
+                                                "enabled": {
+                                                  "type": "boolean",
+                                                  "description": "Whether quota optimization is enabled for this object.",
+                                                  "example": true
+                                                }
                                               }
                                             }
                                           }
@@ -25742,6 +25877,21 @@
                                                     "object.restored"
                                                   ]
                                                 }
+                                              },
+                                              "salesforceQuotaOptimization": {
+                                                "title": "Salesforce Quota Optimization Config",
+                                                "description": "Salesforce only. Reduces Salesforce API quota consumption for update events by filtering irrelevant change events at the source: Ampersand creates a checkbox field on the object and an Apex trigger that sets it when a watched field changes, then only delivers update events where the checkbox is set. Requires `updateEvent.requiredWatchFields` to be non-empty; it cannot be used with `updateEvent.watchFieldsAuto: all`.\n",
+                                                "type": "object",
+                                                "required": [
+                                                  "enabled"
+                                                ],
+                                                "properties": {
+                                                  "enabled": {
+                                                    "type": "boolean",
+                                                    "description": "Whether quota optimization is enabled for this object.",
+                                                    "example": true
+                                                  }
+                                                }
                                               }
                                             }
                                           }
@@ -25876,6 +26026,21 @@
                                                         "object.merged",
                                                         "object.restored"
                                                       ]
+                                                    }
+                                                  },
+                                                  "salesforceQuotaOptimization": {
+                                                    "title": "Salesforce Quota Optimization Config",
+                                                    "description": "Salesforce only. Reduces Salesforce API quota consumption for update events by filtering irrelevant change events at the source: Ampersand creates a checkbox field on the object and an Apex trigger that sets it when a watched field changes, then only delivers update events where the checkbox is set. Requires `updateEvent.requiredWatchFields` to be non-empty; it cannot be used with `updateEvent.watchFieldsAuto: all`.\n",
+                                                    "type": "object",
+                                                    "required": [
+                                                      "enabled"
+                                                    ],
+                                                    "properties": {
+                                                      "enabled": {
+                                                        "type": "boolean",
+                                                        "description": "Whether quota optimization is enabled for this object.",
+                                                        "example": true
+                                                      }
                                                     }
                                                   }
                                                 }
@@ -28798,6 +28963,21 @@
                                                     "object.restored"
                                                   ]
                                                 }
+                                              },
+                                              "salesforceQuotaOptimization": {
+                                                "title": "Salesforce Quota Optimization Config",
+                                                "description": "Salesforce only. Reduces Salesforce API quota consumption for update events by filtering irrelevant change events at the source: Ampersand creates a checkbox field on the object and an Apex trigger that sets it when a watched field changes, then only delivers update events where the checkbox is set. Requires `updateEvent.requiredWatchFields` to be non-empty; it cannot be used with `updateEvent.watchFieldsAuto: all`.\n",
+                                                "type": "object",
+                                                "required": [
+                                                  "enabled"
+                                                ],
+                                                "properties": {
+                                                  "enabled": {
+                                                    "type": "boolean",
+                                                    "description": "Whether quota optimization is enabled for this object.",
+                                                    "example": true
+                                                  }
+                                                }
                                               }
                                             }
                                           }
@@ -28932,6 +29112,21 @@
                                                         "object.merged",
                                                         "object.restored"
                                                       ]
+                                                    }
+                                                  },
+                                                  "salesforceQuotaOptimization": {
+                                                    "title": "Salesforce Quota Optimization Config",
+                                                    "description": "Salesforce only. Reduces Salesforce API quota consumption for update events by filtering irrelevant change events at the source: Ampersand creates a checkbox field on the object and an Apex trigger that sets it when a watched field changes, then only delivers update events where the checkbox is set. Requires `updateEvent.requiredWatchFields` to be non-empty; it cannot be used with `updateEvent.watchFieldsAuto: all`.\n",
+                                                    "type": "object",
+                                                    "required": [
+                                                      "enabled"
+                                                    ],
+                                                    "properties": {
+                                                      "enabled": {
+                                                        "type": "boolean",
+                                                        "description": "Whether quota optimization is enabled for this object.",
+                                                        "example": true
+                                                      }
                                                     }
                                                   }
                                                 }
@@ -32051,6 +32246,21 @@
                                                       "object.restored"
                                                     ]
                                                   }
+                                                },
+                                                "salesforceQuotaOptimization": {
+                                                  "title": "Salesforce Quota Optimization Config",
+                                                  "description": "Salesforce only. Reduces Salesforce API quota consumption for update events by filtering irrelevant change events at the source: Ampersand creates a checkbox field on the object and an Apex trigger that sets it when a watched field changes, then only delivers update events where the checkbox is set. Requires `updateEvent.requiredWatchFields` to be non-empty; it cannot be used with `updateEvent.watchFieldsAuto: all`.\n",
+                                                  "type": "object",
+                                                  "required": [
+                                                    "enabled"
+                                                  ],
+                                                  "properties": {
+                                                    "enabled": {
+                                                      "type": "boolean",
+                                                      "description": "Whether quota optimization is enabled for this object.",
+                                                      "example": true
+                                                    }
+                                                  }
                                                 }
                                               }
                                             }
@@ -32185,6 +32395,21 @@
                                                           "object.merged",
                                                           "object.restored"
                                                         ]
+                                                      }
+                                                    },
+                                                    "salesforceQuotaOptimization": {
+                                                      "title": "Salesforce Quota Optimization Config",
+                                                      "description": "Salesforce only. Reduces Salesforce API quota consumption for update events by filtering irrelevant change events at the source: Ampersand creates a checkbox field on the object and an Apex trigger that sets it when a watched field changes, then only delivers update events where the checkbox is set. Requires `updateEvent.requiredWatchFields` to be non-empty; it cannot be used with `updateEvent.watchFieldsAuto: all`.\n",
+                                                      "type": "object",
+                                                      "required": [
+                                                        "enabled"
+                                                      ],
+                                                      "properties": {
+                                                        "enabled": {
+                                                          "type": "boolean",
+                                                          "description": "Whether quota optimization is enabled for this object.",
+                                                          "example": true
+                                                        }
                                                       }
                                                     }
                                                   }
@@ -72074,6 +72299,21 @@
                                           "object.restored"
                                         ]
                                       }
+                                    },
+                                    "salesforceQuotaOptimization": {
+                                      "title": "Salesforce Quota Optimization Config",
+                                      "description": "Salesforce only. Reduces Salesforce API quota consumption for update events by filtering irrelevant change events at the source: Ampersand creates a checkbox field on the object and an Apex trigger that sets it when a watched field changes, then only delivers update events where the checkbox is set. Requires `updateEvent.requiredWatchFields` to be non-empty; it cannot be used with `updateEvent.watchFieldsAuto: all`.\n",
+                                      "type": "object",
+                                      "required": [
+                                        "enabled"
+                                      ],
+                                      "properties": {
+                                        "enabled": {
+                                          "type": "boolean",
+                                          "description": "Whether quota optimization is enabled for this object.",
+                                          "example": true
+                                        }
+                                      }
                                     }
                                   }
                                 }
@@ -72208,6 +72448,21 @@
                                               "object.merged",
                                               "object.restored"
                                             ]
+                                          }
+                                        },
+                                        "salesforceQuotaOptimization": {
+                                          "title": "Salesforce Quota Optimization Config",
+                                          "description": "Salesforce only. Reduces Salesforce API quota consumption for update events by filtering irrelevant change events at the source: Ampersand creates a checkbox field on the object and an Apex trigger that sets it when a watched field changes, then only delivers update events where the checkbox is set. Requires `updateEvent.requiredWatchFields` to be non-empty; it cannot be used with `updateEvent.watchFieldsAuto: all`.\n",
+                                          "type": "object",
+                                          "required": [
+                                            "enabled"
+                                          ],
+                                          "properties": {
+                                            "enabled": {
+                                              "type": "boolean",
+                                              "description": "Whether quota optimization is enabled for this object.",
+                                              "example": true
+                                            }
                                           }
                                         }
                                       }
@@ -73714,6 +73969,21 @@
                                       "object.restored"
                                     ]
                                   }
+                                },
+                                "salesforceQuotaOptimization": {
+                                  "title": "Salesforce Quota Optimization Config",
+                                  "description": "Salesforce only. Reduces Salesforce API quota consumption for update events by filtering irrelevant change events at the source: Ampersand creates a checkbox field on the object and an Apex trigger that sets it when a watched field changes, then only delivers update events where the checkbox is set. Requires `updateEvent.requiredWatchFields` to be non-empty; it cannot be used with `updateEvent.watchFieldsAuto: all`.\n",
+                                  "type": "object",
+                                  "required": [
+                                    "enabled"
+                                  ],
+                                  "properties": {
+                                    "enabled": {
+                                      "type": "boolean",
+                                      "description": "Whether quota optimization is enabled for this object.",
+                                      "example": true
+                                    }
+                                  }
                                 }
                               }
                             }
@@ -73848,6 +74118,21 @@
                                           "object.merged",
                                           "object.restored"
                                         ]
+                                      }
+                                    },
+                                    "salesforceQuotaOptimization": {
+                                      "title": "Salesforce Quota Optimization Config",
+                                      "description": "Salesforce only. Reduces Salesforce API quota consumption for update events by filtering irrelevant change events at the source: Ampersand creates a checkbox field on the object and an Apex trigger that sets it when a watched field changes, then only delivers update events where the checkbox is set. Requires `updateEvent.requiredWatchFields` to be non-empty; it cannot be used with `updateEvent.watchFieldsAuto: all`.\n",
+                                      "type": "object",
+                                      "required": [
+                                        "enabled"
+                                      ],
+                                      "properties": {
+                                        "enabled": {
+                                          "type": "boolean",
+                                          "description": "Whether quota optimization is enabled for this object.",
+                                          "example": true
+                                        }
                                       }
                                     }
                                   }

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -204,6 +204,25 @@ components:
           $ref: '#/components/schemas/ConfigDeleteEvent'
         otherEvents:
           $ref: '#/components/schemas/ConfigOtherEvents'
+        salesforceQuotaOptimization:
+          $ref: '#/components/schemas/SalesforceQuotaOptimizationConfig'
+
+    SalesforceQuotaOptimizationConfig:
+      title: Salesforce Quota Optimization Config
+      description: >
+        Salesforce only. Reduces Salesforce API quota consumption for update events by filtering
+        irrelevant change events at the source: Ampersand creates a checkbox field on the object and
+        an Apex trigger that sets it when a watched field changes, then only delivers update events
+        where the checkbox is set. Requires `updateEvent.requiredWatchFields` to be non-empty;
+        it cannot be used with `updateEvent.watchFieldsAuto: all`.
+      type: object
+      required:
+        - enabled
+      properties:
+        enabled:
+          type: boolean
+          description: Whether quota optimization is enabled for this object.
+          example: true
 
     ConfigOtherEvents:
       title: Other Events

--- a/config/generated/config.json
+++ b/config/generated/config.json
@@ -1440,6 +1440,21 @@
                       "object.restored"
                     ]
                   }
+                },
+                "salesforceQuotaOptimization": {
+                  "title": "Salesforce Quota Optimization Config",
+                  "description": "Salesforce only. Reduces Salesforce API quota consumption for update events by filtering irrelevant change events at the source: Ampersand creates a checkbox field on the object and an Apex trigger that sets it when a watched field changes, then only delivers update events where the checkbox is set. Requires `updateEvent.requiredWatchFields` to be non-empty; it cannot be used with `updateEvent.watchFieldsAuto: all`.\n",
+                  "type": "object",
+                  "required": [
+                    "enabled"
+                  ],
+                  "properties": {
+                    "enabled": {
+                      "type": "boolean",
+                      "description": "Whether quota optimization is enabled for this object.",
+                      "example": true
+                    }
+                  }
                 }
               }
             }
@@ -1565,6 +1580,36 @@
                 "object.restored"
               ]
             }
+          },
+          "salesforceQuotaOptimization": {
+            "title": "Salesforce Quota Optimization Config",
+            "description": "Salesforce only. Reduces Salesforce API quota consumption for update events by filtering irrelevant change events at the source: Ampersand creates a checkbox field on the object and an Apex trigger that sets it when a watched field changes, then only delivers update events where the checkbox is set. Requires `updateEvent.requiredWatchFields` to be non-empty; it cannot be used with `updateEvent.watchFieldsAuto: all`.\n",
+            "type": "object",
+            "required": [
+              "enabled"
+            ],
+            "properties": {
+              "enabled": {
+                "type": "boolean",
+                "description": "Whether quota optimization is enabled for this object.",
+                "example": true
+              }
+            }
+          }
+        }
+      },
+      "SalesforceQuotaOptimizationConfig": {
+        "title": "Salesforce Quota Optimization Config",
+        "description": "Salesforce only. Reduces Salesforce API quota consumption for update events by filtering irrelevant change events at the source: Ampersand creates a checkbox field on the object and an Apex trigger that sets it when a watched field changes, then only delivers update events where the checkbox is set. Requires `updateEvent.requiredWatchFields` to be non-empty; it cannot be used with `updateEvent.watchFieldsAuto: all`.\n",
+        "type": "object",
+        "required": [
+          "enabled"
+        ],
+        "properties": {
+          "enabled": {
+            "type": "boolean",
+            "description": "Whether quota optimization is enabled for this object.",
+            "example": true
           }
         }
       },
@@ -3093,6 +3138,21 @@
                                   "object.restored"
                                 ]
                               }
+                            },
+                            "salesforceQuotaOptimization": {
+                              "title": "Salesforce Quota Optimization Config",
+                              "description": "Salesforce only. Reduces Salesforce API quota consumption for update events by filtering irrelevant change events at the source: Ampersand creates a checkbox field on the object and an Apex trigger that sets it when a watched field changes, then only delivers update events where the checkbox is set. Requires `updateEvent.requiredWatchFields` to be non-empty; it cannot be used with `updateEvent.watchFieldsAuto: all`.\n",
+                              "type": "object",
+                              "required": [
+                                "enabled"
+                              ],
+                              "properties": {
+                                "enabled": {
+                                  "type": "boolean",
+                                  "description": "Whether quota optimization is enabled for this object.",
+                                  "example": true
+                                }
+                              }
                             }
                           }
                         }
@@ -3227,6 +3287,21 @@
                                       "object.merged",
                                       "object.restored"
                                     ]
+                                  }
+                                },
+                                "salesforceQuotaOptimization": {
+                                  "title": "Salesforce Quota Optimization Config",
+                                  "description": "Salesforce only. Reduces Salesforce API quota consumption for update events by filtering irrelevant change events at the source: Ampersand creates a checkbox field on the object and an Apex trigger that sets it when a watched field changes, then only delivers update events where the checkbox is set. Requires `updateEvent.requiredWatchFields` to be non-empty; it cannot be used with `updateEvent.watchFieldsAuto: all`.\n",
+                                  "type": "object",
+                                  "required": [
+                                    "enabled"
+                                  ],
+                                  "properties": {
+                                    "enabled": {
+                                      "type": "boolean",
+                                      "description": "Whether quota optimization is enabled for this object.",
+                                      "example": true
+                                    }
                                   }
                                 }
                               }
@@ -4643,6 +4718,21 @@
                           "object.restored"
                         ]
                       }
+                    },
+                    "salesforceQuotaOptimization": {
+                      "title": "Salesforce Quota Optimization Config",
+                      "description": "Salesforce only. Reduces Salesforce API quota consumption for update events by filtering irrelevant change events at the source: Ampersand creates a checkbox field on the object and an Apex trigger that sets it when a watched field changes, then only delivers update events where the checkbox is set. Requires `updateEvent.requiredWatchFields` to be non-empty; it cannot be used with `updateEvent.watchFieldsAuto: all`.\n",
+                      "type": "object",
+                      "required": [
+                        "enabled"
+                      ],
+                      "properties": {
+                        "enabled": {
+                          "type": "boolean",
+                          "description": "Whether quota optimization is enabled for this object.",
+                          "example": true
+                        }
+                      }
                     }
                   }
                 }
@@ -4777,6 +4867,21 @@
                               "object.merged",
                               "object.restored"
                             ]
+                          }
+                        },
+                        "salesforceQuotaOptimization": {
+                          "title": "Salesforce Quota Optimization Config",
+                          "description": "Salesforce only. Reduces Salesforce API quota consumption for update events by filtering irrelevant change events at the source: Ampersand creates a checkbox field on the object and an Apex trigger that sets it when a watched field changes, then only delivers update events where the checkbox is set. Requires `updateEvent.requiredWatchFields` to be non-empty; it cannot be used with `updateEvent.watchFieldsAuto: all`.\n",
+                          "type": "object",
+                          "required": [
+                            "enabled"
+                          ],
+                          "properties": {
+                            "enabled": {
+                              "type": "boolean",
+                              "description": "Whether quota optimization is enabled for this object.",
+                              "example": true
+                            }
                           }
                         }
                       }
@@ -4917,6 +5022,21 @@
                     "object.merged",
                     "object.restored"
                   ]
+                }
+              },
+              "salesforceQuotaOptimization": {
+                "title": "Salesforce Quota Optimization Config",
+                "description": "Salesforce only. Reduces Salesforce API quota consumption for update events by filtering irrelevant change events at the source: Ampersand creates a checkbox field on the object and an Apex trigger that sets it when a watched field changes, then only delivers update events where the checkbox is set. Requires `updateEvent.requiredWatchFields` to be non-empty; it cannot be used with `updateEvent.watchFieldsAuto: all`.\n",
+                "type": "object",
+                "required": [
+                  "enabled"
+                ],
+                "properties": {
+                  "enabled": {
+                    "type": "boolean",
+                    "description": "Whether quota optimization is enabled for this object.",
+                    "example": true
+                  }
                 }
               }
             }
@@ -5491,6 +5611,21 @@
                               "object.merged",
                               "object.restored"
                             ]
+                          }
+                        },
+                        "salesforceQuotaOptimization": {
+                          "title": "Salesforce Quota Optimization Config",
+                          "description": "Salesforce only. Reduces Salesforce API quota consumption for update events by filtering irrelevant change events at the source: Ampersand creates a checkbox field on the object and an Apex trigger that sets it when a watched field changes, then only delivers update events where the checkbox is set. Requires `updateEvent.requiredWatchFields` to be non-empty; it cannot be used with `updateEvent.watchFieldsAuto: all`.\n",
+                          "type": "object",
+                          "required": [
+                            "enabled"
+                          ],
+                          "properties": {
+                            "enabled": {
+                              "type": "boolean",
+                              "description": "Whether quota optimization is enabled for this object.",
+                              "example": true
+                            }
                           }
                         }
                       }


### PR DESCRIPTION
Adds a per-object opt-in for Salesforce CDC quota optimization so customers can enable the feature themselves via UpdateInstallation and read it back via GetInstallation, instead of engineers hardcoding (projectId, groupRef) pairs in the server.

The property is added to BaseSubscribeConfigObject, so it applies to both SubscribeConfigObject (create/read surface) and UpdateInstallationConfigContent (which uses BaseSubscribeConfig). No new update mask is needed — config.content.subscribe.objects.<objectName> already covers it.

Per-object rather than per-installation because the Salesforce artifacts the feature provisions (checkbox field, Apex trigger, CDC filter expression) are per-object.


